### PR TITLE
feat(ecs): add Sparse Set Component Storage (SDS-MOD-011)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ add_subdirectory(src/foundation)
 # add_subdirectory(src/services)
 
 # Layer 4: ECS core
-# add_subdirectory(src/ecs)
+add_subdirectory(src/ecs)
 
 # Layer 5: Game logic
 # add_subdirectory(src/game)

--- a/include/cgs/ecs/component_storage.hpp
+++ b/include/cgs/ecs/component_storage.hpp
@@ -1,0 +1,223 @@
+#pragma once
+
+/// @file component_storage.hpp
+/// @brief Sparse-set based component storage for the ECS.
+///
+/// ComponentStorage<T> provides O(1) add / get / has / remove and
+/// cache-friendly dense iteration over all components of type T.
+/// A per-component version counter supports change detection.
+///
+/// @see docs/reference/ECS_DESIGN.md  Section 2.3
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "cgs/ecs/component_type_id.hpp"
+#include "cgs/ecs/entity.hpp"
+
+namespace cgs::ecs {
+
+/// Type-erased base for component pools, allowing EntityManager to
+/// call Remove / Has / Clear without knowing the component type.
+class IComponentStorage {
+public:
+    virtual ~IComponentStorage() = default;
+
+    virtual void Remove(Entity entity) = 0;
+    [[nodiscard]] virtual bool Has(Entity entity) const = 0;
+    virtual void Clear() = 0;
+    [[nodiscard]] virtual std::size_t Size() const = 0;
+};
+
+/// Sparse-set component storage.
+///
+/// Memory layout:
+/// @code
+///   sparse_  [entity.id] -> dense index  (or kInvalidIndex)
+///   dense_   [index]     -> component data
+///   entities_[index]     -> entity.id that owns dense_[index]
+///   versions_[index]     -> change counter for dense_[index]
+/// @endcode
+///
+/// All mutating operations bump a global version counter; the per-component
+/// version is set to globalVersion_ at the point of modification so that
+/// systems can efficiently detect stale data.
+template <typename T>
+class ComponentStorage final : public IComponentStorage {
+public:
+    static_assert(std::is_move_constructible_v<T>,
+                  "Component type must be move-constructible");
+
+    using value_type = T;
+    using iterator = typename std::vector<T>::iterator;
+    using const_iterator = typename std::vector<T>::const_iterator;
+
+    // ── Capacity ────────────────────────────────────────────────────────
+
+    /// Number of stored components.
+    [[nodiscard]] std::size_t Size() const override { return dense_.size(); }
+
+    /// True when no components are stored.
+    [[nodiscard]] bool Empty() const noexcept { return dense_.empty(); }
+
+    // ── CRUD ────────────────────────────────────────────────────────────
+
+    /// Add a component for @p entity, constructed from @p args.
+    /// @pre `!Has(entity)` — adding a duplicate is undefined behavior.
+    /// @return Mutable reference to the newly stored component.
+    template <typename... Args>
+    T& Add(Entity entity, Args&&... args) {
+        assert(entity.isValid() && "Cannot add component to invalid entity");
+        assert(!Has(entity) && "Entity already has this component");
+
+        const auto idx = static_cast<uint32_t>(dense_.size());
+
+        ensureSparseSize(entity.id());
+        sparse_[entity.id()] = idx;
+
+        dense_.emplace_back(std::forward<Args>(args)...);
+        entities_.push_back(entity.id());
+        versions_.push_back(++globalVersion_);
+
+        return dense_.back();
+    }
+
+    /// Get a mutable reference to the component owned by @p entity.
+    /// @pre `Has(entity)` — accessing a missing component is undefined.
+    [[nodiscard]] T& Get(Entity entity) {
+        assert(Has(entity) && "Entity does not have this component");
+        return dense_[sparse_[entity.id()]];
+    }
+
+    /// Get a const reference to the component owned by @p entity.
+    [[nodiscard]] const T& Get(Entity entity) const {
+        assert(Has(entity) && "Entity does not have this component");
+        return dense_[sparse_[entity.id()]];
+    }
+
+    /// Replace the component for @p entity and bump its version.
+    /// @pre `Has(entity)`.
+    void Replace(Entity entity, T&& component) {
+        assert(Has(entity) && "Entity does not have this component");
+        auto idx = sparse_[entity.id()];
+        dense_[idx] = std::move(component);
+        versions_[idx] = ++globalVersion_;
+    }
+
+    /// Check whether @p entity has a component in this storage.
+    [[nodiscard]] bool Has(Entity entity) const override {
+        auto eid = entity.id();
+        return eid < sparse_.size() && sparse_[eid] != kInvalidIndex;
+    }
+
+    /// Remove the component owned by @p entity.
+    /// Safe to call even if the entity has no component (no-op).
+    void Remove(Entity entity) override {
+        if (!Has(entity)) {
+            return;
+        }
+
+        auto idx = sparse_[entity.id()];
+        auto lastIdx = static_cast<uint32_t>(dense_.size() - 1);
+
+        if (idx != lastIdx) {
+            // Swap the removed element with the last element.
+            dense_[idx] = std::move(dense_[lastIdx]);
+            entities_[idx] = entities_[lastIdx];
+            versions_[idx] = versions_[lastIdx];
+
+            // Update the sparse entry for the moved entity.
+            sparse_[entities_[idx]] = idx;
+        }
+
+        dense_.pop_back();
+        entities_.pop_back();
+        versions_.pop_back();
+        sparse_[entity.id()] = kInvalidIndex;
+
+        ++globalVersion_;
+    }
+
+    /// Get or add: return the existing component or default-construct one.
+    T& GetOrAdd(Entity entity) {
+        if (Has(entity)) {
+            return Get(entity);
+        }
+        return Add(entity);
+    }
+
+    /// Remove all components and reset version tracking.
+    void Clear() override {
+        dense_.clear();
+        entities_.clear();
+        versions_.clear();
+        std::fill(sparse_.begin(), sparse_.end(), kInvalidIndex);
+        ++globalVersion_;
+    }
+
+    // ── Iteration ───────────────────────────────────────────────────────
+
+    iterator begin() noexcept { return dense_.begin(); }
+    iterator end() noexcept { return dense_.end(); }
+    [[nodiscard]] const_iterator begin() const noexcept { return dense_.begin(); }
+    [[nodiscard]] const_iterator end() const noexcept { return dense_.end(); }
+    [[nodiscard]] const_iterator cbegin() const noexcept { return dense_.cbegin(); }
+    [[nodiscard]] const_iterator cend() const noexcept { return dense_.cend(); }
+
+    /// Return the entity id that owns the component at @p index.
+    [[nodiscard]] uint32_t EntityAt(std::size_t index) const {
+        assert(index < entities_.size());
+        return entities_[index];
+    }
+
+    // ── Version / change detection ──────────────────────────────────────
+
+    /// Explicitly mark the component for @p entity as changed.
+    void MarkChanged(Entity entity) {
+        assert(Has(entity) && "Entity does not have this component");
+        versions_[sparse_[entity.id()]] = ++globalVersion_;
+    }
+
+    /// Return the version counter for the component owned by @p entity.
+    [[nodiscard]] uint32_t GetVersion(Entity entity) const {
+        assert(Has(entity) && "Entity does not have this component");
+        return versions_[sparse_[entity.id()]];
+    }
+
+    /// True when the component's version is newer than @p sinceVersion.
+    [[nodiscard]] bool HasChanged(Entity entity, uint32_t sinceVersion) const {
+        assert(Has(entity) && "Entity does not have this component");
+        return versions_[sparse_[entity.id()]] > sinceVersion;
+    }
+
+    /// The current global version counter.
+    [[nodiscard]] uint32_t GlobalVersion() const noexcept { return globalVersion_; }
+
+    // ── Type ID ─────────────────────────────────────────────────────────
+
+    /// The compile-time-generated type ID for this component type.
+    [[nodiscard]] static ComponentTypeId TypeId() noexcept {
+        return ComponentType<T>::Id();
+    }
+
+private:
+    static constexpr uint32_t kInvalidIndex = std::numeric_limits<uint32_t>::max();
+
+    void ensureSparseSize(uint32_t entityId) {
+        if (entityId >= sparse_.size()) {
+            sparse_.resize(static_cast<std::size_t>(entityId) + 1, kInvalidIndex);
+        }
+    }
+
+    std::vector<T> dense_;              ///< Packed component data.
+    std::vector<uint32_t> entities_;    ///< dense index -> entity id.
+    std::vector<uint32_t> sparse_;      ///< entity id  -> dense index.
+    std::vector<uint32_t> versions_;    ///< dense index -> change version.
+    uint32_t globalVersion_ = 0;        ///< Monotonically increasing version.
+};
+
+} // namespace cgs::ecs

