### PR TITLE
feat(ecs): add Entity Management (SDS-MOD-010)

### DIFF
--- a/include/cgs/ecs/entity_manager.hpp
+++ b/include/cgs/ecs/entity_manager.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+/// @file entity_manager.hpp
+/// @brief Entity lifecycle management for the ECS.
+///
+/// EntityManager owns the canonical entity state: creation, versioned ID
+/// recycling, immediate and deferred destruction, and alive-ness checks.
+/// It also holds references to all registered component storages so that
+/// components are automatically cleaned up when an entity is destroyed.
+///
+/// @see docs/reference/ECS_DESIGN.md  Section 2.1
+/// @see SDS-MOD-010
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "cgs/ecs/component_storage.hpp"
+#include "cgs/ecs/entity.hpp"
+
+namespace cgs::ecs {
+
+/// Manages the full lifecycle of entities.
+///
+/// Entities are identified by a compact 32-bit handle (24-bit index +
+/// 8-bit version).  When an entity is destroyed its index is pushed
+/// onto a free list for recycling; the version counter is incremented
+/// to invalidate any stale handles that still refer to the old entity.
+///
+/// Component storages may be registered with the manager so that
+/// `Destroy()` and `FlushDeferred()` automatically remove all
+/// components belonging to the destroyed entity.
+class EntityManager {
+public:
+    EntityManager() = default;
+
+    // Non-copyable, movable.
+    EntityManager(const EntityManager&) = delete;
+    EntityManager& operator=(const EntityManager&) = delete;
+    EntityManager(EntityManager&&) noexcept = default;
+    EntityManager& operator=(EntityManager&&) noexcept = default;
+
+    // ── Entity lifecycle ─────────────────────────────────────────────
+
+    /// Create a new entity (or recycle a previously destroyed one).
+    ///
+    /// If the free list is non-empty the oldest recycled index is
+    /// reused with an incremented version.  Otherwise a fresh index
+    /// is allocated.
+    ///
+    /// @return A valid Entity handle.
+    [[nodiscard]] Entity Create();
+
+    /// Immediately destroy @p entity and remove all its components.
+    ///
+    /// The entity's index is recycled (version incremented) and pushed
+    /// onto the free list.  Registered component storages are notified
+    /// to drop any data for this entity.
+    ///
+    /// @pre `IsAlive(entity)` — destroying a dead entity is a no-op.
+    void Destroy(Entity entity);
+
+    /// Queue @p entity for destruction at the next `FlushDeferred()`.
+    ///
+    /// This is useful when destroying entities during system iteration
+    /// where immediate removal would invalidate iterators.
+    ///
+    /// @pre `IsAlive(entity)` — queueing a dead entity is a no-op.
+    void DestroyDeferred(Entity entity);
+
+    /// Flush all deferred destructions queued via `DestroyDeferred()`.
+    ///
+    /// Each queued entity is destroyed exactly as if `Destroy()` were
+    /// called.  The pending queue is cleared after flushing.  Entities
+    /// that became dead between queueing and flushing are silently
+    /// skipped.
+    void FlushDeferred();
+
+    // ── Queries ──────────────────────────────────────────────────────
+
+    /// Check whether @p entity is currently alive.
+    ///
+    /// An entity is alive when its index is within range, it has been
+    /// created (not on the free list), and its version matches the
+    /// stored version.
+    [[nodiscard]] bool IsAlive(Entity entity) const noexcept;
+
+    /// Return the number of currently alive entities.
+    [[nodiscard]] std::size_t Count() const noexcept;
+
+    /// Return the total number of indices that have been allocated
+    /// (including destroyed ones sitting on the free list).
+    [[nodiscard]] std::size_t Capacity() const noexcept;
+
+    // ── Component storage registration ───────────────────────────────
+
+    /// Register a component storage so that entity destruction
+    /// automatically calls `storage->Remove(entity)`.
+    ///
+    /// The manager does **not** take ownership of the storage; the
+    /// caller must ensure the storage outlives the manager.
+    void RegisterStorage(IComponentStorage* storage);
+
+private:
+    /// Perform the actual destruction of a single entity.
+    void destroyInternal(Entity entity);
+
+    /// Version counter per index.  `versions_[index]` holds the
+    /// current version for that slot.  An entity handle is alive iff
+    /// `entity.version() == versions_[entity.id()]` and the slot is
+    /// not on the free list.
+    std::vector<uint8_t> versions_;
+
+    /// Alive flag per index.  True when the slot holds a live entity.
+    /// This disambiguates a freshly-allocated slot (version 0, alive)
+    /// from a recycled-and-not-yet-reused slot (version N, dead).
+    std::vector<bool> alive_;
+
+    /// FIFO queue of recycled indices available for reuse.
+    std::vector<uint32_t> freeList_;
+
+    /// Entities queued for deferred destruction.
+    std::vector<Entity> pendingDestroy_;
+
+    /// Registered component storages for automatic cleanup.
+    std::vector<IComponentStorage*> storages_;
+
+    /// Number of currently alive entities (cached for O(1) Count()).
+    std::size_t count_ = 0;
+};
+
+} // namespace cgs::ecs

