### PR TITLE
feat(ecs): add Component Query System (SDS-MOD-013)

### DIFF
--- a/include/cgs/ecs/component_storage.hpp
+++ b/include/cgs/ecs/component_storage.hpp
@@ -31,6 +31,12 @@ public:
     [[nodiscard]] virtual bool Has(Entity entity) const = 0;
     virtual void Clear() = 0;
     [[nodiscard]] virtual std::size_t Size() const = 0;
+
+    /// Return the entity id stored at dense @p index.
+    [[nodiscard]] virtual uint32_t EntityAt(std::size_t index) const = 0;
+
+    /// Return the storage's global modification version counter.
+    [[nodiscard]] virtual uint32_t Version() const noexcept = 0;
 };
 
 /// Sparse-set component storage.
@@ -169,10 +175,13 @@ public:
     [[nodiscard]] const_iterator cend() const noexcept { return dense_.cend(); }
 
     /// Return the entity id that owns the component at @p index.
-    [[nodiscard]] uint32_t EntityAt(std::size_t index) const {
+    [[nodiscard]] uint32_t EntityAt(std::size_t index) const override {
         assert(index < entities_.size());
         return entities_[index];
     }
+
+    /// Return the storage's global modification version counter.
+    [[nodiscard]] uint32_t Version() const noexcept override { return globalVersion_; }
 
     // ── Version / change detection ──────────────────────────────────────
 

--- a/include/cgs/ecs/query.hpp
+++ b/include/cgs/ecs/query.hpp
@@ -1,0 +1,296 @@
+#pragma once
+
+/// @file query.hpp
+/// @brief Multi-component query system for the ECS.
+///
+/// Query<Includes...> provides filtered iteration over entities that
+/// possess all specified component types, with support for exclude
+/// filters, optional component access, and cached results.
+///
+/// @see SDS-MOD-013
+/// @see docs/reference/ECS_DESIGN.md  Section 2.5
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "cgs/ecs/component_storage.hpp"
+#include "cgs/ecs/component_type_id.hpp"
+#include "cgs/ecs/entity.hpp"
+
+namespace cgs::ecs {
+
+/// Multi-component query with include/exclude filters and caching.
+///
+/// A Query iterates all entities that possess every component type in
+/// the Includes... pack, optionally excluding entities that have certain
+/// other components.  Query results are cached and automatically
+/// invalidated when any relevant storage is modified.
+///
+/// @note Entity handles yielded by ForEach and iterators carry version 0.
+///       The entity id is valid for all component storage operations.
+///       Use EntityManager::IsAlive() if full version checking is needed.
+///
+/// @note Modifying a storage that is being iterated by ForEach is
+///       undefined behavior.  Schedule mutations via deferred operations
+///       or separate passes.
+///
+/// Usage:
+/// @code
+///   ComponentStorage<Position> posStore;
+///   ComponentStorage<Velocity> velStore;
+///   ComponentStorage<Static>   staticStore;
+///
+///   Query<Position, Velocity> movables(posStore, velStore);
+///   movables.Exclude(staticStore)
+///           .ForEach([](Entity e, Position& pos, Velocity& vel) {
+///               pos.x += vel.dx;
+///           });
+/// @endcode
+template <typename... Includes>
+class Query {
+    static_assert(sizeof...(Includes) > 0,
+                  "Query must have at least one component type");
+
+public:
+    using iterator = typename std::vector<Entity>::iterator;
+    using const_iterator = typename std::vector<Entity>::const_iterator;
+
+    /// Construct a query from the storages for each included component type.
+    explicit Query(ComponentStorage<Includes>&... storages)
+        : storages_{&storages...} {}
+
+    // Non-copyable, movable.
+    Query(const Query&) = delete;
+    Query& operator=(const Query&) = delete;
+    Query(Query&&) noexcept = default;
+    Query& operator=(Query&&) noexcept = default;
+
+    // ── Filters ──────────────────────────────────────────────────────────
+
+    /// Exclude entities that have a component in @p storage.
+    ///
+    /// Multiple exclude filters may be chained.  An entity is excluded
+    /// if it has a component in *any* excluded storage.
+    Query& Exclude(const IComponentStorage& storage) {
+        excludes_.push_back(&storage);
+        cacheValid_ = false;
+        return *this;
+    }
+
+    /// Register an optional component storage for @p T.
+    ///
+    /// Optional components do not affect entity matching but can be
+    /// accessed via GetOptional<T>() inside a ForEach callback.
+    template <typename T>
+    Query& Optional(ComponentStorage<T>& storage) {
+        optionals_[ComponentType<T>::Id()] = &storage;
+        return *this;
+    }
+
+    // ── Iteration ────────────────────────────────────────────────────────
+
+    /// Invoke @p func for every matching entity.
+    ///
+    /// The callback receives the Entity handle followed by mutable
+    /// references to each included component type.
+    ///
+    /// @code
+    ///   query.ForEach([](Entity e, Position& pos, Velocity& vel) {
+    ///       pos.x += vel.dx;
+    ///   });
+    /// @endcode
+    template <typename Func>
+    void ForEach(Func&& func) {
+        RefreshCache();
+        for (Entity e : cachedEntities_) {
+            func(e, std::get<ComponentStorage<Includes>*>(storages_)->Get(e)...);
+        }
+    }
+
+    /// Return the number of matching entities.
+    [[nodiscard]] std::size_t Count() const {
+        RefreshCache();
+        return cachedEntities_.size();
+    }
+
+    // ── Optional access ──────────────────────────────────────────────────
+
+    /// Get an optional component for @p entity, or nullptr if absent.
+    ///
+    /// @pre The component type @p T must have been registered via
+    ///      Optional() before calling this method.
+    ///
+    /// @code
+    ///   query.Optional(healthStore);
+    ///   query.ForEach([&](Entity e, Position& pos) {
+    ///       Health* h = query.GetOptional<Health>(e);
+    ///       if (h) h->current -= 10;
+    ///   });
+    /// @endcode
+    template <typename T>
+    [[nodiscard]] T* GetOptional(Entity entity) {
+        auto it = optionals_.find(ComponentType<T>::Id());
+        if (it == optionals_.end()) {
+            return nullptr;
+        }
+        auto* storage = static_cast<ComponentStorage<T>*>(it->second);
+        if (!storage->Has(entity)) {
+            return nullptr;
+        }
+        return &storage->Get(entity);
+    }
+
+    /// Get an optional component (const) for @p entity, or nullptr.
+    template <typename T>
+    [[nodiscard]] const T* GetOptional(Entity entity) const {
+        auto it = optionals_.find(ComponentType<T>::Id());
+        if (it == optionals_.end()) {
+            return nullptr;
+        }
+        const auto* storage =
+            static_cast<const ComponentStorage<T>*>(it->second);
+        if (!storage->Has(entity)) {
+            return nullptr;
+        }
+        return &storage->Get(entity);
+    }
+
+    // ── Range-based for loop ─────────────────────────────────────────────
+
+    /// @{
+    /// Iterator access for range-based for loops.
+    ///
+    /// The iterators yield Entity values.  Use ForEach for typed
+    /// component access, or call storage.Get(e) manually.
+    iterator begin() {
+        RefreshCache();
+        return cachedEntities_.begin();
+    }
+    iterator end() { return cachedEntities_.end(); }
+
+    [[nodiscard]] const_iterator begin() const {
+        RefreshCache();
+        return cachedEntities_.cbegin();
+    }
+    [[nodiscard]] const_iterator end() const { return cachedEntities_.cend(); }
+    /// @}
+
+private:
+    /// Compute a version fingerprint from all relevant storages.
+    ///
+    /// The fingerprint changes whenever any Include or Exclude storage
+    /// is modified.  Optional storages do not affect entity matching
+    /// and are excluded from the fingerprint.
+    [[nodiscard]] uint64_t computeVersionFingerprint() const noexcept {
+        uint64_t fp = 0;
+        std::apply(
+            [&](auto*... ptrs) { ((fp += ptrs->GlobalVersion()), ...); },
+            storages_);
+        for (const auto* ex : excludes_) {
+            fp += ex->Version();
+        }
+        return fp;
+    }
+
+    /// Rebuild the cached entity list if stale.
+    void RefreshCache() const {
+        const uint64_t fp = computeVersionFingerprint();
+        if (cacheValid_ && cacheVersion_ == fp) {
+            return;
+        }
+
+        cachedEntities_.clear();
+
+        // Find the smallest Include storage for optimal iteration.
+        const IComponentStorage* smallest = nullptr;
+        std::size_t smallestSize = std::numeric_limits<std::size_t>::max();
+        std::apply(
+            [&](auto*... ptrs) {
+                auto pick = [&](const IComponentStorage* p) {
+                    if (p->Size() < smallestSize) {
+                        smallest = p;
+                        smallestSize = p->Size();
+                    }
+                };
+                (pick(ptrs), ...);
+            },
+            storages_);
+
+        if (smallest == nullptr || smallestSize == 0) {
+            cacheVersion_ = fp;
+            cacheValid_ = true;
+            return;
+        }
+
+        // Iterate entities in the smallest storage and test membership.
+        for (std::size_t i = 0; i < smallestSize; ++i) {
+            const uint32_t eid = smallest->EntityAt(i);
+            const Entity entity(eid, 0);
+
+            // All Include storages must contain this entity.
+            bool matchesAll = true;
+            std::apply(
+                [&](auto*... ptrs) {
+                    auto check = [&](const IComponentStorage* p) {
+                        if (!matchesAll) {
+                            return;
+                        }
+                        if (p == smallest) {
+                            return; // Already known to be present.
+                        }
+                        if (!p->Has(entity)) {
+                            matchesAll = false;
+                        }
+                    };
+                    (check(ptrs), ...);
+                },
+                storages_);
+
+            if (!matchesAll) {
+                continue;
+            }
+
+            // None of the Exclude storages may contain this entity.
+            bool excluded = false;
+            for (const auto* ex : excludes_) {
+                if (ex->Has(entity)) {
+                    excluded = true;
+                    break;
+                }
+            }
+            if (excluded) {
+                continue;
+            }
+
+            cachedEntities_.push_back(entity);
+        }
+
+        cacheVersion_ = fp;
+        cacheValid_ = true;
+    }
+
+    /// Pointers to the Include component storages.
+    std::tuple<ComponentStorage<Includes>*...> storages_;
+
+    /// Pointers to storages whose presence excludes an entity.
+    std::vector<const IComponentStorage*> excludes_;
+
+    /// Optional component storages keyed by ComponentTypeId.
+    std::unordered_map<ComponentTypeId, void*> optionals_;
+
+    /// Cached matching entities (rebuilt on version mismatch).
+    mutable std::vector<Entity> cachedEntities_;
+
+    /// Version fingerprint at the time the cache was built.
+    mutable uint64_t cacheVersion_ = 0;
+
+    /// Whether the cache is currently valid.
+    mutable bool cacheValid_ = false;
+};
+
+} // namespace cgs::ecs

--- a/src/ecs/CMakeLists.txt
+++ b/src/ecs/CMakeLists.txt
@@ -2,3 +2,4 @@
 add_subdirectory(component_storage)
 add_subdirectory(entity_manager)
 add_subdirectory(system_scheduler)
+add_subdirectory(query)

--- a/src/ecs/query/CMakeLists.txt
+++ b/src/ecs/query/CMakeLists.txt
@@ -1,0 +1,8 @@
+# ECS Component Query System (SDS-MOD-013)
+add_library(cgs_ecs_query
+    query.cpp
+)
+target_link_libraries(cgs_ecs_query
+    PUBLIC cgs_ecs_component_storage
+)
+add_library(cgs::ecs_query ALIAS cgs_ecs_query)

--- a/src/ecs/query/query.cpp
+++ b/src/ecs/query/query.cpp
@@ -1,0 +1,12 @@
+/// @file query.cpp
+/// @brief Anchor translation unit for the Query module (SDS-MOD-013).
+///
+/// Query<...> is fully template-based and implemented in the header.
+/// This file exists to provide a library target for the build system
+/// and to anchor the module in the linker.
+
+#include "cgs/ecs/query.hpp"
+
+namespace cgs::ecs {
+// Intentionally empty — all Query logic is in the header template.
+} // namespace cgs::ecs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,17 @@ target_link_libraries(cgs_ecs_system_scheduler_tests PRIVATE
 )
 gtest_discover_tests(cgs_ecs_system_scheduler_tests)
 
