### PR TITLE
feat(ecs): add System Scheduling & Execution (SDS-MOD-012)

### DIFF
--- a/include/cgs/ecs/system_scheduler.hpp
+++ b/include/cgs/ecs/system_scheduler.hpp
@@ -1,0 +1,311 @@
+#pragma once
+
+/// @file system_scheduler.hpp
+/// @brief System scheduling with dependency management for the ECS.
+///
+/// SystemScheduler manages system registration, stage-based grouping,
+/// dependency-driven topological ordering, and runtime enable/disable.
+/// FixedUpdate runs at a configurable fixed interval independent of
+/// frame rate.
+///
+/// @see docs/reference/ECS_DESIGN.md  Section 3
+/// @see SDS-MOD-012
+
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "cgs/ecs/component_type_id.hpp"
+
+namespace cgs::ecs {
+
+// ── System type identification ──────────────────────────────────────────
+
+/// Integer type used to identify system types at runtime.
+using SystemTypeId = uint32_t;
+
+/// Sentinel value meaning "no system type".
+constexpr SystemTypeId kInvalidSystemTypeId = static_cast<SystemTypeId>(-1);
+
+namespace detail {
+
+/// Global atomic counter for generating unique SystemTypeId values.
+inline SystemTypeId nextSystemTypeId() noexcept {
+    static std::atomic<SystemTypeId> counter{0};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace detail
+
+/// Obtain the unique SystemTypeId for system type `T`.
+///
+/// Usage:
+/// @code
+///   auto id = SystemType<MovementSystem>::Id();
+/// @endcode
+template <typename T>
+struct SystemType {
+    static SystemTypeId Id() noexcept {
+        static const SystemTypeId value = detail::nextSystemTypeId();
+        return value;
+    }
+};
+
+// ── Execution stages ────────────────────────────────────────────────────
+
+/// Execution stage for a system.  Stages are executed in order:
+/// PreUpdate -> Update -> PostUpdate -> FixedUpdate.
+enum class SystemStage : uint8_t {
+    PreUpdate,   ///< Before main update (input processing, etc.)
+    Update,      ///< Main game logic update
+    PostUpdate,  ///< After main update (cleanup, event dispatch, etc.)
+    FixedUpdate  ///< Fixed-timestep update (physics, etc.)
+};
+
+// ── System interface ────────────────────────────────────────────────────
+
+/// Abstract base class for ECS systems.
+///
+/// Concrete systems override `Execute()` and optionally `GetStage()`.
+/// The scheduler owns and manages the lifecycle of registered systems.
+class ISystem {
+public:
+    virtual ~ISystem() = default;
+
+    /// Execute this system's logic for the given time step.
+    ///
+    /// @param deltaTime  Frame delta time in seconds.
+    virtual void Execute(float deltaTime) = 0;
+
+    /// Return the execution stage this system belongs to.
+    ///
+    /// Override to place the system in a non-default stage.
+    /// Default is SystemStage::Update.
+    [[nodiscard]] virtual SystemStage GetStage() const { return SystemStage::Update; }
+
+    /// Return a human-readable name for this system (for diagnostics).
+    [[nodiscard]] virtual std::string_view GetName() const = 0;
+};
+
+// ── System scheduler ────────────────────────────────────────────────────
+
+/// Manages system registration, dependency ordering, and staged execution.
+///
+/// Systems are grouped by stage and topologically sorted within each
+/// stage according to explicit dependencies.  Circular dependencies
+/// are detected at build time and reported via an error string.
+///
+/// FixedUpdate accumulates elapsed time and ticks at a fixed interval
+/// (default 1/60 s) independent of the variable frame rate.
+class SystemScheduler {
+public:
+    SystemScheduler() = default;
+
+    // Non-copyable, movable.
+    SystemScheduler(const SystemScheduler&) = delete;
+    SystemScheduler& operator=(const SystemScheduler&) = delete;
+    SystemScheduler(SystemScheduler&&) noexcept = default;
+    SystemScheduler& operator=(SystemScheduler&&) noexcept = default;
+
+    // ── Registration ────────────────────────────────────────────────
+
+    /// Register a system of type `T`, constructing it in-place.
+    ///
+    /// The system's stage is determined by `T::GetStage()`.
+    /// Re-registering the same type is a no-op and returns the
+    /// existing instance.
+    ///
+    /// @tparam T       Concrete system type (must derive from ISystem).
+    /// @tparam Args    Constructor argument types.
+    /// @param  args    Forwarded to T's constructor.
+    /// @return Reference to the registered system.
+    template <typename T, typename... Args>
+    T& Register(Args&&... args);
+
+    /// Return the number of registered systems.
+    [[nodiscard]] std::size_t SystemCount() const noexcept;
+
+    // ── Dependencies ────────────────────────────────────────────────
+
+    /// Declare that `before` must execute before `after`.
+    ///
+    /// Both systems must already be registered.  Dependencies across
+    /// different stages are silently ignored (stage ordering is
+    /// implicit).
+    ///
+    /// @return true if the dependency was added, false if either
+    ///         system is not registered or they belong to different stages.
+    bool AddDependency(SystemTypeId before, SystemTypeId after);
+
+    /// Convenience: declare a dependency using system types.
+    template <typename Before, typename After>
+    bool AddDependency();
+
+    // ── Enable / disable ────────────────────────────────────────────
+
+    /// Enable or disable a system at runtime.
+    ///
+    /// Disabled systems are skipped during execution without changing
+    /// the execution plan.  They remain registered and can be
+    /// re-enabled at any time.
+    void SetEnabled(SystemTypeId system, bool enabled);
+
+    /// Convenience: enable/disable using system type.
+    template <typename T>
+    void SetEnabled(bool enabled);
+
+    /// Check if a system is enabled.
+    [[nodiscard]] bool IsEnabled(SystemTypeId system) const;
+
+    // ── Execution ───────────────────────────────────────────────────
+
+    /// Build the execution plan (topological sort per stage).
+    ///
+    /// Must be called after all registrations and dependencies are set
+    /// and before the first Execute().  Returns true on success.
+    /// On failure (circular dependency), returns false and populates
+    /// the error string retrievable via GetLastError().
+    [[nodiscard]] bool Build();
+
+    /// Execute all enabled systems in stage order.
+    ///
+    /// PreUpdate, Update, and PostUpdate receive @p deltaTime.
+    /// FixedUpdate accumulates time and ticks at the configured
+    /// fixed interval.
+    ///
+    /// @pre Build() must have been called successfully.
+    void Execute(float deltaTime);
+
+    /// Return the error message from the last failed Build().
+    [[nodiscard]] const std::string& GetLastError() const noexcept;
+
+    // ── FixedUpdate configuration ───────────────────────────────────
+
+    /// Set the fixed timestep for FixedUpdate (default: 1/60 s).
+    void SetFixedTimeStep(float seconds);
+
+    /// Get the current fixed timestep.
+    [[nodiscard]] float GetFixedTimeStep() const noexcept;
+
+    // ── Queries ─────────────────────────────────────────────────────
+
+    /// Retrieve a registered system by type.
+    ///
+    /// @return Pointer to the system, or nullptr if not registered.
+    template <typename T>
+    [[nodiscard]] T* GetSystem();
+
+    /// Retrieve the execution order for a specific stage (after Build).
+    ///
+    /// @return Vector of SystemTypeIds in execution order.
+    [[nodiscard]] const std::vector<SystemTypeId>&
+    GetExecutionOrder(SystemStage stage) const;
+
+private:
+    /// Internal entry for a registered system.
+    struct SystemEntry {
+        std::unique_ptr<ISystem> instance;
+        SystemTypeId typeId = kInvalidSystemTypeId;
+        SystemStage stage = SystemStage::Update;
+        bool enabled = true;
+    };
+
+    /// Perform topological sort on systems within a stage.
+    ///
+    /// @param ids  System type IDs belonging to the stage.
+    /// @param[out] sorted  Output execution order.
+    /// @return true on success, false on circular dependency.
+    [[nodiscard]] bool topologicalSort(
+        const std::vector<SystemTypeId>& ids,
+        std::vector<SystemTypeId>& sorted);
+
+    /// All registered systems, keyed by SystemTypeId.
+    std::unordered_map<SystemTypeId, SystemEntry> systems_;
+
+    /// Systems grouped by stage (registration order within stage).
+    std::unordered_map<SystemStage, std::vector<SystemTypeId>> stageGroups_;
+
+    /// Dependency edges: dependencies_[A] contains all B where A -> B
+    /// (A must run before B).
+    std::unordered_map<SystemTypeId, std::unordered_set<SystemTypeId>> dependencies_;
+
+    /// Reverse dependency edges: reverseDeps_[B] contains all A where A -> B.
+    std::unordered_map<SystemTypeId, std::unordered_set<SystemTypeId>> reverseDeps_;
+
+    /// Computed execution order per stage (populated by Build()).
+    std::unordered_map<SystemStage, std::vector<SystemTypeId>> executionOrder_;
+
+    /// Whether Build() has been called successfully.
+    bool built_ = false;
+
+    /// Error string from the last failed Build().
+    std::string lastError_;
+
+    /// Fixed timestep for FixedUpdate (seconds).
+    float fixedTimeStep_ = 1.0f / 60.0f;
+
+    /// Accumulated time for FixedUpdate.
+    float fixedTimeAccumulator_ = 0.0f;
+
+    /// Empty vector returned for stages with no systems.
+    static const std::vector<SystemTypeId> kEmptyOrder_;
+};
+
+// ── Template implementations ────────────────────────────────────────────
+
+template <typename T, typename... Args>
+T& SystemScheduler::Register(Args&&... args) {
+    static_assert(std::is_base_of_v<ISystem, T>,
+                  "T must derive from ISystem");
+
+    const auto typeId = SystemType<T>::Id();
+
+    // Return existing instance if already registered.
+    if (auto it = systems_.find(typeId); it != systems_.end()) {
+        return static_cast<T&>(*it->second.instance);
+    }
+
+    auto system = std::make_unique<T>(std::forward<Args>(args)...);
+    T& ref = *system;
+
+    SystemEntry entry;
+    entry.instance = std::move(system);
+    entry.typeId = typeId;
+    entry.stage = ref.GetStage();
+    entry.enabled = true;
+
+    stageGroups_[entry.stage].push_back(typeId);
+    systems_.emplace(typeId, std::move(entry));
+
+    // Invalidate any previously built plan.
+    built_ = false;
+
+    return ref;
+}
+
+template <typename Before, typename After>
+bool SystemScheduler::AddDependency() {
+    return AddDependency(SystemType<Before>::Id(), SystemType<After>::Id());
+}
+
+template <typename T>
+void SystemScheduler::SetEnabled(bool enabled) {
+    SetEnabled(SystemType<T>::Id(), enabled);
+}
+
+template <typename T>
+T* SystemScheduler::GetSystem() {
+    const auto typeId = SystemType<T>::Id();
+    if (auto it = systems_.find(typeId); it != systems_.end()) {
+        return static_cast<T*>(it->second.instance.get());
+    }
+    return nullptr;
+}
+
+} // namespace cgs::ecs

--- a/src/ecs/CMakeLists.txt
+++ b/src/ecs/CMakeLists.txt
@@ -1,3 +1,4 @@
 # ECS Core (Layer 4)
 add_subdirectory(component_storage)
 add_subdirectory(entity_manager)
+add_subdirectory(system_scheduler)

--- a/src/ecs/system_scheduler/CMakeLists.txt
+++ b/src/ecs/system_scheduler/CMakeLists.txt
@@ -1,0 +1,8 @@
+# ECS System Scheduler (SDS-MOD-012)
+add_library(cgs_ecs_system_scheduler
+    system_scheduler.cpp
+)
+target_link_libraries(cgs_ecs_system_scheduler
+    PUBLIC cgs_ecs_component_storage
+)
+add_library(cgs::ecs_system_scheduler ALIAS cgs_ecs_system_scheduler)

--- a/src/ecs/system_scheduler/system_scheduler.cpp
+++ b/src/ecs/system_scheduler/system_scheduler.cpp
@@ -1,0 +1,236 @@
+/// @file system_scheduler.cpp
+/// @brief System scheduling implementation.
+///
+/// Provides staged execution with topological ordering via Kahn's
+/// algorithm for dependency resolution.  Circular dependencies are
+/// detected and reported with the names of the involved systems.
+///
+/// @see SDS-MOD-012
+
+#include "cgs/ecs/system_scheduler.hpp"
+
+#include <algorithm>
+#include <queue>
+#include <sstream>
+
+namespace cgs::ecs {
+
+// ── Static member ───────────────────────────────────────────────────────
+
+const std::vector<SystemTypeId> SystemScheduler::kEmptyOrder_;
+
+// ── Registration ────────────────────────────────────────────────────────
+
+std::size_t SystemScheduler::SystemCount() const noexcept {
+    return systems_.size();
+}
+
+// ── Dependencies ────────────────────────────────────────────────────────
+
+bool SystemScheduler::AddDependency(SystemTypeId before, SystemTypeId after) {
+    // Both systems must be registered.
+    auto itBefore = systems_.find(before);
+    auto itAfter = systems_.find(after);
+
+    if (itBefore == systems_.end() || itAfter == systems_.end()) {
+        return false;
+    }
+
+    // Dependencies across different stages are meaningless (stage
+    // ordering is implicit), so silently reject them.
+    if (itBefore->second.stage != itAfter->second.stage) {
+        return false;
+    }
+
+    dependencies_[before].insert(after);
+    reverseDeps_[after].insert(before);
+
+    // Invalidate any previously built plan.
+    built_ = false;
+
+    return true;
+}
+
+// ── Enable / disable ────────────────────────────────────────────────────
+
+void SystemScheduler::SetEnabled(SystemTypeId system, bool enabled) {
+    if (auto it = systems_.find(system); it != systems_.end()) {
+        it->second.enabled = enabled;
+    }
+}
+
+bool SystemScheduler::IsEnabled(SystemTypeId system) const {
+    if (auto it = systems_.find(system); it != systems_.end()) {
+        return it->second.enabled;
+    }
+    return false;
+}
+
+// ── Build ───────────────────────────────────────────────────────────────
+
+bool SystemScheduler::Build() {
+    lastError_.clear();
+    executionOrder_.clear();
+
+    // Process each stage independently.
+    for (const auto& [stage, ids] : stageGroups_) {
+        std::vector<SystemTypeId> sorted;
+        if (!topologicalSort(ids, sorted)) {
+            built_ = false;
+            return false;
+        }
+        executionOrder_[stage] = std::move(sorted);
+    }
+
+    built_ = true;
+    return true;
+}
+
+bool SystemScheduler::topologicalSort(
+    const std::vector<SystemTypeId>& ids,
+    std::vector<SystemTypeId>& sorted) {
+
+    // Build a local set of IDs for this stage (for fast lookup).
+    std::unordered_set<SystemTypeId> stageSet(ids.begin(), ids.end());
+
+    // Compute in-degree for each system in this stage, considering
+    // only dependencies where both endpoints are in the same stage.
+    std::unordered_map<SystemTypeId, uint32_t> inDegree;
+    for (auto id : ids) {
+        inDegree[id] = 0;
+    }
+
+    for (auto id : ids) {
+        if (auto it = reverseDeps_.find(id); it != reverseDeps_.end()) {
+            for (auto dep : it->second) {
+                if (stageSet.contains(dep)) {
+                    ++inDegree[id];
+                }
+            }
+        }
+    }
+
+    // Kahn's algorithm: start with systems that have no incoming edges.
+    std::queue<SystemTypeId> ready;
+    for (auto id : ids) {
+        if (inDegree[id] == 0) {
+            ready.push(id);
+        }
+    }
+
+    sorted.clear();
+    sorted.reserve(ids.size());
+
+    while (!ready.empty()) {
+        auto current = ready.front();
+        ready.pop();
+        sorted.push_back(current);
+
+        // Reduce in-degree for successors in this stage.
+        if (auto it = dependencies_.find(current); it != dependencies_.end()) {
+            for (auto successor : it->second) {
+                if (!stageSet.contains(successor)) {
+                    continue;
+                }
+                --inDegree[successor];
+                if (inDegree[successor] == 0) {
+                    ready.push(successor);
+                }
+            }
+        }
+    }
+
+    // If not all systems were visited, there is a cycle.
+    if (sorted.size() != ids.size()) {
+        std::ostringstream oss;
+        oss << "Circular dependency detected among systems: [";
+        bool first = true;
+        for (auto id : ids) {
+            if (inDegree[id] != 0) {
+                if (!first) {
+                    oss << ", ";
+                }
+                oss << systems_.at(id).instance->GetName();
+                first = false;
+            }
+        }
+        oss << "]";
+        lastError_ = oss.str();
+        return false;
+    }
+
+    return true;
+}
+
+// ── Execution ───────────────────────────────────────────────────────────
+
+void SystemScheduler::Execute(float deltaTime) {
+    assert(built_ && "SystemScheduler::Build() must be called before Execute()");
+
+    // Stage execution order: PreUpdate -> Update -> PostUpdate.
+    static constexpr SystemStage kVariableStages[] = {
+        SystemStage::PreUpdate,
+        SystemStage::Update,
+        SystemStage::PostUpdate,
+    };
+
+    for (auto stage : kVariableStages) {
+        auto it = executionOrder_.find(stage);
+        if (it == executionOrder_.end()) {
+            continue;
+        }
+        for (auto typeId : it->second) {
+            auto& entry = systems_.at(typeId);
+            if (entry.enabled) {
+                entry.instance->Execute(deltaTime);
+            }
+        }
+    }
+
+    // FixedUpdate: accumulate time and tick at fixed intervals.
+    auto fixedIt = executionOrder_.find(SystemStage::FixedUpdate);
+    if (fixedIt != executionOrder_.end() && !fixedIt->second.empty()) {
+        fixedTimeAccumulator_ += deltaTime;
+
+        while (fixedTimeAccumulator_ >= fixedTimeStep_) {
+            fixedTimeAccumulator_ -= fixedTimeStep_;
+
+            for (auto typeId : fixedIt->second) {
+                auto& entry = systems_.at(typeId);
+                if (entry.enabled) {
+                    entry.instance->Execute(fixedTimeStep_);
+                }
+            }
+        }
+    }
+}
+
+// ── Error reporting ─────────────────────────────────────────────────────
+
+const std::string& SystemScheduler::GetLastError() const noexcept {
+    return lastError_;
+}
+
+// ── FixedUpdate configuration ───────────────────────────────────────────
+
+void SystemScheduler::SetFixedTimeStep(float seconds) {
+    assert(seconds > 0.0f && "Fixed timestep must be positive");
+    fixedTimeStep_ = seconds;
+}
+
+float SystemScheduler::GetFixedTimeStep() const noexcept {
+    return fixedTimeStep_;
+}
+
+// ── Queries ─────────────────────────────────────────────────────────────
+
+const std::vector<SystemTypeId>&
+SystemScheduler::GetExecutionOrder(SystemStage stage) const {
+    auto it = executionOrder_.find(stage);
+    if (it != executionOrder_.end()) {
+        return it->second;
+    }
+    return kEmptyOrder_;
+}
+
+} // namespace cgs::ecs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,16 @@ target_link_libraries(cgs_ecs_entity_manager_tests PRIVATE
 )
 gtest_discover_tests(cgs_ecs_entity_manager_tests)
 
+# Unit tests - ECS system scheduler
+add_executable(cgs_ecs_system_scheduler_tests
+    unit/ecs/system_scheduler_test.cpp
+)
+target_link_libraries(cgs_ecs_system_scheduler_tests PRIVATE
+    cgs::ecs_system_scheduler
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_ecs_system_scheduler_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/ecs/system_scheduler_test.cpp
+++ b/tests/unit/ecs/system_scheduler_test.cpp
@@ -1,0 +1,619 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "cgs/ecs/system_scheduler.hpp"
+
+using namespace cgs::ecs;
+
+// ── Test system types ───────────────────────────────────────────────────────
+
+/// Records each Execute() call with its deltaTime for verification.
+class RecordingSystem : public ISystem {
+public:
+    explicit RecordingSystem(std::string name, SystemStage stage = SystemStage::Update)
+        : name_(std::move(name)), stage_(stage) {}
+
+    void Execute(float deltaTime) override {
+        calls_.push_back(deltaTime);
+        executionLog().push_back(name_);
+    }
+
+    [[nodiscard]] SystemStage GetStage() const override { return stage_; }
+    [[nodiscard]] std::string_view GetName() const override { return name_; }
+
+    [[nodiscard]] const std::vector<float>& Calls() const { return calls_; }
+    [[nodiscard]] std::size_t CallCount() const { return calls_.size(); }
+
+    /// Shared log across all RecordingSystem instances for ordering verification.
+    static std::vector<std::string>& executionLog() {
+        static std::vector<std::string> log;
+        return log;
+    }
+
+    static void clearLog() { executionLog().clear(); }
+
+private:
+    std::string name_;
+    SystemStage stage_;
+    std::vector<float> calls_;
+};
+
+class PreUpdateSystem : public RecordingSystem {
+public:
+    PreUpdateSystem() : RecordingSystem("PreUpdateSystem", SystemStage::PreUpdate) {}
+};
+
+class UpdateSystemA : public RecordingSystem {
+public:
+    UpdateSystemA() : RecordingSystem("UpdateSystemA", SystemStage::Update) {}
+};
+
+class UpdateSystemB : public RecordingSystem {
+public:
+    UpdateSystemB() : RecordingSystem("UpdateSystemB", SystemStage::Update) {}
+};
+
+class UpdateSystemC : public RecordingSystem {
+public:
+    UpdateSystemC() : RecordingSystem("UpdateSystemC", SystemStage::Update) {}
+};
+
+class PostUpdateSystem : public RecordingSystem {
+public:
+    PostUpdateSystem() : RecordingSystem("PostUpdateSystem", SystemStage::PostUpdate) {}
+};
+
+class FixedUpdateSystem : public RecordingSystem {
+public:
+    FixedUpdateSystem() : RecordingSystem("FixedUpdateSystem", SystemStage::FixedUpdate) {}
+};
+
+class FixedUpdateSystemB : public RecordingSystem {
+public:
+    FixedUpdateSystemB() : RecordingSystem("FixedUpdateSystemB", SystemStage::FixedUpdate) {}
+};
+
+// Systems for circular dependency testing
+class CycleSystemA : public RecordingSystem {
+public:
+    CycleSystemA() : RecordingSystem("CycleSystemA", SystemStage::Update) {}
+};
+
+class CycleSystemB : public RecordingSystem {
+public:
+    CycleSystemB() : RecordingSystem("CycleSystemB", SystemStage::Update) {}
+};
+
+class CycleSystemC : public RecordingSystem {
+public:
+    CycleSystemC() : RecordingSystem("CycleSystemC", SystemStage::Update) {}
+};
+
+// ===========================================================================
+// SystemScheduler: Registration
+// ===========================================================================
+
+TEST(SystemSchedulerTest, RegisterIncrementsCount) {
+    SystemScheduler scheduler;
+    EXPECT_EQ(scheduler.SystemCount(), 0u);
+
+    scheduler.Register<UpdateSystemA>();
+    EXPECT_EQ(scheduler.SystemCount(), 1u);
+
+    scheduler.Register<UpdateSystemB>();
+    EXPECT_EQ(scheduler.SystemCount(), 2u);
+}
+
+TEST(SystemSchedulerTest, RegisterReturnsReference) {
+    SystemScheduler scheduler;
+    auto& sys = scheduler.Register<UpdateSystemA>();
+    EXPECT_EQ(sys.GetName(), "UpdateSystemA");
+}
+
+TEST(SystemSchedulerTest, DuplicateRegistrationReturnsExisting) {
+    SystemScheduler scheduler;
+    auto& first = scheduler.Register<UpdateSystemA>();
+    auto& second = scheduler.Register<UpdateSystemA>();
+
+    EXPECT_EQ(&first, &second);
+    EXPECT_EQ(scheduler.SystemCount(), 1u);
+}
+
+TEST(SystemSchedulerTest, GetSystemReturnsRegistered) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemA>();
+
+    auto* sys = scheduler.GetSystem<UpdateSystemA>();
+    ASSERT_NE(sys, nullptr);
+    EXPECT_EQ(sys->GetName(), "UpdateSystemA");
+}
+
+TEST(SystemSchedulerTest, GetSystemReturnsNullForUnregistered) {
+    SystemScheduler scheduler;
+    auto* sys = scheduler.GetSystem<UpdateSystemA>();
+    EXPECT_EQ(sys, nullptr);
+}
+
+// ===========================================================================
+// SystemScheduler: Stage assignment
+// ===========================================================================
+
+TEST(SystemSchedulerTest, SystemsAssignedToCorrectStages) {
+    SystemScheduler scheduler;
+    scheduler.Register<PreUpdateSystem>();
+    scheduler.Register<UpdateSystemA>();
+    scheduler.Register<PostUpdateSystem>();
+    scheduler.Register<FixedUpdateSystem>();
+
+    ASSERT_TRUE(scheduler.Build());
+
+    EXPECT_EQ(scheduler.GetExecutionOrder(SystemStage::PreUpdate).size(), 1u);
+    EXPECT_EQ(scheduler.GetExecutionOrder(SystemStage::Update).size(), 1u);
+    EXPECT_EQ(scheduler.GetExecutionOrder(SystemStage::PostUpdate).size(), 1u);
+    EXPECT_EQ(scheduler.GetExecutionOrder(SystemStage::FixedUpdate).size(), 1u);
+}
+
+TEST(SystemSchedulerTest, EmptyStageReturnsEmptyOrder) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemA>();
+    ASSERT_TRUE(scheduler.Build());
+
+    const auto& order = scheduler.GetExecutionOrder(SystemStage::PreUpdate);
+    EXPECT_TRUE(order.empty());
+}
+
+// ===========================================================================
+// SystemScheduler: Stage execution order
+// ===========================================================================
+
+TEST(SystemSchedulerTest, StagesExecuteInCorrectOrder) {
+    SystemScheduler scheduler;
+    scheduler.Register<PostUpdateSystem>();
+    scheduler.Register<PreUpdateSystem>();
+    scheduler.Register<UpdateSystemA>();
+
+    ASSERT_TRUE(scheduler.Build());
+    RecordingSystem::clearLog();
+
+    scheduler.Execute(1.0f / 60.0f);
+
+    const auto& log = RecordingSystem::executionLog();
+    ASSERT_EQ(log.size(), 3u);
+    EXPECT_EQ(log[0], "PreUpdateSystem");
+    EXPECT_EQ(log[1], "UpdateSystemA");
+    EXPECT_EQ(log[2], "PostUpdateSystem");
+}
+
+// ===========================================================================
+// SystemScheduler: Dependency ordering
+// ===========================================================================
+
+TEST(SystemSchedulerTest, DependencyDeterminesOrder) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemA>();
+    scheduler.Register<UpdateSystemB>();
+    scheduler.Register<UpdateSystemC>();
+
+    // C -> A -> B  (C first, then A, then B)
+    EXPECT_TRUE((scheduler.AddDependency<UpdateSystemC, UpdateSystemA>()));
+    EXPECT_TRUE((scheduler.AddDependency<UpdateSystemA, UpdateSystemB>()));
+
+    ASSERT_TRUE(scheduler.Build());
+
+    const auto& order = scheduler.GetExecutionOrder(SystemStage::Update);
+    ASSERT_EQ(order.size(), 3u);
+
+    // Find positions.
+    auto posC = std::find(order.begin(), order.end(), SystemType<UpdateSystemC>::Id());
+    auto posA = std::find(order.begin(), order.end(), SystemType<UpdateSystemA>::Id());
+    auto posB = std::find(order.begin(), order.end(), SystemType<UpdateSystemB>::Id());
+
+    EXPECT_LT(posC, posA);
+    EXPECT_LT(posA, posB);
+}
+
+TEST(SystemSchedulerTest, DependencyAcrossStagesReturnsFalse) {
+    SystemScheduler scheduler;
+    scheduler.Register<PreUpdateSystem>();
+    scheduler.Register<UpdateSystemA>();
+
+    // Cross-stage dependency should be rejected.
+    EXPECT_FALSE((scheduler.AddDependency<PreUpdateSystem, UpdateSystemA>()));
+}
+
+TEST(SystemSchedulerTest, DependencyOnUnregisteredSystemReturnsFalse) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemA>();
+
+    EXPECT_FALSE((scheduler.AddDependency<UpdateSystemA, UpdateSystemB>()));
+}
+
+TEST(SystemSchedulerTest, DependencyOrderIsRespectedDuringExecution) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemB>();
+    scheduler.Register<UpdateSystemA>();
+
+    // A must run before B.
+    EXPECT_TRUE((scheduler.AddDependency<UpdateSystemA, UpdateSystemB>()));
+
+    ASSERT_TRUE(scheduler.Build());
+    RecordingSystem::clearLog();
+
+    scheduler.Execute(1.0f / 60.0f);
+
+    const auto& log = RecordingSystem::executionLog();
+    auto posA = std::find(log.begin(), log.end(), "UpdateSystemA");
+    auto posB = std::find(log.begin(), log.end(), "UpdateSystemB");
+
+    ASSERT_NE(posA, log.end());
+    ASSERT_NE(posB, log.end());
+    EXPECT_LT(posA, posB);
+}
+
+// ===========================================================================
+// SystemScheduler: Circular dependency detection
+// ===========================================================================
+
+TEST(SystemSchedulerTest, CircularDependencyDetected) {
+    SystemScheduler scheduler;
+    scheduler.Register<CycleSystemA>();
+    scheduler.Register<CycleSystemB>();
+
+    EXPECT_TRUE((scheduler.AddDependency<CycleSystemA, CycleSystemB>()));
+    EXPECT_TRUE((scheduler.AddDependency<CycleSystemB, CycleSystemA>()));
+
+    EXPECT_FALSE(scheduler.Build());
+    EXPECT_FALSE(scheduler.GetLastError().empty());
+    EXPECT_NE(scheduler.GetLastError().find("Circular dependency"), std::string::npos);
+}
+
+TEST(SystemSchedulerTest, ThreeWayCircularDependencyDetected) {
+    SystemScheduler scheduler;
+    scheduler.Register<CycleSystemA>();
+    scheduler.Register<CycleSystemB>();
+    scheduler.Register<CycleSystemC>();
+
+    // A -> B -> C -> A
+    EXPECT_TRUE((scheduler.AddDependency<CycleSystemA, CycleSystemB>()));
+    EXPECT_TRUE((scheduler.AddDependency<CycleSystemB, CycleSystemC>()));
+    EXPECT_TRUE((scheduler.AddDependency<CycleSystemC, CycleSystemA>()));
+
+    EXPECT_FALSE(scheduler.Build());
+
+    const auto& err = scheduler.GetLastError();
+    EXPECT_NE(err.find("CycleSystemA"), std::string::npos);
+    EXPECT_NE(err.find("CycleSystemB"), std::string::npos);
+    EXPECT_NE(err.find("CycleSystemC"), std::string::npos);
+}
+
+TEST(SystemSchedulerTest, CircularDependencyErrorContainsSystemNames) {
+    SystemScheduler scheduler;
+    scheduler.Register<CycleSystemA>();
+    scheduler.Register<CycleSystemB>();
+
+    EXPECT_TRUE((scheduler.AddDependency<CycleSystemA, CycleSystemB>()));
+    EXPECT_TRUE((scheduler.AddDependency<CycleSystemB, CycleSystemA>()));
+
+    EXPECT_FALSE(scheduler.Build());
+    EXPECT_NE(scheduler.GetLastError().find("CycleSystemA"), std::string::npos);
+    EXPECT_NE(scheduler.GetLastError().find("CycleSystemB"), std::string::npos);
+}
+
+// ===========================================================================
+// SystemScheduler: FixedUpdate
+// ===========================================================================
+
+TEST(SystemSchedulerTest, FixedUpdateRunsAtFixedInterval) {
+    SystemScheduler scheduler;
+    scheduler.SetFixedTimeStep(1.0f / 60.0f);
+    auto& sys = scheduler.Register<FixedUpdateSystem>();
+
+    ASSERT_TRUE(scheduler.Build());
+
+    // Simulate one frame at 30 fps (33.3ms) — should tick twice at ~16.7ms.
+    scheduler.Execute(1.0f / 30.0f);
+    EXPECT_EQ(sys.CallCount(), 2u);
+}
+
+TEST(SystemSchedulerTest, FixedUpdateReceivesFixedTimestep) {
+    SystemScheduler scheduler;
+    constexpr float kFixedDt = 1.0f / 60.0f;
+    scheduler.SetFixedTimeStep(kFixedDt);
+    auto& sys = scheduler.Register<FixedUpdateSystem>();
+
+    ASSERT_TRUE(scheduler.Build());
+    scheduler.Execute(1.0f / 30.0f);
+
+    for (auto dt : sys.Calls()) {
+        EXPECT_FLOAT_EQ(dt, kFixedDt);
+    }
+}
+
+TEST(SystemSchedulerTest, FixedUpdateAccumulatesTime) {
+    SystemScheduler scheduler;
+    constexpr float kFixedDt = 1.0f / 60.0f;
+    scheduler.SetFixedTimeStep(kFixedDt);
+    auto& sys = scheduler.Register<FixedUpdateSystem>();
+
+    ASSERT_TRUE(scheduler.Build());
+
+    // First frame: slightly less than one tick — should not fire.
+    scheduler.Execute(kFixedDt * 0.5f);
+    EXPECT_EQ(sys.CallCount(), 0u);
+
+    // Second frame: another half — total now equals one tick.
+    scheduler.Execute(kFixedDt * 0.5f);
+    EXPECT_EQ(sys.CallCount(), 1u);
+}
+
+TEST(SystemSchedulerTest, FixedUpdateDoesNotRunIfNoTime) {
+    SystemScheduler scheduler;
+    scheduler.SetFixedTimeStep(1.0f / 60.0f);
+    auto& sys = scheduler.Register<FixedUpdateSystem>();
+
+    ASSERT_TRUE(scheduler.Build());
+
+    scheduler.Execute(0.0f);
+    EXPECT_EQ(sys.CallCount(), 0u);
+}
+
+TEST(SystemSchedulerTest, FixedUpdateDependencyOrder) {
+    SystemScheduler scheduler;
+    scheduler.SetFixedTimeStep(1.0f / 60.0f);
+    scheduler.Register<FixedUpdateSystem>();
+    scheduler.Register<FixedUpdateSystemB>();
+
+    // FixedUpdateSystem must run before FixedUpdateSystemB.
+    EXPECT_TRUE((scheduler.AddDependency<FixedUpdateSystem, FixedUpdateSystemB>()));
+
+    ASSERT_TRUE(scheduler.Build());
+    RecordingSystem::clearLog();
+
+    scheduler.Execute(1.0f / 60.0f);
+
+    const auto& log = RecordingSystem::executionLog();
+    auto posA = std::find(log.begin(), log.end(), "FixedUpdateSystem");
+    auto posB = std::find(log.begin(), log.end(), "FixedUpdateSystemB");
+
+    ASSERT_NE(posA, log.end());
+    ASSERT_NE(posB, log.end());
+    EXPECT_LT(posA, posB);
+}
+
+TEST(SystemSchedulerTest, GetFixedTimeStepReturnsConfigured) {
+    SystemScheduler scheduler;
+    scheduler.SetFixedTimeStep(1.0f / 30.0f);
+    EXPECT_FLOAT_EQ(scheduler.GetFixedTimeStep(), 1.0f / 30.0f);
+}
+
+// ===========================================================================
+// SystemScheduler: Enable / disable
+// ===========================================================================
+
+TEST(SystemSchedulerTest, SystemsEnabledByDefault) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemA>();
+    EXPECT_TRUE(scheduler.IsEnabled(SystemType<UpdateSystemA>::Id()));
+}
+
+TEST(SystemSchedulerTest, DisabledSystemNotExecuted) {
+    SystemScheduler scheduler;
+    auto& sys = scheduler.Register<UpdateSystemA>();
+    scheduler.Register<UpdateSystemB>();
+
+    scheduler.SetEnabled<UpdateSystemA>(false);
+    ASSERT_TRUE(scheduler.Build());
+
+    scheduler.Execute(1.0f / 60.0f);
+    EXPECT_EQ(sys.CallCount(), 0u);
+}
+
+TEST(SystemSchedulerTest, ReenabledSystemExecutes) {
+    SystemScheduler scheduler;
+    auto& sys = scheduler.Register<UpdateSystemA>();
+
+    scheduler.SetEnabled<UpdateSystemA>(false);
+    ASSERT_TRUE(scheduler.Build());
+
+    scheduler.Execute(1.0f / 60.0f);
+    EXPECT_EQ(sys.CallCount(), 0u);
+
+    scheduler.SetEnabled<UpdateSystemA>(true);
+    scheduler.Execute(1.0f / 60.0f);
+    EXPECT_EQ(sys.CallCount(), 1u);
+}
+
+TEST(SystemSchedulerTest, DisableDoesNotAffectOtherSystems) {
+    SystemScheduler scheduler;
+    auto& sysA = scheduler.Register<UpdateSystemA>();
+    auto& sysB = scheduler.Register<UpdateSystemB>();
+
+    scheduler.SetEnabled<UpdateSystemA>(false);
+    ASSERT_TRUE(scheduler.Build());
+
+    scheduler.Execute(1.0f / 60.0f);
+    EXPECT_EQ(sysA.CallCount(), 0u);
+    EXPECT_EQ(sysB.CallCount(), 1u);
+}
+
+TEST(SystemSchedulerTest, DisabledFixedUpdateNotExecuted) {
+    SystemScheduler scheduler;
+    scheduler.SetFixedTimeStep(1.0f / 60.0f);
+    auto& sys = scheduler.Register<FixedUpdateSystem>();
+
+    scheduler.SetEnabled<FixedUpdateSystem>(false);
+    ASSERT_TRUE(scheduler.Build());
+
+    scheduler.Execute(1.0f / 30.0f);
+    EXPECT_EQ(sys.CallCount(), 0u);
+}
+
+TEST(SystemSchedulerTest, IsEnabledReturnsFalseForUnregistered) {
+    SystemScheduler scheduler;
+    EXPECT_FALSE(scheduler.IsEnabled(kInvalidSystemTypeId));
+}
+
+// ===========================================================================
+// SystemScheduler: Build validation
+// ===========================================================================
+
+TEST(SystemSchedulerTest, BuildWithoutSystemsSucceeds) {
+    SystemScheduler scheduler;
+    EXPECT_TRUE(scheduler.Build());
+}
+
+TEST(SystemSchedulerTest, BuildWithNoDependenciesSucceeds) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemA>();
+    scheduler.Register<UpdateSystemB>();
+    EXPECT_TRUE(scheduler.Build());
+}
+
+TEST(SystemSchedulerTest, RebuildAfterNewRegistrationInvalidates) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemA>();
+    ASSERT_TRUE(scheduler.Build());
+
+    // Registering a new system invalidates the plan.
+    scheduler.Register<UpdateSystemB>();
+    // The scheduler should require a rebuild (tested implicitly by
+    // verifying the new system appears in the execution order).
+    ASSERT_TRUE(scheduler.Build());
+
+    const auto& order = scheduler.GetExecutionOrder(SystemStage::Update);
+    EXPECT_EQ(order.size(), 2u);
+}
+
+TEST(SystemSchedulerTest, LastErrorClearedOnSuccessfulBuild) {
+    SystemScheduler scheduler;
+    scheduler.Register<CycleSystemA>();
+    scheduler.Register<CycleSystemB>();
+
+    (scheduler.AddDependency<CycleSystemA, CycleSystemB>());
+    (scheduler.AddDependency<CycleSystemB, CycleSystemA>());
+    EXPECT_FALSE(scheduler.Build());
+    EXPECT_FALSE(scheduler.GetLastError().empty());
+
+    // Fix the cycle and rebuild.
+    // Since we cannot remove dependencies, create a fresh scheduler.
+    SystemScheduler scheduler2;
+    scheduler2.Register<UpdateSystemA>();
+    EXPECT_TRUE(scheduler2.Build());
+    EXPECT_TRUE(scheduler2.GetLastError().empty());
+}
+
+// ===========================================================================
+// SystemScheduler: Integration - full game loop
+// ===========================================================================
+
+TEST(SystemSchedulerTest, FullGameLoopMultipleSystems) {
+    SystemScheduler scheduler;
+    scheduler.SetFixedTimeStep(1.0f / 60.0f);
+
+    auto& pre = scheduler.Register<PreUpdateSystem>();
+    auto& updateA = scheduler.Register<UpdateSystemA>();
+    auto& updateB = scheduler.Register<UpdateSystemB>();
+    auto& post = scheduler.Register<PostUpdateSystem>();
+    auto& fixed = scheduler.Register<FixedUpdateSystem>();
+
+    // UpdateA before UpdateB.
+    (scheduler.AddDependency<UpdateSystemA, UpdateSystemB>());
+
+    ASSERT_TRUE(scheduler.Build());
+    RecordingSystem::clearLog();
+
+    // Simulate 3 frames at 60fps.
+    constexpr float kDt = 1.0f / 60.0f;
+    for (int frame = 0; frame < 3; ++frame) {
+        scheduler.Execute(kDt);
+    }
+
+    // Variable-rate systems: 3 calls each.
+    EXPECT_EQ(pre.CallCount(), 3u);
+    EXPECT_EQ(updateA.CallCount(), 3u);
+    EXPECT_EQ(updateB.CallCount(), 3u);
+    EXPECT_EQ(post.CallCount(), 3u);
+
+    // FixedUpdate: at 60fps with 1/60 fixed step, should tick once per frame.
+    EXPECT_EQ(fixed.CallCount(), 3u);
+
+    // Verify stage ordering in execution log for each frame.
+    const auto& log = RecordingSystem::executionLog();
+    // Each frame produces: PreUpdate, UpdateA, UpdateB, PostUpdate, Fixed.
+    // Total = 3 * 5 = 15 entries.
+    ASSERT_EQ(log.size(), 15u);
+
+    for (int frame = 0; frame < 3; ++frame) {
+        auto base = static_cast<std::size_t>(frame * 5);
+        EXPECT_EQ(log[base + 0], "PreUpdateSystem");
+        EXPECT_EQ(log[base + 1], "UpdateSystemA");
+        EXPECT_EQ(log[base + 2], "UpdateSystemB");
+        EXPECT_EQ(log[base + 3], "PostUpdateSystem");
+        EXPECT_EQ(log[base + 4], "FixedUpdateSystem");
+    }
+}
+
+TEST(SystemSchedulerTest, VariableFrameRateWithFixedUpdate) {
+    SystemScheduler scheduler;
+    constexpr float kFixedDt = 1.0f / 60.0f;
+    scheduler.SetFixedTimeStep(kFixedDt);
+
+    auto& update = scheduler.Register<UpdateSystemA>();
+    auto& fixed = scheduler.Register<FixedUpdateSystem>();
+
+    ASSERT_TRUE(scheduler.Build());
+
+    // Simulate a slow frame (100ms) followed by a fast frame (5ms).
+    scheduler.Execute(0.1f);
+    auto fixedCountAfterSlow = fixed.CallCount();
+    EXPECT_EQ(fixedCountAfterSlow, 6u);  // 0.1 / (1/60) = 6
+
+    scheduler.Execute(0.005f);
+    // 5ms is less than 16.7ms, but accumulator had leftover from 0.1f.
+    // Total accumulated: 0.1 + 0.005 = 0.105, ticks = floor(0.105 / (1/60)) = 6
+    // Already ticked 6, so no additional tick.
+    EXPECT_EQ(update.CallCount(), 2u);  // Called once per Execute().
+}
+
+// ===========================================================================
+// SystemScheduler: Edge cases
+// ===========================================================================
+
+TEST(SystemSchedulerTest, ExecuteOnEmptySchedulerDoesNothing) {
+    SystemScheduler scheduler;
+    ASSERT_TRUE(scheduler.Build());
+    scheduler.Execute(1.0f / 60.0f);
+    // Should not crash.
+}
+
+TEST(SystemSchedulerTest, MoveConstructedSchedulerWorks) {
+    SystemScheduler scheduler;
+    scheduler.Register<UpdateSystemA>();
+    ASSERT_TRUE(scheduler.Build());
+
+    SystemScheduler moved(std::move(scheduler));
+    EXPECT_EQ(moved.SystemCount(), 1u);
+
+    auto* sys = moved.GetSystem<UpdateSystemA>();
+    ASSERT_NE(sys, nullptr);
+
+    RecordingSystem::clearLog();
+    moved.Execute(1.0f / 60.0f);
+    EXPECT_EQ(sys->CallCount(), 1u);
+}
+
+TEST(SystemSchedulerTest, DeltaTimePassedCorrectly) {
+    SystemScheduler scheduler;
+    auto& sys = scheduler.Register<UpdateSystemA>();
+
+    ASSERT_TRUE(scheduler.Build());
+    scheduler.Execute(0.042f);
+
+    ASSERT_EQ(sys.CallCount(), 1u);
+    EXPECT_FLOAT_EQ(sys.Calls()[0], 0.042f);
+}