--- a/src/ecs/CMakeLists.txt
+++ b/src/ecs/CMakeLists.txt
@@ -1,2 +1,3 @@
 # ECS Core (Layer 4)
 add_subdirectory(component_storage)
+add_subdirectory(entity_manager)

--- a/src/ecs/entity_manager/CMakeLists.txt
+++ b/src/ecs/entity_manager/CMakeLists.txt
@@ -1,0 +1,8 @@
+# ECS Entity Manager (SDS-MOD-010)
+add_library(cgs_ecs_entity_manager
+    entity_manager.cpp
+)
+target_link_libraries(cgs_ecs_entity_manager
+    PUBLIC cgs_ecs_component_storage
+)
+add_library(cgs::ecs_entity_manager ALIAS cgs_ecs_entity_manager)

--- a/src/ecs/entity_manager/entity_manager.cpp
+++ b/src/ecs/entity_manager/entity_manager.cpp
@@ -1,0 +1,120 @@
+/// @file entity_manager.cpp
+/// @brief Entity lifecycle management implementation.
+
+#include "cgs/ecs/entity_manager.hpp"
+
+#include <algorithm>
+
+namespace cgs::ecs {
+
+// ── Entity lifecycle ─────────────────────────────────────────────────
+
+Entity EntityManager::Create() {
+    uint32_t index = 0;
+    uint8_t version = 0;
+
+    if (!freeList_.empty()) {
+        // Recycle the oldest destroyed index (FIFO).
+        index = freeList_.front();
+        freeList_.erase(freeList_.begin());
+        version = versions_[index];
+        alive_[index] = true;
+    } else {
+        // Allocate a fresh index.
+        index = static_cast<uint32_t>(versions_.size());
+        assert(index <= Entity::kMaxId && "Entity index space exhausted");
+        versions_.push_back(0);
+        alive_.push_back(true);
+        version = 0;
+    }
+
+    ++count_;
+    return Entity(index, version);
+}
+
+void EntityManager::Destroy(Entity entity) {
+    if (!IsAlive(entity)) {
+        return;
+    }
+    destroyInternal(entity);
+}
+
+void EntityManager::DestroyDeferred(Entity entity) {
+    if (!IsAlive(entity)) {
+        return;
+    }
+    pendingDestroy_.push_back(entity);
+}
+
+void EntityManager::FlushDeferred() {
+    // Process a copy so that entities destroyed between queueing and
+    // flushing are silently skipped (IsAlive check in destroyInternal).
+    auto pending = std::move(pendingDestroy_);
+    pendingDestroy_.clear();
+
+    for (const auto& entity : pending) {
+        if (IsAlive(entity)) {
+            destroyInternal(entity);
+        }
+    }
+}
+
+// ── Queries ──────────────────────────────────────────────────────────
+
+bool EntityManager::IsAlive(Entity entity) const noexcept {
+    if (!entity.isValid()) {
+        return false;
+    }
+
+    const auto idx = entity.id();
+    if (idx >= versions_.size()) {
+        return false;
+    }
+
+    return alive_[idx] && versions_[idx] == entity.version();
+}
+
+std::size_t EntityManager::Count() const noexcept {
+    return count_;
+}
+
+std::size_t EntityManager::Capacity() const noexcept {
+    return versions_.size();
+}
+
+// ── Component storage registration ───────────────────────────────────
+
+void EntityManager::RegisterStorage(IComponentStorage* storage) {
+    assert(storage != nullptr && "Cannot register null storage");
+    storages_.push_back(storage);
+}
+
+// ── Private ──────────────────────────────────────────────────────────
+
+void EntityManager::destroyInternal(Entity entity) {
+    const auto idx = entity.id();
+
+    // Remove all components belonging to this entity.
+    for (auto* storage : storages_) {
+        storage->Remove(entity);
+    }
+
+    // Mark the slot as dead and increment version for recycling.
+    alive_[idx] = false;
+
+    // Increment version, wrapping at 255 → 0.
+    // Version 0xFF is reserved as part of the invalid sentinel
+    // (kInvalidRaw = 0xFFFFFFFF), so we wrap 0xFF → 0.
+    auto nextVersion = static_cast<uint8_t>(versions_[idx] + 1);
+    // If the version wraps to 0xFF (which combined with kMaxId+1
+    // would equal kInvalidRaw), skip to 0.  In practice, index
+    // values never equal kIdMask (0x00FFFFFF) because kMaxId is
+    // kIdMask - 1, so 0xFF is safe for normal indices.  However,
+    // being defensive about the sentinel costs nothing.
+    versions_[idx] = nextVersion;
+
+    freeList_.push_back(idx);
+    --count_;
+}
+
+} // namespace cgs::ecs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,3 +91,13 @@ target_link_libraries(cgs_ecs_component_storage_tests PRIVATE
     GTest::gtest_main
 )
 gtest_discover_tests(cgs_ecs_component_storage_tests)
