### PR TITLE
feat(plugin): add Plugin Dependency Resolution (SDS-MOD-018)

### DIFF
--- a/include/cgs/plugin/version_constraint.hpp
+++ b/include/cgs/plugin/version_constraint.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+/// @file version_constraint.hpp
+/// @brief Version constraint parsing and matching for plugin dependencies.
+///
+/// Supports version constraint operators: >=, >, <=, <, ==, ~= (compatible release).
+/// Dependency strings combine a plugin name with optional constraints:
+///   "PluginName"          — any version
+///   "PluginName>=1.0.0"   — version 1.0.0 or newer
+///   "PluginName~=1.5"     — compatible release (>=1.5.0, <2.0.0)
+///
+/// @see SDS-MOD-018 (Plugin Dependency Resolution)
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/plugin/plugin_types.hpp"
+
+namespace cgs::plugin {
+
+/// Comparison operator for a version constraint.
+enum class ConstraintOp : uint8_t {
+    GreaterEqual,      ///< >=
+    GreaterThan,       ///< >
+    LessEqual,         ///< <=
+    LessThan,          ///< <
+    Equal,             ///< ==
+    CompatibleRelease  ///< ~= (same major, minor >= specified)
+};
+
+/// A single version constraint: operator + version.
+///
+/// Example: `>=1.2.0` means "version must be at least 1.2.0".
+struct VersionConstraint {
+    ConstraintOp op = ConstraintOp::GreaterEqual;
+    Version version;
+
+    /// Check whether the given version satisfies this constraint.
+    [[nodiscard]] bool IsSatisfiedBy(const Version& v) const noexcept;
+
+    /// Parse a constraint string like ">=1.2.0", "<2.0.0", "~=1.5".
+    ///
+    /// @return Parsed constraint, or error if the format is invalid.
+    [[nodiscard]] static cgs::foundation::GameResult<VersionConstraint>
+    Parse(std::string_view spec);
+
+    /// Format the constraint as a human-readable string.
+    [[nodiscard]] std::string ToString() const;
+};
+
+/// A parsed dependency specification: plugin name + optional version constraints.
+///
+/// Parses dependency strings from PluginInfo::dependencies:
+///   "NetworkPlugin"           → name="NetworkPlugin", no constraints
+///   "NetworkPlugin>=1.0.0"    → name="NetworkPlugin", constraints=[>=1.0.0]
+///   "CoreLib>=1.0,<2.0"       → name="CoreLib", constraints=[>=1.0.0, <2.0.0]
+struct DependencySpec {
+    std::string name;
+    std::vector<VersionConstraint> constraints;
+
+    /// Check whether all constraints are satisfied by the given version.
+    [[nodiscard]] bool IsSatisfiedBy(const Version& v) const noexcept;
+
+    /// Parse a dependency string.
+    ///
+    /// @return Parsed spec, or error if the format is invalid.
+    [[nodiscard]] static cgs::foundation::GameResult<DependencySpec>
+    Parse(std::string_view dep);
+
+    /// Format all constraints as a human-readable string.
+    [[nodiscard]] std::string ConstraintsToString() const;
+};
+
+/// Parse a version string "major.minor.patch" (minor and patch are optional).
+///
+/// Examples: "1" → {1,0,0}, "1.2" → {1,2,0}, "1.2.3" → {1,2,3}
+[[nodiscard]] cgs::foundation::GameResult<Version> ParseVersion(std::string_view str);
+
+} // namespace cgs::plugin

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -1,6 +1,7 @@
-# Plugin System (SDS-MOD-020, SDS-MOD-021)
+# Plugin System (SDS-MOD-020, SDS-MOD-021, SDS-MOD-018)
 add_library(cgs_plugin
     plugin_manager.cpp
+    version_constraint.cpp
 )
 target_link_libraries(cgs_plugin
     PUBLIC cgs_core

--- a/src/plugins/version_constraint.cpp
+++ b/src/plugins/version_constraint.cpp
@@ -1,0 +1,248 @@
+/// @file version_constraint.cpp
+/// @brief Version constraint parsing and matching implementation.
+///
+/// @see SDS-MOD-018
+
+#include "cgs/plugin/version_constraint.hpp"
+
+#include <charconv>
+
+#include "cgs/foundation/error_code.hpp"
+
+using cgs::foundation::ErrorCode;
+using cgs::foundation::GameError;
+using cgs::foundation::GameResult;
+
+namespace cgs::plugin {
+
+// ── Version parsing ─────────────────────────────────────────────────────
+
+GameResult<Version> ParseVersion(std::string_view str) {
+    Version ver{};
+
+    // Trim whitespace.
+    while (!str.empty() && str.front() == ' ') {
+        str.remove_prefix(1);
+    }
+    while (!str.empty() && str.back() == ' ') {
+        str.remove_suffix(1);
+    }
+
+    if (str.empty()) {
+        return GameResult<Version>::err(
+            GameError(ErrorCode::InvalidArgument, "Empty version string"));
+    }
+
+    // Parse major.
+    auto dotPos = str.find('.');
+    auto majorStr = str.substr(0, dotPos);
+    auto [pMaj, ecMaj] =
+        std::from_chars(majorStr.data(), majorStr.data() + majorStr.size(), ver.major);
+    if (ecMaj != std::errc()) {
+        return GameResult<Version>::err(
+            GameError(ErrorCode::InvalidArgument,
+                      "Invalid major version: " + std::string(str)));
+    }
+
+    if (dotPos == std::string_view::npos) {
+        return GameResult<Version>::ok(ver);
+    }
+
+    // Parse minor.
+    str.remove_prefix(dotPos + 1);
+    dotPos = str.find('.');
+    auto minorStr = str.substr(0, dotPos);
+    auto [pMin, ecMin] =
+        std::from_chars(minorStr.data(), minorStr.data() + minorStr.size(), ver.minor);
+    if (ecMin != std::errc()) {
+        return GameResult<Version>::err(
+            GameError(ErrorCode::InvalidArgument,
+                      "Invalid minor version: " + std::string(str)));
+    }
+
+    if (dotPos == std::string_view::npos) {
+        return GameResult<Version>::ok(ver);
+    }
+
+    // Parse patch.
+    str.remove_prefix(dotPos + 1);
+    auto [pPat, ecPat] =
+        std::from_chars(str.data(), str.data() + str.size(), ver.patch);
+    if (ecPat != std::errc()) {
+        return GameResult<Version>::err(
+            GameError(ErrorCode::InvalidArgument,
+                      "Invalid patch version: " + std::string(str)));
+    }
+
+    return GameResult<Version>::ok(ver);
+}
+
+// ── VersionConstraint ───────────────────────────────────────────────────
+
+bool VersionConstraint::IsSatisfiedBy(const Version& v) const noexcept {
+    switch (op) {
+        case ConstraintOp::GreaterEqual:
+            return v >= version;
+        case ConstraintOp::GreaterThan:
+            return v > version;
+        case ConstraintOp::LessEqual:
+            return v <= version;
+        case ConstraintOp::LessThan:
+            return v < version;
+        case ConstraintOp::Equal:
+            return v == version;
+        case ConstraintOp::CompatibleRelease:
+            // ~=1.5.0 means >=1.5.0 and <2.0.0 (same major).
+            return v >= version && v.major == version.major;
+    }
+    return false;
+}
+
+GameResult<VersionConstraint> VersionConstraint::Parse(std::string_view spec) {
+    // Trim whitespace.
+    while (!spec.empty() && spec.front() == ' ') {
+        spec.remove_prefix(1);
+    }
+
+    if (spec.empty()) {
+        return GameResult<VersionConstraint>::err(
+            GameError(ErrorCode::InvalidArgument, "Empty constraint string"));
+    }
+
+    VersionConstraint constraint;
+
+    // Detect operator.
+    if (spec.starts_with("~=")) {
+        constraint.op = ConstraintOp::CompatibleRelease;
+        spec.remove_prefix(2);
+    } else if (spec.starts_with(">=")) {
+        constraint.op = ConstraintOp::GreaterEqual;
+        spec.remove_prefix(2);
+    } else if (spec.starts_with(">")) {
+        constraint.op = ConstraintOp::GreaterThan;
+        spec.remove_prefix(1);
+    } else if (spec.starts_with("<=")) {
+        constraint.op = ConstraintOp::LessEqual;
+        spec.remove_prefix(2);
+    } else if (spec.starts_with("<")) {
+        constraint.op = ConstraintOp::LessThan;
+        spec.remove_prefix(1);
+    } else if (spec.starts_with("==")) {
+        constraint.op = ConstraintOp::Equal;
+        spec.remove_prefix(2);
+    } else {
+        // Default: treat bare version as ==.
+        constraint.op = ConstraintOp::Equal;
+    }
+
+    auto verResult = ParseVersion(spec);
+    if (verResult.hasError()) {
+        return GameResult<VersionConstraint>::err(verResult.error());
+    }
+    constraint.version = verResult.value();
+
+    return GameResult<VersionConstraint>::ok(constraint);
+}
+
+std::string VersionConstraint::ToString() const {
+    std::string result;
+    switch (op) {
+        case ConstraintOp::GreaterEqual:      result = ">="; break;
+        case ConstraintOp::GreaterThan:       result = ">";  break;
+        case ConstraintOp::LessEqual:         result = "<="; break;
+        case ConstraintOp::LessThan:          result = "<";  break;
+        case ConstraintOp::Equal:             result = "=="; break;
+        case ConstraintOp::CompatibleRelease: result = "~="; break;
+    }
+    result += std::to_string(version.major) + "." +
+              std::to_string(version.minor) + "." +
+              std::to_string(version.patch);
+    return result;
+}
+
+// ── DependencySpec ──────────────────────────────────────────────────────
+
+bool DependencySpec::IsSatisfiedBy(const Version& v) const noexcept {
+    for (const auto& c : constraints) {
+        if (!c.IsSatisfiedBy(v)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+GameResult<DependencySpec> DependencySpec::Parse(std::string_view dep) {
+    // Trim whitespace.
+    while (!dep.empty() && dep.front() == ' ') {
+        dep.remove_prefix(1);
+    }
+    while (!dep.empty() && dep.back() == ' ') {
+        dep.remove_suffix(1);
+    }
+
+    if (dep.empty()) {
+        return GameResult<DependencySpec>::err(
+            GameError(ErrorCode::InvalidArgument, "Empty dependency string"));
+    }
+
+    DependencySpec spec;
+
+    // Find the start of version constraints (first operator character).
+    auto constraintStart = dep.find_first_of("><=~");
+
+    if (constraintStart == std::string_view::npos) {
+        // No version constraint — just a plugin name.
+        spec.name = std::string(dep);
+        return GameResult<DependencySpec>::ok(std::move(spec));
+    }
+
+    spec.name = std::string(dep.substr(0, constraintStart));
+
+    // Trim trailing whitespace from name.
+    while (!spec.name.empty() && spec.name.back() == ' ') {
+        spec.name.pop_back();
+    }
+
+    if (spec.name.empty()) {
+        return GameResult<DependencySpec>::err(
+            GameError(ErrorCode::InvalidArgument,
+                      "Missing plugin name in dependency: " + std::string(dep)));
+    }
+
+    // Parse comma-separated constraints.
+    auto remaining = dep.substr(constraintStart);
+    while (!remaining.empty()) {
+        // Find next comma.
+        auto commaPos = remaining.find(',');
+        auto part = remaining.substr(0, commaPos);
+
+        auto constraintResult = VersionConstraint::Parse(part);
+        if (constraintResult.hasError()) {
+            return GameResult<DependencySpec>::err(constraintResult.error());
+        }
+        spec.constraints.push_back(constraintResult.value());
+
+        if (commaPos == std::string_view::npos) {
+            break;
+        }
+        remaining.remove_prefix(commaPos + 1);
+    }
+
+    return GameResult<DependencySpec>::ok(std::move(spec));
+}
+
+std::string DependencySpec::ConstraintsToString() const {
+    if (constraints.empty()) {
+        return "(any version)";
+    }
+    std::string result;
+    for (std::size_t i = 0; i < constraints.size(); ++i) {
+        if (i > 0) {
+            result += ", ";
+        }
+        result += constraints[i].ToString();
+    }
+    return result;
+}
+
+} // namespace cgs::plugin

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,16 @@ target_link_libraries(cgs_plugin_tests PRIVATE
 )
 gtest_discover_tests(cgs_plugin_tests)
 
+# Unit tests - Plugin dependency resolution
+add_executable(cgs_plugin_dependency_tests
+    unit/plugin/dependency_resolution_test.cpp
+)
+target_link_libraries(cgs_plugin_dependency_tests PRIVATE
+    cgs::plugin
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_plugin_dependency_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/plugin/dependency_resolution_test.cpp
+++ b/tests/unit/plugin/dependency_resolution_test.cpp
@@ -1,0 +1,580 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/plugin/iplugin.hpp"
+#include "cgs/plugin/plugin_export.hpp"
+#include "cgs/plugin/plugin_manager.hpp"
+#include "cgs/plugin/plugin_types.hpp"
+#include "cgs/plugin/version_constraint.hpp"
+
+using namespace cgs::plugin;
+using cgs::foundation::ErrorCode;
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+/// Configurable test plugin for dependency resolution tests.
+class DepTestPlugin : public IPlugin {
+public:
+    explicit DepTestPlugin(PluginInfo info) : info_(std::move(info)) {}
+
+    const PluginInfo& GetInfo() const override { return info_; }
+    bool OnLoad(PluginContext& /*ctx*/) override { return true; }
+    bool OnInit() override { return true; }
+    void OnUpdate(float /*deltaTime*/) override {}
+    void OnShutdown() override {}
+    void OnUnload() override {}
+
+private:
+    PluginInfo info_;
+};
+
+/// Helper to register temporary plugins and load them into a PluginManager.
+class TestPluginLoader {
+public:
+    void Add(PluginInfo info) { infos_.push_back(std::move(info)); }
+
+    PluginManager Build() {
+        PluginManager mgr;
+        auto& registry = StaticPluginRegistry();
+        auto savedRegistry = std::move(registry);
+        registry.clear();
+
+        for (const auto& info : infos_) {
+            auto captured = info;
+            registry.push_back(
+                {info.name,
+                 [captured]() -> std::unique_ptr<IPlugin> {
+                     return std::make_unique<DepTestPlugin>(captured);
+                 }});
+        }
+
+        auto result = mgr.RegisterStaticPlugins();
+        registry = std::move(savedRegistry);
+        return mgr;
+    }
+
+private:
+    std::vector<PluginInfo> infos_;
+};
+
+// ===========================================================================
+// ParseVersion
+// ===========================================================================
+
+TEST(ParseVersionTest, FullVersion) {
+    auto result = ParseVersion("1.2.3");
+    ASSERT_TRUE(result.hasValue()) << result.error().message();
+    EXPECT_EQ(result.value().major, 1);
+    EXPECT_EQ(result.value().minor, 2);
+    EXPECT_EQ(result.value().patch, 3);
+}
+
+TEST(ParseVersionTest, MajorOnly) {
+    auto result = ParseVersion("3");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().major, 3);
+    EXPECT_EQ(result.value().minor, 0);
+    EXPECT_EQ(result.value().patch, 0);
+}
+
+TEST(ParseVersionTest, MajorMinor) {
+    auto result = ParseVersion("2.5");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().major, 2);
+    EXPECT_EQ(result.value().minor, 5);
+    EXPECT_EQ(result.value().patch, 0);
+}
+
+TEST(ParseVersionTest, EmptyStringFails) {
+    auto result = ParseVersion("");
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST(ParseVersionTest, InvalidStringFails) {
+    auto result = ParseVersion("abc");
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST(ParseVersionTest, WhitespaceTrimmed) {
+    auto result = ParseVersion("  1.0.0  ");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().major, 1);
+}
+
+// ===========================================================================
+// VersionConstraint: Parse
+// ===========================================================================
+
+TEST(VersionConstraintTest, ParseGreaterEqual) {
+    auto result = VersionConstraint::Parse(">=1.2.0");
+    ASSERT_TRUE(result.hasValue()) << result.error().message();
+    EXPECT_EQ(result.value().op, ConstraintOp::GreaterEqual);
+    EXPECT_EQ(result.value().version, (Version{1, 2, 0}));
+}
+
+TEST(VersionConstraintTest, ParseGreaterThan) {
+    auto result = VersionConstraint::Parse(">2.0");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().op, ConstraintOp::GreaterThan);
+    EXPECT_EQ(result.value().version, (Version{2, 0, 0}));
+}
+
+TEST(VersionConstraintTest, ParseLessEqual) {
+    auto result = VersionConstraint::Parse("<=3.0.0");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().op, ConstraintOp::LessEqual);
+}
+
+TEST(VersionConstraintTest, ParseLessThan) {
+    auto result = VersionConstraint::Parse("<2.0.0");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().op, ConstraintOp::LessThan);
+    EXPECT_EQ(result.value().version, (Version{2, 0, 0}));
+}
+
+TEST(VersionConstraintTest, ParseEqual) {
+    auto result = VersionConstraint::Parse("==1.5.0");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().op, ConstraintOp::Equal);
+}
+
+TEST(VersionConstraintTest, ParseCompatibleRelease) {
+    auto result = VersionConstraint::Parse("~=1.5");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().op, ConstraintOp::CompatibleRelease);
+    EXPECT_EQ(result.value().version, (Version{1, 5, 0}));
+}
+
+TEST(VersionConstraintTest, ParseEmptyFails) {
+    auto result = VersionConstraint::Parse("");
+    EXPECT_TRUE(result.hasError());
+}
+
+// ===========================================================================
+// VersionConstraint: IsSatisfiedBy
+// ===========================================================================
+
+TEST(VersionConstraintTest, GreaterEqualSatisfied) {
+    auto c = VersionConstraint{ConstraintOp::GreaterEqual, {1, 0, 0}};
+    EXPECT_TRUE(c.IsSatisfiedBy({1, 0, 0}));
+    EXPECT_TRUE(c.IsSatisfiedBy({1, 1, 0}));
+    EXPECT_TRUE(c.IsSatisfiedBy({2, 0, 0}));
+    EXPECT_FALSE(c.IsSatisfiedBy({0, 9, 9}));
+}
+
+TEST(VersionConstraintTest, GreaterThanSatisfied) {
+    auto c = VersionConstraint{ConstraintOp::GreaterThan, {1, 0, 0}};
+    EXPECT_FALSE(c.IsSatisfiedBy({1, 0, 0}));
+    EXPECT_TRUE(c.IsSatisfiedBy({1, 0, 1}));
+}
+
+TEST(VersionConstraintTest, LessThanSatisfied) {
+    auto c = VersionConstraint{ConstraintOp::LessThan, {2, 0, 0}};
+    EXPECT_TRUE(c.IsSatisfiedBy({1, 9, 9}));
+    EXPECT_FALSE(c.IsSatisfiedBy({2, 0, 0}));
+    EXPECT_FALSE(c.IsSatisfiedBy({2, 0, 1}));
+}
+
+TEST(VersionConstraintTest, LessEqualSatisfied) {
+    auto c = VersionConstraint{ConstraintOp::LessEqual, {2, 0, 0}};
+    EXPECT_TRUE(c.IsSatisfiedBy({2, 0, 0}));
+    EXPECT_TRUE(c.IsSatisfiedBy({1, 9, 9}));
+    EXPECT_FALSE(c.IsSatisfiedBy({2, 0, 1}));
+}
+
+TEST(VersionConstraintTest, EqualSatisfied) {
+    auto c = VersionConstraint{ConstraintOp::Equal, {1, 5, 0}};
+    EXPECT_TRUE(c.IsSatisfiedBy({1, 5, 0}));
+    EXPECT_FALSE(c.IsSatisfiedBy({1, 5, 1}));
+    EXPECT_FALSE(c.IsSatisfiedBy({1, 4, 0}));
+}
+
+TEST(VersionConstraintTest, CompatibleReleaseSatisfied) {
+    auto c = VersionConstraint{ConstraintOp::CompatibleRelease, {1, 5, 0}};
+    // ~=1.5.0 means >=1.5.0 and same major (1.x.x).
+    EXPECT_TRUE(c.IsSatisfiedBy({1, 5, 0}));
+    EXPECT_TRUE(c.IsSatisfiedBy({1, 9, 0}));
+    EXPECT_FALSE(c.IsSatisfiedBy({1, 4, 9}));
+    EXPECT_FALSE(c.IsSatisfiedBy({2, 0, 0}));
+}
+
+// ===========================================================================
+// VersionConstraint: ToString
+// ===========================================================================
+
+TEST(VersionConstraintTest, ToStringFormat) {
+    auto c = VersionConstraint{ConstraintOp::GreaterEqual, {1, 2, 3}};
+    EXPECT_EQ(c.ToString(), ">=1.2.3");
+
+    auto c2 = VersionConstraint{ConstraintOp::CompatibleRelease, {1, 5, 0}};
+    EXPECT_EQ(c2.ToString(), "~=1.5.0");
+}
+
+// ===========================================================================
+// DependencySpec: Parse
+// ===========================================================================
+
+TEST(DependencySpecTest, NameOnly) {
+    auto result = DependencySpec::Parse("NetworkPlugin");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().name, "NetworkPlugin");
+    EXPECT_TRUE(result.value().constraints.empty());
+}
+
+TEST(DependencySpecTest, NameWithConstraint) {
+    auto result = DependencySpec::Parse("CoreLib>=1.0.0");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().name, "CoreLib");
+    ASSERT_EQ(result.value().constraints.size(), 1u);
+    EXPECT_EQ(result.value().constraints[0].op, ConstraintOp::GreaterEqual);
+    EXPECT_EQ(result.value().constraints[0].version, (Version{1, 0, 0}));
+}
+
+TEST(DependencySpecTest, NameWithMultipleConstraints) {
+    auto result = DependencySpec::Parse("CoreLib>=1.0,<2.0");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().name, "CoreLib");
+    ASSERT_EQ(result.value().constraints.size(), 2u);
+    EXPECT_EQ(result.value().constraints[0].op, ConstraintOp::GreaterEqual);
+    EXPECT_EQ(result.value().constraints[1].op, ConstraintOp::LessThan);
+}
+
+TEST(DependencySpecTest, CompatibleRelease) {
+    auto result = DependencySpec::Parse("Renderer~=1.5");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().name, "Renderer");
+    ASSERT_EQ(result.value().constraints.size(), 1u);
+    EXPECT_EQ(result.value().constraints[0].op, ConstraintOp::CompatibleRelease);
+}
+
+TEST(DependencySpecTest, EmptyStringFails) {
+    auto result = DependencySpec::Parse("");
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST(DependencySpecTest, IsSatisfiedByMultipleConstraints) {
+    auto result = DependencySpec::Parse("CoreLib>=1.0,<2.0");
+    ASSERT_TRUE(result.hasValue());
+    const auto& spec = result.value();
+
+    EXPECT_TRUE(spec.IsSatisfiedBy({1, 0, 0}));
+    EXPECT_TRUE(spec.IsSatisfiedBy({1, 5, 0}));
+    EXPECT_TRUE(spec.IsSatisfiedBy({1, 9, 9}));
+    EXPECT_FALSE(spec.IsSatisfiedBy({0, 9, 0}));
+    EXPECT_FALSE(spec.IsSatisfiedBy({2, 0, 0}));
+}
+
+TEST(DependencySpecTest, ConstraintsToString) {
+    auto result = DependencySpec::Parse("Foo>=1.0,<2.0");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().ConstraintsToString(), ">=1.0.0, <2.0.0");
+}
+
+TEST(DependencySpecTest, NoConstraintsToString) {
+    auto result = DependencySpec::Parse("Foo");
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().ConstraintsToString(), "(any version)");
+}
+
+// ===========================================================================
+// PluginManager::ValidateDependencies - Missing dependency
+// ===========================================================================
+
+TEST(PluginDependencyTest, MissingDependencyReported) {
+    TestPluginLoader loader;
+    loader.Add({"PluginA", "Test A", {1, 0, 0}, {"MissingPlugin"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_FALSE(report.success);
+    ASSERT_EQ(report.issues.size(), 1u);
+    EXPECT_EQ(report.issues[0].kind,
+              PluginManager::DependencyIssue::Kind::Missing);
+    EXPECT_EQ(report.issues[0].plugin, "PluginA");
+    EXPECT_EQ(report.issues[0].dependency, "MissingPlugin");
+}
+
+TEST(PluginDependencyTest, MissingDependencyMessageIsDescriptive) {
+    TestPluginLoader loader;
+    loader.Add({"PluginA", "Test A", {1, 0, 0}, {"MissingPlugin>=2.0"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_FALSE(report.success);
+    ASSERT_GE(report.issues.size(), 1u);
+    EXPECT_NE(report.issues[0].detail.find("MissingPlugin"), std::string::npos);
+    EXPECT_NE(report.issues[0].detail.find("PluginA"), std::string::npos);
+}
+
+// ===========================================================================
+// PluginManager::ValidateDependencies - Version mismatch
+// ===========================================================================
+
+TEST(PluginDependencyTest, VersionMismatchReported) {
+    TestPluginLoader loader;
+    loader.Add({"CoreLib", "Core library", {1, 0, 0}, {}, kPluginApiVersion});
+    loader.Add({"PluginA", "Uses Core", {1, 0, 0}, {"CoreLib>=2.0.0"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_FALSE(report.success);
+    ASSERT_GE(report.issues.size(), 1u);
+
+    bool foundMismatch = false;
+    for (const auto& issue : report.issues) {
+        if (issue.kind == PluginManager::DependencyIssue::Kind::VersionMismatch) {
+            EXPECT_EQ(issue.plugin, "PluginA");
+            EXPECT_EQ(issue.dependency, "CoreLib");
+            EXPECT_NE(issue.detail.find("1.0.0"), std::string::npos);
+            foundMismatch = true;
+        }
+    }
+    EXPECT_TRUE(foundMismatch);
+}
+
+TEST(PluginDependencyTest, VersionConstraintSatisfied) {
+    TestPluginLoader loader;
+    loader.Add({"CoreLib", "Core library", {1, 5, 0}, {}, kPluginApiVersion});
+    loader.Add({"PluginA", "Uses Core", {1, 0, 0}, {"CoreLib>=1.0,<2.0"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_TRUE(report.success);
+    EXPECT_TRUE(report.issues.empty());
+}
+
+TEST(PluginDependencyTest, CompatibleReleaseConstraintSatisfied) {
+    TestPluginLoader loader;
+    loader.Add({"Renderer", "Render engine", {1, 7, 0}, {}, kPluginApiVersion});
+    loader.Add({"Game", "Game plugin", {1, 0, 0}, {"Renderer~=1.5"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_TRUE(report.success);
+}
+
+TEST(PluginDependencyTest, CompatibleReleaseConstraintViolated) {
+    TestPluginLoader loader;
+    loader.Add({"Renderer", "Render engine", {2, 0, 0}, {}, kPluginApiVersion});
+    loader.Add({"Game", "Game plugin", {1, 0, 0}, {"Renderer~=1.5"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_FALSE(report.success);
+    bool foundMismatch = false;
+    for (const auto& issue : report.issues) {
+        if (issue.kind == PluginManager::DependencyIssue::Kind::VersionMismatch &&
+            issue.dependency == "Renderer") {
+            foundMismatch = true;
+        }
+    }
+    EXPECT_TRUE(foundMismatch);
+}
+
+// ===========================================================================
+// PluginManager::ValidateDependencies - Circular dependency
+// ===========================================================================
+
+TEST(PluginDependencyTest, CircularDependencyDetected) {
+    TestPluginLoader loader;
+    loader.Add({"PluginA", "A", {1, 0, 0}, {"PluginB"}, kPluginApiVersion});
+    loader.Add({"PluginB", "B", {1, 0, 0}, {"PluginA"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_FALSE(report.success);
+    EXPECT_FALSE(report.cyclePath.empty());
+
+    // The cycle path should contain both plugins.
+    bool hasA = false;
+    bool hasB = false;
+    for (const auto& name : report.cyclePath) {
+        if (name == "PluginA") hasA = true;
+        if (name == "PluginB") hasB = true;
+    }
+    EXPECT_TRUE(hasA);
+    EXPECT_TRUE(hasB);
+}
+
+TEST(PluginDependencyTest, ThreeWayCircularDependency) {
+    TestPluginLoader loader;
+    loader.Add({"A", "A", {1, 0, 0}, {"B"}, kPluginApiVersion});
+    loader.Add({"B", "B", {1, 0, 0}, {"C"}, kPluginApiVersion});
+    loader.Add({"C", "C", {1, 0, 0}, {"A"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_FALSE(report.success);
+    EXPECT_FALSE(report.cyclePath.empty());
+
+    // The cycle should form a closed loop.
+    EXPECT_EQ(report.cyclePath.front(), report.cyclePath.back());
+}
+
+TEST(PluginDependencyTest, CircularDependencyErrorInResolveDependencies) {
+    TestPluginLoader loader;
+    loader.Add({"PluginA", "A", {1, 0, 0}, {"PluginB"}, kPluginApiVersion});
+    loader.Add({"PluginB", "B", {1, 0, 0}, {"PluginA"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto result = mgr.InitializeAll();
+
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::DependencyError);
+    // Error message should contain cycle information.
+    EXPECT_NE(result.error().message().find("cycle"), std::string::npos);
+}
+
+// ===========================================================================
+// PluginManager::ValidateDependencies - DAG resolution
+// ===========================================================================
+
+TEST(PluginDependencyTest, LinearDependencyChain) {
+    TestPluginLoader loader;
+    loader.Add({"Base", "Base", {1, 0, 0}, {}, kPluginApiVersion});
+    loader.Add({"Mid", "Mid", {1, 0, 0}, {"Base"}, kPluginApiVersion});
+    loader.Add({"Top", "Top", {1, 0, 0}, {"Mid"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_TRUE(report.success);
+    ASSERT_EQ(report.loadOrder.size(), 3u);
+
+    // Base must come before Mid, Mid before Top.
+    auto posBase = std::find(report.loadOrder.begin(), report.loadOrder.end(), "Base");
+    auto posMid = std::find(report.loadOrder.begin(), report.loadOrder.end(), "Mid");
+    auto posTop = std::find(report.loadOrder.begin(), report.loadOrder.end(), "Top");
+    EXPECT_LT(posBase, posMid);
+    EXPECT_LT(posMid, posTop);
+}
+
+TEST(PluginDependencyTest, DiamondDependency) {
+    // A depends on B and C; both B and C depend on D.
+    TestPluginLoader loader;
+    loader.Add({"D", "Shared base", {1, 0, 0}, {}, kPluginApiVersion});
+    loader.Add({"B", "Left", {1, 0, 0}, {"D"}, kPluginApiVersion});
+    loader.Add({"C", "Right", {1, 0, 0}, {"D"}, kPluginApiVersion});
+    loader.Add({"A", "Top", {1, 0, 0}, {"B", "C"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_TRUE(report.success);
+    ASSERT_EQ(report.loadOrder.size(), 4u);
+
+    auto posD = std::find(report.loadOrder.begin(), report.loadOrder.end(), "D");
+    auto posB = std::find(report.loadOrder.begin(), report.loadOrder.end(), "B");
+    auto posC = std::find(report.loadOrder.begin(), report.loadOrder.end(), "C");
+    auto posA = std::find(report.loadOrder.begin(), report.loadOrder.end(), "A");
+
+    // D before B and C; B and C before A.
+    EXPECT_LT(posD, posB);
+    EXPECT_LT(posD, posC);
+    EXPECT_LT(posB, posA);
+    EXPECT_LT(posC, posA);
+}
+
+TEST(PluginDependencyTest, NoDepPluginsAllResolved) {
+    TestPluginLoader loader;
+    loader.Add({"Alpha", "A", {1, 0, 0}, {}, kPluginApiVersion});
+    loader.Add({"Beta", "B", {1, 0, 0}, {}, kPluginApiVersion});
+    loader.Add({"Gamma", "C", {1, 0, 0}, {}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_TRUE(report.success);
+    EXPECT_EQ(report.loadOrder.size(), 3u);
+}
+
+// ===========================================================================
+// PluginManager::ValidateDependencies - Multiple issues
+// ===========================================================================
+
+TEST(PluginDependencyTest, MultipleIssuesCollected) {
+    TestPluginLoader loader;
+    loader.Add({"CoreLib", "Core", {1, 0, 0}, {}, kPluginApiVersion});
+    loader.Add({"PluginA", "A", {1, 0, 0},
+                {"CoreLib>=2.0", "MissingDep"}, kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto report = mgr.ValidateDependencies();
+
+    EXPECT_FALSE(report.success);
+    // Should have at least 2 issues: version mismatch + missing dep.
+    EXPECT_GE(report.issues.size(), 2u);
+
+    bool hasMissing = false;
+    bool hasMismatch = false;
+    for (const auto& issue : report.issues) {
+        if (issue.kind == PluginManager::DependencyIssue::Kind::Missing) {
+            hasMissing = true;
+        }
+        if (issue.kind == PluginManager::DependencyIssue::Kind::VersionMismatch) {
+            hasMismatch = true;
+        }
+    }
+    EXPECT_TRUE(hasMissing);
+    EXPECT_TRUE(hasMismatch);
+}
+
+// ===========================================================================
+// PluginManager: InitializeAll with version constraints
+// ===========================================================================
+
+TEST(PluginDependencyTest, InitializeAllWithValidConstraints) {
+    TestPluginLoader loader;
+    loader.Add({"CoreLib", "Core", {1, 5, 0}, {}, kPluginApiVersion});
+    loader.Add({"Feature", "Feature", {1, 0, 0}, {"CoreLib>=1.0,<2.0"},
+                kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto result = mgr.InitializeAll();
+
+    ASSERT_TRUE(result.hasValue()) << result.error().message();
+
+    auto stateCore = mgr.GetPluginState("CoreLib");
+    auto stateFeat = mgr.GetPluginState("Feature");
+    ASSERT_TRUE(stateCore.hasValue());
+    ASSERT_TRUE(stateFeat.hasValue());
+    EXPECT_EQ(stateCore.value(), PluginState::Initialized);
+    EXPECT_EQ(stateFeat.value(), PluginState::Initialized);
+}
+
+TEST(PluginDependencyTest, InitializeAllFailsOnVersionMismatch) {
+    TestPluginLoader loader;
+    loader.Add({"CoreLib", "Core", {1, 0, 0}, {}, kPluginApiVersion});
+    loader.Add({"Feature", "Feature", {1, 0, 0}, {"CoreLib>=2.0"},
+                kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto result = mgr.InitializeAll();
+
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::DependencyError);
+}
+
+TEST(PluginDependencyTest, InitializeAllFailsOnMissingDependency) {
+    TestPluginLoader loader;
+    loader.Add({"Feature", "Feature", {1, 0, 0}, {"NonExistent"},
+                kPluginApiVersion});
+
+    auto mgr = loader.Build();
+    auto result = mgr.InitializeAll();
+
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::DependencyError);
+}


### PR DESCRIPTION
## Summary

Implement version constraint parsing, enhanced dependency resolution, and comprehensive validation for the plugin system, addressing SRS-PLG-004 requirements.

- Add `VersionConstraint` type supporting operators: `>=`, `>`, `<=`, `<`, `==`, `~=` (compatible release)
- Add `DependencySpec` parser for dependency strings like `"CoreLib>=1.0,<2.0"`
- Enhance `PluginManager::resolveDependencies()` with version constraint validation
- Add DFS-based circular dependency detection with cycle path reporting (e.g., `A -> B -> C -> A`)
- Add missing dependency detection with descriptive error messages
- Add `ValidateDependencies()` public API that collects all issues into a `DependencyReport`

## SRS Traceability

| SRS ID | Requirement | Status |
|--------|-------------|--------|
| SRS-PLG-004.1 | Topological sort for plugin load order | Done |
| SRS-PLG-004.2 | Circular dependency detection with cycle path | Done |
| SRS-PLG-004.3 | Version constraints (>=, <, ~=) | Done |
| SRS-PLG-004.4 | Graceful failure on unsatisfied dependencies | Done |

## Files Changed

### New Files
- `include/cgs/plugin/version_constraint.hpp` — VersionConstraint, DependencySpec, ParseVersion
- `src/plugins/version_constraint.cpp` — Parsing and matching implementation
- `tests/unit/plugin/dependency_resolution_test.cpp` — 44 unit tests

### Modified Files
- `include/cgs/plugin/plugin_manager.hpp` — Add DependencyReport, ValidateDependencies(), helper declarations
- `src/plugins/plugin_manager.cpp` — Enhanced resolveDependencies(), DFS cycle detection, version validation
- `src/plugins/CMakeLists.txt` — Add version_constraint.cpp
- `tests/CMakeLists.txt` — Add dependency resolution test target

## Test Plan

- [x] 44 new dependency resolution tests pass (version parsing, constraint matching, DAG ordering, cycle detection, missing deps, version mismatch)
- [x] 38 existing plugin tests pass (no regressions)
- [x] Build succeeds with `-Werror` strict warnings

Closes #15