### PR DESCRIPTION
Closes #11

## Summary
- Implement `SystemScheduler` with four execution stages: PreUpdate, Update, PostUpdate, FixedUpdate
- Topological sort (Kahn's algorithm) for dependency-driven execution ordering within each stage
- Circular dependency detection with clear error reporting (includes system names)
- FixedUpdate runs at configurable fixed intervals independent of frame rate (default 1/60s)
- Runtime enable/disable of systems without re-registration
- RTTI-free `SystemTypeId` using atomic counter pattern (consistent with `ComponentTypeId`)

## SRS Traceability

| SRS ID | Requirement | Status |
|--------|-------------|--------|
| SRS-ECS-003.1 | System execution ordering | Implemented |
| SRS-ECS-003.2 | Circular dependency detection | Implemented |
| SRS-ECS-003.3 | Fixed/variable update stages | Implemented |
| SRS-ECS-003.4 | Runtime enable/disable | Implemented |

## Files Changed
- `include/cgs/ecs/system_scheduler.hpp` — Public header with ISystem, SystemStage, SystemScheduler
- `src/ecs/system_scheduler/system_scheduler.cpp` — Core implementation
- `src/ecs/system_scheduler/CMakeLists.txt` — Build target `cgs_ecs_system_scheduler`
- `src/ecs/CMakeLists.txt` — Add system_scheduler subdirectory
- `tests/unit/ecs/system_scheduler_test.cpp` — 36 unit/integration tests
- `tests/CMakeLists.txt` — Add test target

## Test Plan
- [x] 36 unit tests covering all acceptance criteria pass
- [x] All 456 existing tests pass (no regressions)
- [x] Registration, stage assignment, dependency ordering verified
- [x] Circular dependency detection (2-way and 3-way) verified
- [x] FixedUpdate accumulation and fixed timestep delivery verified
- [x] Enable/disable at runtime verified
- [x] Full game loop integration test with multiple systems across all stages