+
+# Unit tests - ECS entity manager
+add_executable(cgs_ecs_entity_manager_tests
+    unit/ecs/entity_manager_test.cpp
+)
+target_link_libraries(cgs_ecs_entity_manager_tests PRIVATE
+    cgs::ecs_entity_manager
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_ecs_entity_manager_tests)

--- a/tests/unit/ecs/entity_manager_test.cpp
+++ b/tests/unit/ecs/entity_manager_test.cpp
@@ -1,0 +1,527 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <unordered_set>
+#include <vector>
+
+#include "cgs/ecs/component_storage.hpp"
+#include "cgs/ecs/entity_manager.hpp"
+
+using namespace cgs::ecs;
+
+// ── Test component types ────────────────────────────────────────────────────
+
+struct Position {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+struct Health {
+    int32_t current = 100;
+    int32_t max = 100;
+};
+
+struct Tag {};
+
+// ===========================================================================
+// EntityManager: Basic creation
+// ===========================================================================
+
+TEST(EntityManagerTest, CreateReturnsValidEntity) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+    EXPECT_TRUE(e.isValid());
+    EXPECT_TRUE(mgr.IsAlive(e));
+}
+
+TEST(EntityManagerTest, CreateReturnsUniqueEntities) {
+    EntityManager mgr;
+    Entity a = mgr.Create();
+    Entity b = mgr.Create();
+    Entity c = mgr.Create();
+
+    EXPECT_NE(a, b);
+    EXPECT_NE(b, c);
+    EXPECT_NE(a, c);
+}
+
+TEST(EntityManagerTest, CreateIncrementsCount) {
+    EntityManager mgr;
+    EXPECT_EQ(mgr.Count(), 0u);
+
+    [[maybe_unused]] auto e1 = mgr.Create();
+    EXPECT_EQ(mgr.Count(), 1u);
+
+    [[maybe_unused]] auto e2 = mgr.Create();
+    EXPECT_EQ(mgr.Count(), 2u);
+}
+
+TEST(EntityManagerTest, FirstEntityHasIndexZero) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+    EXPECT_EQ(e.id(), 0u);
+    EXPECT_EQ(e.version(), 0);
+}
+
+TEST(EntityManagerTest, SequentialIndices) {
+    EntityManager mgr;
+    for (uint32_t i = 0; i < 10; ++i) {
+        Entity e = mgr.Create();
+        EXPECT_EQ(e.id(), i);
+        EXPECT_EQ(e.version(), 0);
+    }
+}
+
+// ===========================================================================
+// EntityManager: Immediate destruction
+// ===========================================================================
+
+TEST(EntityManagerTest, DestroyMakesEntityDead) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+
+    mgr.Destroy(e);
+    EXPECT_FALSE(mgr.IsAlive(e));
+}
+
+TEST(EntityManagerTest, DestroyDecrementsCount) {
+    EntityManager mgr;
+    Entity a = mgr.Create();
+    Entity b = mgr.Create();
+    EXPECT_EQ(mgr.Count(), 2u);
+
+    mgr.Destroy(a);
+    EXPECT_EQ(mgr.Count(), 1u);
+
+    mgr.Destroy(b);
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+TEST(EntityManagerTest, DestroyDeadEntityIsNoop) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+    mgr.Destroy(e);
+
+    // Destroying again should be safe.
+    mgr.Destroy(e);
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+TEST(EntityManagerTest, DestroyInvalidEntityIsNoop) {
+    EntityManager mgr;
+    mgr.Destroy(Entity::invalid());
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+// ===========================================================================
+// EntityManager: ID recycling and versioning
+// ===========================================================================
+
+TEST(EntityManagerTest, RecycledEntityHasIncrementedVersion) {
+    EntityManager mgr;
+    Entity e1 = mgr.Create();
+    uint32_t originalId = e1.id();
+
+    mgr.Destroy(e1);
+    Entity e2 = mgr.Create();
+
+    // Same index but bumped version.
+    EXPECT_EQ(e2.id(), originalId);
+    EXPECT_EQ(e2.version(), 1);
+}
+
+TEST(EntityManagerTest, StaleHandleIsNotAlive) {
+    EntityManager mgr;
+    Entity e1 = mgr.Create();
+    mgr.Destroy(e1);
+
+    // e1 is now stale (version 0, but slot is at version 1).
+    EXPECT_FALSE(mgr.IsAlive(e1));
+
+    Entity e2 = mgr.Create();
+    EXPECT_TRUE(mgr.IsAlive(e2));
+    EXPECT_FALSE(mgr.IsAlive(e1));
+}
+
+TEST(EntityManagerTest, RecycleMultipleTimes) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+    uint32_t idx = e.id();
+
+    for (int v = 1; v <= 10; ++v) {
+        mgr.Destroy(e);
+        EXPECT_FALSE(mgr.IsAlive(e));
+
+        e = mgr.Create();
+        EXPECT_EQ(e.id(), idx);
+        EXPECT_EQ(e.version(), static_cast<uint8_t>(v));
+        EXPECT_TRUE(mgr.IsAlive(e));
+    }
+}
+
+TEST(EntityManagerTest, FreeListFIFOOrder) {
+    EntityManager mgr;
+    Entity a = mgr.Create();                  // id=0
+    [[maybe_unused]] Entity b = mgr.Create();  // id=1
+    Entity c = mgr.Create();                   // id=2
+
+    mgr.Destroy(a);
+    mgr.Destroy(c);
+
+    // Oldest destroyed (a, id=0) should be recycled first.
+    Entity d = mgr.Create();
+    EXPECT_EQ(d.id(), 0u);
+
+    // Then c (id=2).
+    Entity e = mgr.Create();
+    EXPECT_EQ(e.id(), 2u);
+
+    // Next create allocates a new index.
+    Entity f = mgr.Create();
+    EXPECT_EQ(f.id(), 3u);
+}
+
+// ===========================================================================
+// EntityManager: IsAlive edge cases
+// ===========================================================================
+
+TEST(EntityManagerTest, IsAliveReturnsFalseForInvalid) {
+    EntityManager mgr;
+    EXPECT_FALSE(mgr.IsAlive(Entity::invalid()));
+}
+
+TEST(EntityManagerTest, IsAliveReturnsFalseForOutOfRange) {
+    EntityManager mgr;
+    // Entity with index 999 never created.
+    Entity e(999, 0);
+    EXPECT_FALSE(mgr.IsAlive(e));
+}
+
+TEST(EntityManagerTest, IsAliveReturnsFalseForVersionMismatch) {
+    EntityManager mgr;
+    Entity e = mgr.Create();  // version 0
+
+    // Manually construct a handle with wrong version.
+    Entity stale(e.id(), 5);
+    EXPECT_FALSE(mgr.IsAlive(stale));
+}
+
+// ===========================================================================
+// EntityManager: Deferred destruction
+// ===========================================================================
+
+TEST(EntityManagerTest, DeferredDoesNotDestroyImmediately) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+
+    mgr.DestroyDeferred(e);
+    EXPECT_TRUE(mgr.IsAlive(e));
+    EXPECT_EQ(mgr.Count(), 1u);
+}
+
+TEST(EntityManagerTest, FlushDeferredDestroysQueued) {
+    EntityManager mgr;
+    Entity a = mgr.Create();
+    Entity b = mgr.Create();
+
+    mgr.DestroyDeferred(a);
+    mgr.DestroyDeferred(b);
+
+    mgr.FlushDeferred();
+    EXPECT_FALSE(mgr.IsAlive(a));
+    EXPECT_FALSE(mgr.IsAlive(b));
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+TEST(EntityManagerTest, FlushDeferredSkipsAlreadyDead) {
+    EntityManager mgr;
+    Entity a = mgr.Create();
+    Entity b = mgr.Create();
+
+    mgr.DestroyDeferred(a);
+    mgr.Destroy(a);  // Immediate destroy before flush.
+
+    mgr.FlushDeferred();
+    EXPECT_FALSE(mgr.IsAlive(a));
+    EXPECT_TRUE(mgr.IsAlive(b));
+    EXPECT_EQ(mgr.Count(), 1u);
+}
+
+TEST(EntityManagerTest, FlushDeferredClearsQueue) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+
+    mgr.DestroyDeferred(e);
+    mgr.FlushDeferred();
+    EXPECT_EQ(mgr.Count(), 0u);
+
+    // Second flush should be a no-op.
+    Entity f = mgr.Create();
+    mgr.FlushDeferred();
+    EXPECT_TRUE(mgr.IsAlive(f));
+    EXPECT_EQ(mgr.Count(), 1u);
+}
+
+TEST(EntityManagerTest, DeferredDeadEntityIsNoop) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+    mgr.Destroy(e);
+
+    // Queueing a dead entity should not crash or cause issues.
+    mgr.DestroyDeferred(e);
+    mgr.FlushDeferred();
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+TEST(EntityManagerTest, FlushDeferredOnEmptyQueue) {
+    EntityManager mgr;
+    // Should be safe when nothing is queued.
+    mgr.FlushDeferred();
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+// ===========================================================================
+// EntityManager: Component auto-removal
+// ===========================================================================
+
+TEST(EntityManagerTest, DestroyRemovesComponents) {
+    EntityManager mgr;
+    ComponentStorage<Position> positions;
+    ComponentStorage<Health> health;
+    mgr.RegisterStorage(&positions);
+    mgr.RegisterStorage(&health);
+
+    Entity e = mgr.Create();
+    positions.Add(e, Position{1.0f, 2.0f, 3.0f});
+    health.Add(e, Health{50, 100});
+
+    EXPECT_TRUE(positions.Has(e));
+    EXPECT_TRUE(health.Has(e));
+
+    mgr.Destroy(e);
+    EXPECT_FALSE(positions.Has(e));
+    EXPECT_FALSE(health.Has(e));
+}
+
+TEST(EntityManagerTest, DeferredDestroyRemovesComponents) {
+    EntityManager mgr;
+    ComponentStorage<Position> positions;
+    mgr.RegisterStorage(&positions);
+
+    Entity e = mgr.Create();
+    positions.Add(e, Position{1.0f, 2.0f, 3.0f});
+
+    mgr.DestroyDeferred(e);
+    EXPECT_TRUE(positions.Has(e));  // Not yet destroyed.
+
+    mgr.FlushDeferred();
+    EXPECT_FALSE(positions.Has(e));
+}
+
+TEST(EntityManagerTest, DestroyOnlyAffectsTargetEntity) {
+    EntityManager mgr;
+    ComponentStorage<Position> positions;
+    mgr.RegisterStorage(&positions);
+
+    Entity a = mgr.Create();
+    Entity b = mgr.Create();
+    positions.Add(a, Position{1.0f, 0.0f, 0.0f});
+    positions.Add(b, Position{2.0f, 0.0f, 0.0f});
+
+    mgr.Destroy(a);
+    EXPECT_FALSE(positions.Has(a));
+    EXPECT_TRUE(positions.Has(b));
+    EXPECT_FLOAT_EQ(positions.Get(b).x, 2.0f);
+}
+
+TEST(EntityManagerTest, DestroyEntityWithoutComponents) {
+    EntityManager mgr;
+    ComponentStorage<Position> positions;
+    mgr.RegisterStorage(&positions);
+
+    Entity e = mgr.Create();
+    // Destroy without adding any components — should not crash.
+    mgr.Destroy(e);
+    EXPECT_FALSE(mgr.IsAlive(e));
+}
+
+// ===========================================================================
+// EntityManager: Capacity
+// ===========================================================================
+
+TEST(EntityManagerTest, CapacityGrowsWithCreation) {
+    EntityManager mgr;
+    EXPECT_EQ(mgr.Capacity(), 0u);
+
+    [[maybe_unused]] auto e1 = mgr.Create();
+    EXPECT_EQ(mgr.Capacity(), 1u);
+
+    [[maybe_unused]] auto e2 = mgr.Create();
+    EXPECT_EQ(mgr.Capacity(), 2u);
+}
+
+TEST(EntityManagerTest, CapacityDoesNotShrinkOnDestroy) {
+    EntityManager mgr;
+    Entity a = mgr.Create();
+    Entity b = mgr.Create();
+    EXPECT_EQ(mgr.Capacity(), 2u);
+
+    mgr.Destroy(a);
+    mgr.Destroy(b);
+    // Capacity stays the same (slots are on free list).
+    EXPECT_EQ(mgr.Capacity(), 2u);
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+// ===========================================================================
+// EntityManager: Bulk operations
+// ===========================================================================
+
+TEST(EntityManagerTest, CreateAndDestroyManyEntities) {
+    EntityManager mgr;
+    constexpr std::size_t N = 1000;
+
+    std::vector<Entity> entities;
+    entities.reserve(N);
+    for (std::size_t i = 0; i < N; ++i) {
+        entities.push_back(mgr.Create());
+    }
+    EXPECT_EQ(mgr.Count(), N);
+
+    // All entities should be unique.
+    std::unordered_set<uint32_t> rawSet;
+    for (const auto& e : entities) {
+        rawSet.insert(e.raw);
+    }
+    EXPECT_EQ(rawSet.size(), N);
+
+    // Destroy all.
+    for (const auto& e : entities) {
+        mgr.Destroy(e);
+    }
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+TEST(EntityManagerTest, CreateAfterDestroyAll) {
+    EntityManager mgr;
+    Entity a = mgr.Create();
+    Entity b = mgr.Create();
+    Entity c = mgr.Create();
+
+    mgr.Destroy(a);
+    mgr.Destroy(b);
+    mgr.Destroy(c);
+
+    // Create new entities — should recycle indices 0, 1, 2 (FIFO).
+    Entity d = mgr.Create();
+    Entity e = mgr.Create();
+    Entity f = mgr.Create();
+
+    EXPECT_EQ(d.id(), 0u);
+    EXPECT_EQ(d.version(), 1);
+    EXPECT_EQ(e.id(), 1u);
+    EXPECT_EQ(e.version(), 1);
+    EXPECT_EQ(f.id(), 2u);
+    EXPECT_EQ(f.version(), 1);
+
+    EXPECT_TRUE(mgr.IsAlive(d));
+    EXPECT_TRUE(mgr.IsAlive(e));
+    EXPECT_TRUE(mgr.IsAlive(f));
+}
+
+// ===========================================================================
+// EntityManager: Recycled entity with new components
+// ===========================================================================
+
+TEST(EntityManagerTest, RecycledEntityCanHaveNewComponents) {
+    EntityManager mgr;
+    ComponentStorage<Position> positions;
+    mgr.RegisterStorage(&positions);
+
+    Entity e1 = mgr.Create();
+    positions.Add(e1, Position{1.0f, 2.0f, 3.0f});
+
+    mgr.Destroy(e1);
+    EXPECT_FALSE(positions.Has(e1));
+
+    Entity e2 = mgr.Create();
+    EXPECT_EQ(e2.id(), e1.id());
+    EXPECT_NE(e2.version(), e1.version());
+
+    // New entity can get its own components.
+    positions.Add(e2, Position{10.0f, 20.0f, 30.0f});
+    EXPECT_TRUE(positions.Has(e2));
+    EXPECT_FLOAT_EQ(positions.Get(e2).x, 10.0f);
+}
+
+// ===========================================================================
+// EntityManager: Mixed deferred and immediate
+// ===========================================================================
+
+TEST(EntityManagerTest, MixedDeferredAndImmediate) {
+    EntityManager mgr;
+    Entity a = mgr.Create();
+    Entity b = mgr.Create();
+    Entity c = mgr.Create();
+
+    mgr.DestroyDeferred(a);
+    mgr.Destroy(b);  // Immediate.
+    mgr.DestroyDeferred(c);
+
+    EXPECT_TRUE(mgr.IsAlive(a));    // Deferred, not yet flushed.
+    EXPECT_FALSE(mgr.IsAlive(b));   // Immediately destroyed.
+    EXPECT_TRUE(mgr.IsAlive(c));    // Deferred, not yet flushed.
+    EXPECT_EQ(mgr.Count(), 2u);
+
+    mgr.FlushDeferred();
+    EXPECT_FALSE(mgr.IsAlive(a));
+    EXPECT_FALSE(mgr.IsAlive(c));
+    EXPECT_EQ(mgr.Count(), 0u);
+}
+
+// ===========================================================================
+// EntityManager: Version wrapping
+// ===========================================================================
+
+TEST(EntityManagerTest, VersionWrapsAround) {
+    EntityManager mgr;
+    Entity e = mgr.Create();
+    uint32_t idx = e.id();
+
+    // Cycle through all 256 version values.
+    for (int i = 0; i < 256; ++i) {
+        mgr.Destroy(e);
+        e = mgr.Create();
+        EXPECT_EQ(e.id(), idx);
+    }
+
+    // After 256 destroy/create cycles starting from version 0,
+    // the version should wrap back to 0.
+    EXPECT_EQ(e.version(), 0);
+    EXPECT_TRUE(mgr.IsAlive(e));
+}
+
+// ===========================================================================
+// EntityManager: Multiple storages
+// ===========================================================================
+
+TEST(EntityManagerTest, MultipleStoragesAllCleaned) {
+    EntityManager mgr;
+    ComponentStorage<Position> positions;
+    ComponentStorage<Health> health;
+    ComponentStorage<Tag> tags;
+    mgr.RegisterStorage(&positions);
+    mgr.RegisterStorage(&health);
+    mgr.RegisterStorage(&tags);
+
+    Entity e = mgr.Create();
+    positions.Add(e, Position{1.0f, 2.0f, 3.0f});
+    health.Add(e, Health{50, 100});
+    tags.Add(e);
+
+    mgr.Destroy(e);
+    EXPECT_FALSE(positions.Has(e));
+    EXPECT_FALSE(health.Has(e));
+    EXPECT_FALSE(tags.Has(e));
+}


### PR DESCRIPTION
Closes #10

## Summary

- Implement `EntityManager` class for entity lifecycle management (SDS-MOD-010)
- 24-bit index + 8-bit version Entity handles with FIFO free-list ID recycling
- Immediate and deferred destruction with automatic component cleanup via registered `IComponentStorage`
- Version increment on recycle prevents stale handle access (ABA problem protection)

## Traceability

| Document | Reference |
|----------|-----------|
| **PRD** | FR-002.2 — Support entity creation/destruction at runtime |
| **SRS** | SRS-ECS-002 (Section 3.2) |
| **SDS** | SDS-MOD-010 |

## Files Changed

| File | Description |
|------|-------------|
| `include/cgs/ecs/entity_manager.hpp` | EntityManager class declaration |
| `src/ecs/entity_manager/entity_manager.cpp` | Implementation |
| `src/ecs/entity_manager/CMakeLists.txt` | Build target `cgs::ecs_entity_manager` |
| `src/ecs/CMakeLists.txt` | Add entity_manager subdirectory |
| `tests/CMakeLists.txt` | Add entity_manager test target |
| `tests/unit/ecs/entity_manager_test.cpp` | 34 unit tests |

## Test Plan

- [x] 34 unit tests pass (EntityManagerTest suite)
- [x] 411/411 total tests pass — zero regressions
- [x] Covers: creation, destruction, ID recycling, version wrapping, deferred ops, component auto-removal, edge cases