--- a/include/cgs/ecs/component_type_id.hpp
+++ b/include/cgs/ecs/component_type_id.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+/// @file component_type_id.hpp
+/// @brief RTTI-free compile-time component type identification.
+///
+/// Each distinct component type `T` receives a unique integer ID the first
+/// time `ComponentType<T>::Id()` is called.  The IDs are generated via an
+/// atomic counter, so they are safe to use from multiple threads although
+/// the exact numeric values are not deterministic across runs.
+
+#include <atomic>
+#include <cstdint>
+
+namespace cgs::ecs {
+
+/// Integer type used to identify component types at runtime.
+using ComponentTypeId = uint32_t;
+
+/// Sentinel value meaning "no type".
+constexpr ComponentTypeId kInvalidComponentTypeId = static_cast<ComponentTypeId>(-1);
+
+namespace detail {
+
+/// Global atomic counter for generating unique ComponentTypeId values.
+inline ComponentTypeId nextComponentTypeId() noexcept {
+    static std::atomic<ComponentTypeId> counter{0};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace detail
+
+/// Obtain the unique ComponentTypeId for type `T`.
+///
+/// The ID is lazily assigned on first access and remains stable for the
+/// lifetime of the process.  No RTTI (`typeid`) is used.
+///
+/// Usage:
+/// @code
+///   auto id = ComponentType<HealthComponent>::Id();
+/// @endcode
+template <typename T>
+struct ComponentType {
+    static ComponentTypeId Id() noexcept {
+        static const ComponentTypeId value = detail::nextComponentTypeId();
+        return value;
+    }
+};
+
+} // namespace cgs::ecs

--- a/include/cgs/ecs/entity.hpp
+++ b/include/cgs/ecs/entity.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+/// @file entity.hpp
+/// @brief Entity type for the ECS layer.
+///
+/// An entity is a lightweight 32-bit handle that combines a unique index
+/// (24 bits, supporting up to ~16 million entities) with a version counter
+/// (8 bits) for safe recycling.  The compact representation fits in a
+/// single register and keeps sparse-set indexing cache-friendly.
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+
+namespace cgs::ecs {
+
+/// Compact entity handle: 24-bit index + 8-bit version packed into 32 bits.
+///
+/// The version field prevents the ABA problem when entity IDs are recycled.
+/// EntityManager (Issue #10) will manage creation / destruction; this header
+/// only defines the value type so that ComponentStorage can use it.
+struct Entity {
+    uint32_t raw = kInvalidRaw;
+
+    // Bit layout constants.
+    static constexpr uint32_t kIdBits = 24;
+    static constexpr uint32_t kVersionBits = 8;
+    static constexpr uint32_t kIdMask = (1u << kIdBits) - 1;          // 0x00FFFFFF
+    static constexpr uint32_t kVersionShift = kIdBits;
+    static constexpr uint32_t kInvalidRaw = std::numeric_limits<uint32_t>::max();
+    static constexpr uint32_t kMaxId = kIdMask - 1;  // 0x00FFFFFE (reserve 0x00FFFFFF for invalid)
+
+    /// Default-construct to the invalid sentinel.
+    constexpr Entity() = default;
+
+    /// Construct from an index and a version.
+    constexpr Entity(uint32_t id, uint8_t version)
+        : raw((static_cast<uint32_t>(version) << kVersionShift) | (id & kIdMask)) {}
+
+    /// Extract the index portion (0 .. 16'777'214).
+    [[nodiscard]] constexpr uint32_t id() const noexcept { return raw & kIdMask; }
+
+    /// Extract the version portion (0 .. 255).
+    [[nodiscard]] constexpr uint8_t version() const noexcept {
+        return static_cast<uint8_t>(raw >> kVersionShift);
+    }
+
+    /// True when this handle refers to a potentially live entity.
+    [[nodiscard]] constexpr bool isValid() const noexcept { return raw != kInvalidRaw; }
+
+    /// Return the canonical invalid entity.
+    [[nodiscard]] static constexpr Entity invalid() noexcept { return Entity{}; }
+
+    constexpr auto operator<=>(const Entity&) const = default;
+};
+
+static_assert(sizeof(Entity) == 4, "Entity must be exactly 32 bits");
+
+} // namespace cgs::ecs
+
+// Hash support for unordered containers.
+template <>
+struct std::hash<cgs::ecs::Entity> {
+    std::size_t operator()(const cgs::ecs::Entity& e) const noexcept {
+        return std::hash<uint32_t>{}(e.raw);
+    }
+};

--- a/src/ecs/CMakeLists.txt
+++ b/src/ecs/CMakeLists.txt
@@ -1,0 +1,2 @@
+# ECS Core (Layer 4)
+add_subdirectory(component_storage)

--- a/src/ecs/component_storage/CMakeLists.txt
+++ b/src/ecs/component_storage/CMakeLists.txt
@@ -1,0 +1,8 @@
+# ECS Component Storage (SDS-MOD-011)
+add_library(cgs_ecs_component_storage
+    component_storage.cpp
+)
+target_link_libraries(cgs_ecs_component_storage
+    PUBLIC cgs_core
+)
+add_library(cgs::ecs_component_storage ALIAS cgs_ecs_component_storage)

--- a/src/ecs/component_storage/component_storage.cpp
+++ b/src/ecs/component_storage/component_storage.cpp
@@ -1,0 +1,17 @@
+/// @file component_storage.cpp
+/// @brief Non-template parts of the component storage module.
+///
+/// ComponentStorage<T> is predominantly header-only because it is a class
+/// template.  This translation unit exists to give the CMake target a
+/// compilable source file (required by some generators) and to anchor the
+/// ComponentTypeId counter in a single shared library image.
+
+#include "cgs/ecs/component_storage.hpp"
+
+// Force instantiation of the global type-id counter so it is emitted in
+// exactly this translation unit when linking as a shared library.
+namespace cgs::ecs::detail {
+
+static const auto kAnchor [[maybe_unused]] = nextComponentTypeId;
+
+} // namespace cgs::ecs::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,3 +81,13 @@ target_link_libraries(cgs_foundation_container_tests PRIVATE
     GTest::gtest_main
 )
 gtest_discover_tests(cgs_foundation_container_tests)
+
+# Unit tests - ECS component storage
+add_executable(cgs_ecs_component_storage_tests
+    unit/ecs/component_storage_test.cpp
+)
+target_link_libraries(cgs_ecs_component_storage_tests PRIVATE
+    cgs::ecs_component_storage
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_ecs_component_storage_tests)

--- a/tests/unit/ecs/component_storage_test.cpp
+++ b/tests/unit/ecs/component_storage_test.cpp
@@ -1,0 +1,584 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cgs/ecs/component_storage.hpp"
+#include "cgs/ecs/entity.hpp"
+
+using namespace cgs::ecs;
+
+// ── Test component types ────────────────────────────────────────────────────
+
+struct Position {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+struct Velocity {
+    float dx = 0.0f;
+    float dy = 0.0f;
+};
+
+struct Health {
+    int32_t current = 100;
+    int32_t max = 100;
+};
+
+struct Name {
+    std::string value;
+};
+
+// Move-only component.
+struct UniqueResource {
+    int id = 0;
+    UniqueResource() = default;
+    explicit UniqueResource(int i) : id(i) {}
+    UniqueResource(const UniqueResource&) = delete;
+    UniqueResource& operator=(const UniqueResource&) = delete;
+    UniqueResource(UniqueResource&& o) noexcept : id(o.id) { o.id = -1; }
+    UniqueResource& operator=(UniqueResource&& o) noexcept {
+        id = o.id;
+        o.id = -1;
+        return *this;
+    }
+};
+
+// Tag component (zero-size).
+struct DeadTag {};
+
+// ===========================================================================
+// Entity: construction and accessors
+// ===========================================================================
+
+TEST(EntityTest, DefaultIsInvalid) {
+    Entity e;
+    EXPECT_FALSE(e.isValid());
+    EXPECT_EQ(e, Entity::invalid());
+}
+
+TEST(EntityTest, ConstructFromIdAndVersion) {
+    Entity e(42, 3);
+    EXPECT_TRUE(e.isValid());
+    EXPECT_EQ(e.id(), 42u);
+    EXPECT_EQ(e.version(), 3);
+}
+
+TEST(EntityTest, MaxIdValue) {
+    Entity e(Entity::kMaxId, 0);
+    EXPECT_TRUE(e.isValid());
+    EXPECT_EQ(e.id(), Entity::kMaxId);
+}
+
+TEST(EntityTest, Comparison) {
+    Entity a(1, 0);
+    Entity b(1, 0);
+    Entity c(2, 0);
+    Entity d(1, 1);
+    EXPECT_EQ(a, b);
+    EXPECT_NE(a, c);
+    EXPECT_NE(a, d);
+}
+
+TEST(EntityTest, SizeIsFourBytes) {
+    static_assert(sizeof(Entity) == 4);
+}
+
+TEST(EntityTest, HashWorks) {
+    std::unordered_map<Entity, int> map;
+    Entity e(10, 0);
+    map[e] = 42;
+    EXPECT_EQ(map[e], 42);
+}
+
+// ===========================================================================
+// ComponentTypeId: compile-time identification
+// ===========================================================================
+
+TEST(ComponentTypeIdTest, UniquePerType) {
+    auto posId = ComponentType<Position>::Id();
+    auto velId = ComponentType<Velocity>::Id();
+    auto healthId = ComponentType<Health>::Id();
+    EXPECT_NE(posId, velId);
+    EXPECT_NE(posId, healthId);
+    EXPECT_NE(velId, healthId);
+}
+
+TEST(ComponentTypeIdTest, StableAcrossCalls) {
+    auto first = ComponentType<Position>::Id();
+    auto second = ComponentType<Position>::Id();
+    EXPECT_EQ(first, second);
+}
+
+// ===========================================================================
+// ComponentStorage: Add / Get / Has
+// ===========================================================================
+
+TEST(ComponentStorageTest, AddAndGet) {
+    ComponentStorage<Position> storage;
+    Entity e(1, 0);
+
+    auto& pos = storage.Add(e, Position{1.0f, 2.0f, 3.0f});
+    EXPECT_FLOAT_EQ(pos.x, 1.0f);
+    EXPECT_FLOAT_EQ(pos.y, 2.0f);
+    EXPECT_FLOAT_EQ(pos.z, 3.0f);
+
+    EXPECT_TRUE(storage.Has(e));
+    EXPECT_EQ(storage.Size(), 1u);
+
+    auto& got = storage.Get(e);
+    EXPECT_FLOAT_EQ(got.x, 1.0f);
+}
+
+TEST(ComponentStorageTest, AddDefaultConstructed) {
+    ComponentStorage<Health> storage;
+    Entity e(5, 0);
+    auto& h = storage.Add(e);
+    EXPECT_EQ(h.current, 100);
+    EXPECT_EQ(h.max, 100);
+}
+
+TEST(ComponentStorageTest, HasReturnsFalseForAbsent) {
+    ComponentStorage<Position> storage;
+    Entity e(99, 0);
+    EXPECT_FALSE(storage.Has(e));
+}
+
+TEST(ComponentStorageTest, HasReturnsFalseForInvalid) {
+    ComponentStorage<Position> storage;
+    EXPECT_FALSE(storage.Has(Entity::invalid()));
+}
+
+TEST(ComponentStorageTest, GetConst) {
+    ComponentStorage<Position> storage;
+    Entity e(1, 0);
+    storage.Add(e, Position{5.0f, 6.0f, 7.0f});
+
+    const auto& constStorage = storage;
+    EXPECT_FLOAT_EQ(constStorage.Get(e).x, 5.0f);
+}
+
+TEST(ComponentStorageTest, MutateViaGet) {
+    ComponentStorage<Health> storage;
+    Entity e(1, 0);
+    storage.Add(e, Health{50, 100});
+    storage.Get(e).current = 75;
+    EXPECT_EQ(storage.Get(e).current, 75);
+}
+
+// ===========================================================================
+// ComponentStorage: Remove
+// ===========================================================================
+
+TEST(ComponentStorageTest, RemoveSingle) {
+    ComponentStorage<Position> storage;
+    Entity e(1, 0);
+    storage.Add(e, Position{1.0f, 2.0f, 3.0f});
+
+    storage.Remove(e);
+    EXPECT_FALSE(storage.Has(e));
+    EXPECT_EQ(storage.Size(), 0u);
+}
+
+TEST(ComponentStorageTest, RemoveSwapsWithLast) {
+    ComponentStorage<Position> storage;
+    Entity a(1, 0);
+    Entity b(2, 0);
+    Entity c(3, 0);
+
+    storage.Add(a, Position{1.0f, 0.0f, 0.0f});
+    storage.Add(b, Position{2.0f, 0.0f, 0.0f});
+    storage.Add(c, Position{3.0f, 0.0f, 0.0f});
+
+    // Remove middle element; last element (c) should take its place.
+    storage.Remove(b);
+
+    EXPECT_EQ(storage.Size(), 2u);
+    EXPECT_TRUE(storage.Has(a));
+    EXPECT_FALSE(storage.Has(b));
+    EXPECT_TRUE(storage.Has(c));
+
+    // Verify values are correct after swap.
+    EXPECT_FLOAT_EQ(storage.Get(a).x, 1.0f);
+    EXPECT_FLOAT_EQ(storage.Get(c).x, 3.0f);
+}
+
+TEST(ComponentStorageTest, RemoveNonexistentIsNoop) {
+    ComponentStorage<Position> storage;
+    Entity e(42, 0);
+    storage.Remove(e);  // should not crash
+    EXPECT_EQ(storage.Size(), 0u);
+}
+
+TEST(ComponentStorageTest, RemoveLastElement) {
+    ComponentStorage<Position> storage;
+    Entity a(1, 0);
+    Entity b(2, 0);
+    storage.Add(a, Position{1.0f, 0.0f, 0.0f});
+    storage.Add(b, Position{2.0f, 0.0f, 0.0f});
+
+    storage.Remove(b);
+    EXPECT_EQ(storage.Size(), 1u);
+    EXPECT_TRUE(storage.Has(a));
+    EXPECT_FLOAT_EQ(storage.Get(a).x, 1.0f);
+}
+
+TEST(ComponentStorageTest, AddAfterRemove) {
+    ComponentStorage<Health> storage;
+    Entity e(1, 0);
+
+    storage.Add(e, Health{50, 100});
+    storage.Remove(e);
+    EXPECT_FALSE(storage.Has(e));
+
+    // Re-add to the same entity.
+    storage.Add(e, Health{75, 100});
+    EXPECT_TRUE(storage.Has(e));
+    EXPECT_EQ(storage.Get(e).current, 75);
+}
+
+// ===========================================================================
+// ComponentStorage: Replace
+// ===========================================================================
+
+TEST(ComponentStorageTest, ReplaceUpdatesValue) {
+    ComponentStorage<Position> storage;
+    Entity e(1, 0);
+    storage.Add(e, Position{1.0f, 2.0f, 3.0f});
+    storage.Replace(e, Position{10.0f, 20.0f, 30.0f});
+
+    EXPECT_FLOAT_EQ(storage.Get(e).x, 10.0f);
+    EXPECT_FLOAT_EQ(storage.Get(e).y, 20.0f);
+}
+
+// ===========================================================================
+// ComponentStorage: GetOrAdd
+// ===========================================================================
+
+TEST(ComponentStorageTest, GetOrAddExisting) {
+    ComponentStorage<Health> storage;
+    Entity e(1, 0);
+    storage.Add(e, Health{42, 100});
+
+    auto& h = storage.GetOrAdd(e);
+    EXPECT_EQ(h.current, 42);
+    EXPECT_EQ(storage.Size(), 1u);
+}
+
+TEST(ComponentStorageTest, GetOrAddNew) {
+    ComponentStorage<Health> storage;
+    Entity e(1, 0);
+
+    auto& h = storage.GetOrAdd(e);
+    EXPECT_EQ(h.current, 100);  // default
+    EXPECT_EQ(storage.Size(), 1u);
+}
+
+// ===========================================================================
+// ComponentStorage: Clear
+// ===========================================================================
+
+TEST(ComponentStorageTest, ClearRemovesAll) {
+    ComponentStorage<Position> storage;
+    for (uint32_t i = 0; i < 100; ++i) {
+        storage.Add(Entity(i, 0), Position{});
+    }
+    EXPECT_EQ(storage.Size(), 100u);
+
+    storage.Clear();
+    EXPECT_EQ(storage.Size(), 0u);
+    EXPECT_TRUE(storage.Empty());
+
+    // Verify all entities removed.
+    for (uint32_t i = 0; i < 100; ++i) {
+        EXPECT_FALSE(storage.Has(Entity(i, 0)));
+    }
+}
+
+// ===========================================================================
+// ComponentStorage: Iteration
+// ===========================================================================
+
+TEST(ComponentStorageTest, IterateAll) {
+    ComponentStorage<Position> storage;
+    for (uint32_t i = 0; i < 5; ++i) {
+        storage.Add(Entity(i, 0), Position{static_cast<float>(i), 0.0f, 0.0f});
+    }
+
+    float sum = 0.0f;
+    for (const auto& pos : storage) {
+        sum += pos.x;
+    }
+    EXPECT_FLOAT_EQ(sum, 0.0f + 1.0f + 2.0f + 3.0f + 4.0f);
+}
+
+TEST(ComponentStorageTest, IterateEmpty) {
+    ComponentStorage<Position> storage;
+    int count = 0;
+    for ([[maybe_unused]] const auto& pos : storage) {
+        ++count;
+    }
+    EXPECT_EQ(count, 0);
+}
+
+TEST(ComponentStorageTest, EntityAtReturnsCorrectId) {
+    ComponentStorage<Position> storage;
+    Entity a(10, 0);
+    Entity b(20, 0);
+    storage.Add(a, Position{});
+    storage.Add(b, Position{});
+
+    EXPECT_EQ(storage.EntityAt(0), 10u);
+    EXPECT_EQ(storage.EntityAt(1), 20u);
+}
+
+// ===========================================================================
+// ComponentStorage: Version tracking
+// ===========================================================================
+
+TEST(ComponentStorageTest, VersionIncreasesOnAdd) {
+    ComponentStorage<Position> storage;
+    Entity a(1, 0);
+    Entity b(2, 0);
+
+    storage.Add(a, Position{});
+    auto vA = storage.GetVersion(a);
+
+    storage.Add(b, Position{});
+    auto vB = storage.GetVersion(b);
+
+    EXPECT_LT(vA, vB);
+}
+
+TEST(ComponentStorageTest, VersionIncreasesOnReplace) {
+    ComponentStorage<Position> storage;
+    Entity e(1, 0);
+    storage.Add(e, Position{});
+    auto v1 = storage.GetVersion(e);
+
+    storage.Replace(e, Position{1.0f, 2.0f, 3.0f});
+    auto v2 = storage.GetVersion(e);
+
+    EXPECT_GT(v2, v1);
+}
+
+TEST(ComponentStorageTest, MarkChangedBumpsVersion) {
+    ComponentStorage<Position> storage;
+    Entity e(1, 0);
+    storage.Add(e, Position{});
+    auto v1 = storage.GetVersion(e);
+
+    storage.MarkChanged(e);
+    auto v2 = storage.GetVersion(e);
+
+    EXPECT_GT(v2, v1);
+}
+
+TEST(ComponentStorageTest, HasChangedDetectsModification) {
+    ComponentStorage<Position> storage;
+    Entity e(1, 0);
+    storage.Add(e, Position{});
+
+    auto snapshot = storage.GlobalVersion();
+    EXPECT_FALSE(storage.HasChanged(e, snapshot));
+
+    storage.MarkChanged(e);
+    EXPECT_TRUE(storage.HasChanged(e, snapshot));
+}
+
+TEST(ComponentStorageTest, GlobalVersionMonotonicallyIncreases) {
+    ComponentStorage<Position> storage;
+    auto v0 = storage.GlobalVersion();
+
+    storage.Add(Entity(1, 0), Position{});
+    auto v1 = storage.GlobalVersion();
+
+    storage.Add(Entity(2, 0), Position{});
+    auto v2 = storage.GlobalVersion();
+
+    storage.Remove(Entity(1, 0));
+    auto v3 = storage.GlobalVersion();
+
+    EXPECT_LT(v0, v1);
+    EXPECT_LT(v1, v2);
+    EXPECT_LT(v2, v3);
+}
+
+// ===========================================================================
+// ComponentStorage: Move-only types
+// ===========================================================================
+
+TEST(ComponentStorageTest, MoveOnlyAdd) {
+    ComponentStorage<UniqueResource> storage;
+    Entity e(1, 0);
+    auto& res = storage.Add(e, UniqueResource{42});
+    EXPECT_EQ(res.id, 42);
+}
+
+TEST(ComponentStorageTest, MoveOnlyRemoveSwap) {
+    ComponentStorage<UniqueResource> storage;
+    Entity a(1, 0);
+    Entity b(2, 0);
+    Entity c(3, 0);
+
+    storage.Add(a, UniqueResource{10});
+    storage.Add(b, UniqueResource{20});
+    storage.Add(c, UniqueResource{30});
+
+    storage.Remove(a);
+    EXPECT_EQ(storage.Size(), 2u);
+    EXPECT_EQ(storage.Get(b).id, 20);
+    EXPECT_EQ(storage.Get(c).id, 30);
+}
+
+// ===========================================================================
+// ComponentStorage: Tag (zero-size) components
+// ===========================================================================
+
+TEST(ComponentStorageTest, TagComponent) {
+    ComponentStorage<DeadTag> storage;
+    Entity e(1, 0);
+    storage.Add(e);
+    EXPECT_TRUE(storage.Has(e));
+    storage.Remove(e);
+    EXPECT_FALSE(storage.Has(e));
+}
+
+// ===========================================================================
+// ComponentStorage: String component
+// ===========================================================================
+
+TEST(ComponentStorageTest, StringComponent) {
+    ComponentStorage<Name> storage;
+    Entity e(1, 0);
+    storage.Add(e, Name{"Hello World"});
+    EXPECT_EQ(storage.Get(e).value, "Hello World");
+
+    storage.Replace(e, Name{"Replaced"});
+    EXPECT_EQ(storage.Get(e).value, "Replaced");
+}
+
+// ===========================================================================
+// ComponentStorage: IComponentStorage interface
+// ===========================================================================
+
+TEST(IComponentStorageTest, PolymorphicAccess) {
+    auto storage = std::make_unique<ComponentStorage<Position>>();
+    IComponentStorage* base = storage.get();
+
+    Entity e(1, 0);
+    storage->Add(e, Position{});
+
+    EXPECT_TRUE(base->Has(e));
+    EXPECT_EQ(base->Size(), 1u);
+
+    base->Remove(e);
+    EXPECT_FALSE(base->Has(e));
+
+    storage->Add(e, Position{});
+    base->Clear();
+    EXPECT_EQ(base->Size(), 0u);
+}
+
+// ===========================================================================
+// ComponentStorage: Sparse array growth
+// ===========================================================================
+
+TEST(ComponentStorageTest, SparseGrowsForLargeEntityId) {
+    ComponentStorage<Position> storage;
+    Entity e(10000, 0);
+    storage.Add(e, Position{1.0f, 2.0f, 3.0f});
+    EXPECT_TRUE(storage.Has(e));
+    EXPECT_FLOAT_EQ(storage.Get(e).x, 1.0f);
+    EXPECT_EQ(storage.Size(), 1u);
+}
+
+TEST(ComponentStorageTest, NonContiguousEntityIds) {
+    ComponentStorage<Health> storage;
+    Entity a(5, 0);
+    Entity b(500, 0);
+    Entity c(50000, 0);
+
+    storage.Add(a, Health{10, 100});
+    storage.Add(b, Health{20, 100});
+    storage.Add(c, Health{30, 100});
+
+    EXPECT_EQ(storage.Size(), 3u);
+    EXPECT_EQ(storage.Get(a).current, 10);
+    EXPECT_EQ(storage.Get(b).current, 20);
+    EXPECT_EQ(storage.Get(c).current, 30);
+}
+
+// ===========================================================================
+// ComponentStorage: TypeId
+// ===========================================================================
+
+TEST(ComponentStorageTest, TypeIdMatchesComponentType) {
+    EXPECT_EQ(ComponentStorage<Position>::TypeId(), ComponentType<Position>::Id());
+    EXPECT_EQ(ComponentStorage<Health>::TypeId(), ComponentType<Health>::Id());
+    EXPECT_NE(ComponentStorage<Position>::TypeId(), ComponentStorage<Health>::TypeId());
+}
+
+// ===========================================================================
+// Performance: Dense iteration vs unordered_map
+// ===========================================================================
+
+TEST(ComponentStoragePerformanceTest, DenseIterationFasterThanMap) {
+    constexpr std::size_t N = 10'000;
+
+    // Populate ComponentStorage.
+    ComponentStorage<Position> storage;
+    for (uint32_t i = 0; i < N; ++i) {
+        storage.Add(Entity(i, 0), Position{static_cast<float>(i), 0.0f, 0.0f});
+    }
+
+    // Populate unordered_map.
+    std::unordered_map<uint32_t, Position> map;
+    map.reserve(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        map[i] = Position{static_cast<float>(i), 0.0f, 0.0f};
+    }
+
+    // Benchmark: sum x values via dense iteration.
+    constexpr int kRuns = 100;
+
+    auto storageStart = std::chrono::steady_clock::now();
+    volatile float storageSink = 0.0f;
+    for (int run = 0; run < kRuns; ++run) {
+        float sum = 0.0f;
+        for (const auto& pos : storage) {
+            sum += pos.x;
+        }
+        storageSink = sum;
+    }
+    auto storageElapsed = std::chrono::steady_clock::now() - storageStart;
+
+    // Benchmark: sum x values via map iteration.
+    auto mapStart = std::chrono::steady_clock::now();
+    volatile float mapSink = 0.0f;
+    for (int run = 0; run < kRuns; ++run) {
+        float sum = 0.0f;
+        for (const auto& [id, pos] : map) {
+            sum += pos.x;
+        }
+        mapSink = sum;
+    }
+    auto mapElapsed = std::chrono::steady_clock::now() - mapStart;
+
+    // Suppress unused-but-set-variable warnings.
+    (void)storageSink;
+    (void)mapSink;
+
+    auto storageUs = std::chrono::duration_cast<std::chrono::microseconds>(storageElapsed).count();
+    auto mapUs = std::chrono::duration_cast<std::chrono::microseconds>(mapElapsed).count();
+
+    // ComponentStorage should be faster due to cache-friendly dense layout.
+    EXPECT_LT(storageUs, mapUs)
+        << "ComponentStorage (" << storageUs << "us) should be faster than "
+        << "unordered_map (" << mapUs << "us) for 10K iteration x " << kRuns << " runs";
+}


### PR DESCRIPTION
## Summary
- Implement `ComponentStorage<T>` with sparse-set architecture for O(1) CRUD and cache-friendly dense iteration
- Define `Entity` as a 32-bit packed handle (24-bit id + 8-bit version) in `cgs::ecs` namespace
- Add RTTI-free compile-time component type ID via atomic counter pattern
- Include per-component version tracking for efficient change detection
- First ECS layer module, opening the M2 Core ECS milestone

## Key Design Decisions
- **Sparse Set over Archetype**: simpler to implement and extend; archetype optimization deferred
- **PascalCase API**: ECS layer follows SDS convention (`Add()`, `Get()`, `Has()`, `Remove()`)
- **Header-only templates**: `ComponentStorage<T>` is template-heavy; minimal .cpp for CMake target
- **`IComponentStorage` base**: type-erased interface for EntityManager to remove components without knowing type

## Files Added
| File | Purpose |
|------|---------|
| `include/cgs/ecs/entity.hpp` | Entity type (32-bit packed) |
| `include/cgs/ecs/component_type_id.hpp` | Compile-time type ID |
| `include/cgs/ecs/component_storage.hpp` | Sparse set template |
| `src/ecs/component_storage/component_storage.cpp` | Minimal TU anchor |
| `src/ecs/**/CMakeLists.txt` | Build targets |
| `tests/unit/ecs/component_storage_test.cpp` | 40 unit tests |

## Files Modified
| File | Change |
|------|--------|
| `CMakeLists.txt` | Uncomment `add_subdirectory(src/ecs)` |
| `tests/CMakeLists.txt` | Add ECS test executable |

## Test Plan
- [x] 40 new unit tests all pass (Entity, ComponentTypeId, CRUD, iteration, versioning, move-only, tag, performance)
- [x] Performance test confirms dense iteration faster than `std::unordered_map` for 10K components
- [x] All 346 existing tests pass with zero regressions

Closes #9