+# Unit tests - ECS component query system
+add_executable(cgs_ecs_query_tests
+    unit/ecs/query_test.cpp
+)
+target_link_libraries(cgs_ecs_query_tests PRIVATE
+    cgs::ecs_query
+    cgs::ecs_entity_manager
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_ecs_query_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/ecs/query_test.cpp
+++ b/tests/unit/ecs/query_test.cpp
@@ -1,0 +1,530 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <unordered_set>
+#include <vector>
+
+#include "cgs/ecs/entity_manager.hpp"
+#include "cgs/ecs/query.hpp"
+
+using namespace cgs::ecs;
+
+// ── Test component types ────────────────────────────────────────────────────
+
+struct Position {
+    float x = 0.0f;
+    float y = 0.0f;
+};
+
+struct Velocity {
+    float dx = 0.0f;
+    float dy = 0.0f;
+};
+
+struct Health {
+    int32_t current = 100;
+    int32_t max = 100;
+};
+
+struct Armor {
+    int32_t value = 0;
+};
+
+// Tag component (zero-sized).
+struct Static {};
+
+struct DeadTag {};
+
+// ── Test fixture ────────────────────────────────────────────────────────────
+
+class QueryTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        em_.RegisterStorage(&positions_);
+        em_.RegisterStorage(&velocities_);
+        em_.RegisterStorage(&healths_);
+        em_.RegisterStorage(&armors_);
+        em_.RegisterStorage(&statics_);
+        em_.RegisterStorage(&dead_);
+    }
+
+    EntityManager em_;
+    ComponentStorage<Position> positions_;
+    ComponentStorage<Velocity> velocities_;
+    ComponentStorage<Health> healths_;
+    ComponentStorage<Armor> armors_;
+    ComponentStorage<Static> statics_;
+    ComponentStorage<DeadTag> dead_;
+};
+
+// ── Multi-component queries ─────────────────────────────────────────────────
+
+TEST_F(QueryTest, BasicMultiComponentQuery) {
+    // Entity with Position + Velocity (should match).
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    velocities_.Add(e1, Velocity{0.5f, 0.5f});
+
+    // Entity with Position only (should NOT match).
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+
+    // Entity with Velocity only (should NOT match).
+    auto e3 = em_.Create();
+    velocities_.Add(e3, Velocity{1.0f, 1.0f});
+
+    // Entity with Position + Velocity (should match).
+    auto e4 = em_.Create();
+    positions_.Add(e4, Position{5.0f, 6.0f});
+    velocities_.Add(e4, Velocity{2.0f, 2.0f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+    EXPECT_EQ(query.Count(), 2u);
+}
+
+TEST_F(QueryTest, SingleComponentQuery) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    auto e3 = em_.Create();
+    velocities_.Add(e3, Velocity{1.0f, 1.0f});
+
+    Query<Position> query(positions_);
+    EXPECT_EQ(query.Count(), 2u);
+}
+
+TEST_F(QueryTest, ThreeComponentQuery) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    velocities_.Add(e1, Velocity{0.5f, 0.5f});
+    healths_.Add(e1, Health{80, 100});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    velocities_.Add(e2, Velocity{1.0f, 1.0f});
+    // No health — should not match.
+
+    Query<Position, Velocity, Health> query(positions_, velocities_, healths_);
+    EXPECT_EQ(query.Count(), 1u);
+}
+
+TEST_F(QueryTest, EmptyQuery) {
+    // No entities at all.
+    Query<Position, Velocity> query(positions_, velocities_);
+    EXPECT_EQ(query.Count(), 0u);
+
+    std::size_t iterations = 0;
+    query.ForEach([&](Entity, Position&, Velocity&) { ++iterations; });
+    EXPECT_EQ(iterations, 0u);
+}
+
+// ── Exclude filter ──────────────────────────────────────────────────────────
+
+TEST_F(QueryTest, ExcludeFilter) {
+    // Movable entity.
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    velocities_.Add(e1, Velocity{0.5f, 0.5f});
+
+    // Static entity (excluded).
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    velocities_.Add(e2, Velocity{0.0f, 0.0f});
+    statics_.Add(e2, Static{});
+
+    // Another movable entity.
+    auto e3 = em_.Create();
+    positions_.Add(e3, Position{5.0f, 6.0f});
+    velocities_.Add(e3, Velocity{1.0f, 1.0f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+    query.Exclude(statics_);
+
+    EXPECT_EQ(query.Count(), 2u);
+
+    // Verify excluded entity is not present.
+    query.ForEach([&](Entity e, Position&, Velocity&) {
+        EXPECT_NE(e.id(), e2.id());
+    });
+}
+
+TEST_F(QueryTest, MultipleExcludes) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    statics_.Add(e2, Static{});
+
+    auto e3 = em_.Create();
+    positions_.Add(e3, Position{5.0f, 6.0f});
+    dead_.Add(e3, DeadTag{});
+
+    auto e4 = em_.Create();
+    positions_.Add(e4, Position{7.0f, 8.0f});
+
+    Query<Position> query(positions_);
+    query.Exclude(statics_).Exclude(dead_);
+
+    EXPECT_EQ(query.Count(), 2u);
+}
+
+// ── Optional component access ───────────────────────────────────────────────
+
+TEST_F(QueryTest, OptionalComponentAccess) {
+    // Entity with Position + Armor.
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    armors_.Add(e1, Armor{50});
+
+    // Entity with Position only.
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+
+    Query<Position> query(positions_);
+    query.Optional(armors_);
+
+    std::size_t withArmor = 0;
+    std::size_t withoutArmor = 0;
+
+    query.ForEach([&](Entity e, Position&) {
+        Armor* armor = query.GetOptional<Armor>(e);
+        if (armor != nullptr) {
+            EXPECT_EQ(armor->value, 50);
+            ++withArmor;
+        } else {
+            ++withoutArmor;
+        }
+    });
+
+    EXPECT_EQ(withArmor, 1u);
+    EXPECT_EQ(withoutArmor, 1u);
+}
+
+TEST_F(QueryTest, OptionalDoesNotAffectMatching) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    // No armor on either entity.
+
+    Query<Position> query(positions_);
+    query.Optional(armors_);
+
+    // Both should match — optional does not filter.
+    EXPECT_EQ(query.Count(), 2u);
+}
+
+// ── ForEach callback ────────────────────────────────────────────────────────
+
+TEST_F(QueryTest, ForEachMutatesComponents) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{0.0f, 0.0f});
+    velocities_.Add(e1, Velocity{1.0f, 2.0f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{10.0f, 20.0f});
+    velocities_.Add(e2, Velocity{-1.0f, -2.0f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+    query.ForEach([](Entity, Position& pos, Velocity& vel) {
+        pos.x += vel.dx;
+        pos.y += vel.dy;
+    });
+
+    EXPECT_FLOAT_EQ(positions_.Get(e1).x, 1.0f);
+    EXPECT_FLOAT_EQ(positions_.Get(e1).y, 2.0f);
+    EXPECT_FLOAT_EQ(positions_.Get(e2).x, 9.0f);
+    EXPECT_FLOAT_EQ(positions_.Get(e2).y, 18.0f);
+}
+
+TEST_F(QueryTest, ForEachReceivesCorrectEntity) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 0.0f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{2.0f, 0.0f});
+
+    Query<Position> query(positions_);
+
+    std::unordered_set<uint32_t> visited;
+    query.ForEach([&](Entity e, Position& pos) {
+        visited.insert(e.id());
+        // Verify entity id maps to the correct component.
+        EXPECT_FLOAT_EQ(positions_.Get(e).x, pos.x);
+    });
+
+    EXPECT_EQ(visited.size(), 2u);
+    EXPECT_TRUE(visited.count(e1.id()));
+    EXPECT_TRUE(visited.count(e2.id()));
+}
+
+// ── Count ───────────────────────────────────────────────────────────────────
+
+TEST_F(QueryTest, CountMatchesForEach) {
+    for (int i = 0; i < 50; ++i) {
+        auto e = em_.Create();
+        positions_.Add(e, Position{static_cast<float>(i), 0.0f});
+        if (i % 2 == 0) {
+            velocities_.Add(e, Velocity{1.0f, 0.0f});
+        }
+    }
+
+    Query<Position, Velocity> query(positions_, velocities_);
+
+    std::size_t forEachCount = 0;
+    query.ForEach(
+        [&](Entity, Position&, Velocity&) { ++forEachCount; });
+
+    EXPECT_EQ(query.Count(), forEachCount);
+    EXPECT_EQ(query.Count(), 25u);
+}
+
+// ── Cache invalidation ──────────────────────────────────────────────────────
+
+TEST_F(QueryTest, CacheInvalidatedOnComponentAdd) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    velocities_.Add(e1, Velocity{0.5f, 0.5f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+    EXPECT_EQ(query.Count(), 1u);
+
+    // Add a second matching entity.
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    velocities_.Add(e2, Velocity{1.0f, 1.0f});
+
+    // Cache should be invalidated automatically.
+    EXPECT_EQ(query.Count(), 2u);
+}
+
+TEST_F(QueryTest, CacheInvalidatedOnComponentRemove) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    velocities_.Add(e1, Velocity{0.5f, 0.5f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    velocities_.Add(e2, Velocity{1.0f, 1.0f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+    EXPECT_EQ(query.Count(), 2u);
+
+    // Remove velocity from e1.
+    velocities_.Remove(e1);
+    EXPECT_EQ(query.Count(), 1u);
+}
+
+TEST_F(QueryTest, CacheInvalidatedOnExcludeStorageChange) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+
+    Query<Position> query(positions_);
+    query.Exclude(statics_);
+    EXPECT_EQ(query.Count(), 2u);
+
+    // Make e2 static — should be excluded now.
+    statics_.Add(e2, Static{});
+    EXPECT_EQ(query.Count(), 1u);
+}
+
+TEST_F(QueryTest, CacheReusedWhenUnchanged) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    velocities_.Add(e1, Velocity{0.5f, 0.5f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+
+    // First call builds the cache.
+    EXPECT_EQ(query.Count(), 1u);
+
+    // Second call should reuse the cache (no version change).
+    EXPECT_EQ(query.Count(), 1u);
+
+    // Mutate a component value (does not change structure).
+    positions_.Replace(e1, Position{9.0f, 9.0f});
+
+    // Version changed due to Replace, but the entity set is the same.
+    // Cache is rebuilt but produces the same result.
+    EXPECT_EQ(query.Count(), 1u);
+}
+
+// ── Range-based for loop ────────────────────────────────────────────────────
+
+TEST_F(QueryTest, RangeBasedForLoop) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 0.0f});
+    velocities_.Add(e1, Velocity{0.5f, 0.0f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{2.0f, 0.0f});
+    velocities_.Add(e2, Velocity{1.0f, 0.0f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+
+    std::size_t count = 0;
+    for (Entity e : query) {
+        EXPECT_TRUE(positions_.Has(e));
+        EXPECT_TRUE(velocities_.Has(e));
+        ++count;
+    }
+    EXPECT_EQ(count, 2u);
+}
+
+TEST_F(QueryTest, ConstRangeBasedForLoop) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 0.0f});
+
+    const Query<Position> query(positions_);
+
+    std::size_t count = 0;
+    for (Entity e : query) {
+        EXPECT_TRUE(positions_.Has(e));
+        ++count;
+    }
+    EXPECT_EQ(count, 1u);
+}
+
+// ── SmallestStorage optimization ────────────────────────────────────────────
+
+TEST_F(QueryTest, IteratesSmallestStorage) {
+    // Add 100 positions but only 3 velocities.
+    std::vector<Entity> entities;
+    for (int i = 0; i < 100; ++i) {
+        auto e = em_.Create();
+        positions_.Add(e, Position{static_cast<float>(i), 0.0f});
+        entities.push_back(e);
+    }
+    // Only 3 entities get velocity.
+    velocities_.Add(entities[0], Velocity{1.0f, 0.0f});
+    velocities_.Add(entities[50], Velocity{2.0f, 0.0f});
+    velocities_.Add(entities[99], Velocity{3.0f, 0.0f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+    EXPECT_EQ(query.Count(), 3u);
+}
+
+// ── Entity destruction integration ──────────────────────────────────────────
+
+TEST_F(QueryTest, DestroyedEntityRemovedFromQuery) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+    velocities_.Add(e1, Velocity{0.5f, 0.5f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    velocities_.Add(e2, Velocity{1.0f, 1.0f});
+
+    Query<Position, Velocity> query(positions_, velocities_);
+    EXPECT_EQ(query.Count(), 2u);
+
+    // Destroy e1 — EntityManager removes its components.
+    em_.Destroy(e1);
+    EXPECT_EQ(query.Count(), 1u);
+}
+
+// ── Chaining ────────────────────────────────────────────────────────────────
+
+TEST_F(QueryTest, MethodChaining) {
+    auto e1 = em_.Create();
+    positions_.Add(e1, Position{1.0f, 2.0f});
+
+    auto e2 = em_.Create();
+    positions_.Add(e2, Position{3.0f, 4.0f});
+    statics_.Add(e2, Static{});
+
+    auto e3 = em_.Create();
+    positions_.Add(e3, Position{5.0f, 6.0f});
+    dead_.Add(e3, DeadTag{});
+
+    // Chain multiple Exclude and Optional.
+    Query<Position> query(positions_);
+    query.Exclude(statics_).Exclude(dead_).Optional(armors_);
+
+    EXPECT_EQ(query.Count(), 1u);
+}
+
+// ── Performance test ────────────────────────────────────────────────────────
+
+TEST_F(QueryTest, PerformanceCachedVsUncached) {
+    constexpr int kEntityCount = 10'000;
+    constexpr int kIterations = 100;
+
+    // Create entities: 70% have Position+Velocity, 30% Position only.
+    for (int i = 0; i < kEntityCount; ++i) {
+        auto e = em_.Create();
+        positions_.Add(e, Position{static_cast<float>(i), 0.0f});
+        if (i % 10 < 7) {
+            velocities_.Add(e, Velocity{1.0f, 0.0f});
+        }
+    }
+
+    Query<Position, Velocity> query(positions_, velocities_);
+
+    // First (uncached) query.
+    auto t0 = std::chrono::high_resolution_clock::now();
+    auto uncachedCount = query.Count();
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    // Subsequent (cached) queries.
+    auto t2 = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < kIterations; ++i) {
+        auto count = query.Count();
+        EXPECT_EQ(count, uncachedCount);
+    }
+    auto t3 = std::chrono::high_resolution_clock::now();
+
+    auto uncachedUs =
+        std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+    auto cachedUs =
+        std::chrono::duration_cast<std::chrono::microseconds>(t3 - t2).count();
+
+    // Report timings.
+    std::cout << "[PERF] Entity count: " << kEntityCount << "\n";
+    std::cout << "[PERF] Matching entities: " << uncachedCount << "\n";
+    std::cout << "[PERF] Uncached query: " << uncachedUs << " us\n";
+    std::cout << "[PERF] Cached " << kIterations << " queries: " << cachedUs
+              << " us (avg "
+              << (kIterations > 0 ? cachedUs / kIterations : 0)
+              << " us/query)\n";
+
+    // Cached queries should be significantly faster.
+    EXPECT_EQ(uncachedCount, 7000u);
+    // Sanity: cached batch should complete faster than uncached single.
+    // (Allow generous margin for CI variability.)
+    EXPECT_LT(cachedUs, uncachedUs * kIterations);
+}
+
+TEST_F(QueryTest, PerformanceForEach10KEntities) {
+    constexpr int kEntityCount = 10'000;
+
+    for (int i = 0; i < kEntityCount; ++i) {
+        auto e = em_.Create();
+        positions_.Add(e, Position{static_cast<float>(i), 0.0f});
+        velocities_.Add(e, Velocity{1.0f, 2.0f});
+    }
+
+    Query<Position, Velocity> query(positions_, velocities_);
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+    query.ForEach([](Entity, Position& pos, Velocity& vel) {
+        pos.x += vel.dx;
+        pos.y += vel.dy;
+    });
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    auto us =
+        std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+
+    std::cout << "[PERF] ForEach " << kEntityCount
+              << " entities: " << us << " us\n";
+
+    EXPECT_EQ(query.Count(), static_cast<std::size_t>(kEntityCount));
+}


### PR DESCRIPTION
Closes #12

## Summary

- Implement `Query<...Includes>` template class for multi-component entity iteration (SDS-MOD-013)
- Add `Exclude()` filter to skip entities that possess certain components
- Add `Optional()` + `GetOptional<T>()` for nullable component access within ForEach callbacks
- Implement query result caching with automatic version-based invalidation
- Optimize iteration by starting from the smallest include storage
- Extend `IComponentStorage` with `EntityAt()` and `Version()` virtual methods for type-erased access
- Add 22 unit tests covering multi-component queries, exclude/optional filters, cache invalidation, entity destruction integration, and performance benchmarks

## Acceptance Criteria Checklist

- [x] Multi-component queries: iterate entities matching all specified component types
- [x] `Exclude()` filter: skip entities that have the excluded component
- [x] `Optional()` access: include component as nullable pointer via `GetOptional<T>()`
- [x] `ForEach()` with lambda receiving entity + component references
- [x] Query result caching: invalidated when component storage changes
- [x] Range-based for loop support via `begin()`/`end()`
- [x] Unit tests: multi-component, exclude, optional, count
- [x] Performance test: cached vs uncached query on 10K entities

## Performance Results

| Metric | Result |
|--------|--------|
| 10K entity uncached query | ~32 us |
| Cached re-query (100x) | ~0 us/query |
| ForEach 10K entities | ~56 us |

## Test Plan

- [x] 22 unit tests pass (multi-component, single-component, three-component queries)
- [x] Exclude filter tests (single and multiple excludes)
- [x] Optional component access tests
- [x] ForEach mutation and entity correctness tests
- [x] Cache invalidation on add/remove/exclude storage change
- [x] Range-based for loop (mutable and const)
- [x] SmallestStorage optimization verification
- [x] Entity destruction integration test
- [x] Performance benchmarks (cached vs uncached, ForEach 10K)
- [x] No regressions in existing ECS tests (110 tests pass)