### PR TITLE
feat(game): add AI System (BehaviorTree, Brain, Throttling)

### DIFF
--- a/include/cgs/game/ai_components.hpp
+++ b/include/cgs/game/ai_components.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+/// @file ai_components.hpp
+/// @brief AI ECS component: AIBrain.
+///
+/// The AIBrain component attaches AI behavior to an entity by holding
+/// a reference to a shared behavior tree root and per-entity state.
+///
+/// @see SRS-GML-004.1
+/// @see SDS-MOD-023
+
+#include <memory>
+
+#include "cgs/ecs/entity.hpp"
+#include "cgs/game/ai_types.hpp"
+#include "cgs/game/behavior_tree.hpp"
+#include "cgs/game/math_types.hpp"
+
+namespace cgs::game {
+
+// ── AIBrain (SRS-GML-004.1) ─────────────────────────────────────────
+
+/// AI brain component holding behavior tree reference and per-entity state.
+///
+/// Each AI entity has its own AIBrain with a shared_ptr to a behavior
+/// tree root (trees can be shared across multiple entities of the same
+/// type) and a private Blackboard for instance-specific data.
+struct AIBrain {
+    /// Root of the behavior tree (shared across same-type entities).
+    std::shared_ptr<BTNode> behaviorTree;
+
+    /// Per-entity data store for BT node communication.
+    Blackboard blackboard;
+
+    /// Current high-level AI state.
+    AIState state = AIState::Idle;
+
+    /// Accumulated time since last AI tick (for throttling).
+    float timeSinceLastTick = 0.0f;
+
+    /// Per-entity tick interval override (uses system default if <= 0).
+    float tickInterval = 0.0f;
+
+    /// Home position for patrol/return behavior.
+    Vector3 homePosition;
+
+    /// Current target entity for combat/chase behavior.
+    cgs::ecs::Entity target;
+};
+
+} // namespace cgs::game

--- a/include/cgs/game/ai_system.hpp
+++ b/include/cgs/game/ai_system.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+/// @file ai_system.hpp
+/// @brief AISystem: per-tick AI behavior tree execution with throttling.
+///
+/// Iterates all entities with AIBrain components, throttles updates
+/// across frames to distribute CPU load, and executes behavior trees.
+///
+/// @see SRS-GML-004.4
+/// @see SDS-MOD-023
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+#include "cgs/ecs/component_storage.hpp"
+#include "cgs/ecs/system_scheduler.hpp"
+#include "cgs/game/ai_components.hpp"
+#include "cgs/game/combat_components.hpp"
+#include "cgs/game/components.hpp"
+
+namespace cgs::game {
+
+/// System that executes AI behavior trees with frame-distributed throttling.
+///
+/// Each tick:
+///   1. Accumulate deltaTime on each AIBrain's timer.
+///   2. For brains whose timer exceeds their tick interval, execute the BT.
+///   3. Reset the timer after execution.
+///
+/// This ensures AI updates are spread across multiple frames rather than
+/// all running simultaneously, reducing per-frame CPU spikes.
+class AISystem final : public cgs::ecs::ISystem {
+public:
+    AISystem(cgs::ecs::ComponentStorage<AIBrain>& brains,
+             cgs::ecs::ComponentStorage<Transform>& transforms,
+             cgs::ecs::ComponentStorage<Movement>& movements,
+             cgs::ecs::ComponentStorage<Stats>& stats,
+             cgs::ecs::ComponentStorage<ThreatList>& threatLists,
+             float defaultTickInterval = kDefaultAITickInterval);
+
+    void Execute(float deltaTime) override;
+
+    [[nodiscard]] cgs::ecs::SystemStage GetStage() const override {
+        return cgs::ecs::SystemStage::Update;
+    }
+
+    [[nodiscard]] std::string_view GetName() const override {
+        return "AISystem";
+    }
+
+    [[nodiscard]] cgs::ecs::SystemAccessInfo GetAccessInfo() const override;
+
+    // ── Built-in task factories (SRS-GML-004.3) ─────────────────────
+
+    /// Create a MoveTo action node.
+    /// Reads "move_target" (Vector3) from the blackboard and drives
+    /// the entity's Movement toward it.
+    [[nodiscard]] std::unique_ptr<BTNode> CreateMoveToTask();
+
+    /// Create an Attack action node.
+    /// Reads "target" (Entity) from the blackboard and checks range;
+    /// returns Success if in range, Failure otherwise.
+    [[nodiscard]] std::unique_ptr<BTNode> CreateAttackTask();
+
+    /// Create a Patrol action node.
+    /// Reads "waypoints" (vector<Vector3>) and "patrol_index" (size_t)
+    /// from the blackboard and walks between waypoints in sequence.
+    [[nodiscard]] std::unique_ptr<BTNode> CreatePatrolTask();
+
+    /// Create a Flee action node.
+    /// Moves the entity away from its top threat source.
+    [[nodiscard]] std::unique_ptr<BTNode> CreateFleeTask();
+
+    /// Create an Idle action node.
+    /// Sets Movement to Idle state and returns Success immediately.
+    [[nodiscard]] std::unique_ptr<BTNode> CreateIdleTask();
+
+    // ── Configuration ────────────────────────────────────────────────
+
+    /// Set the default tick interval for AI entities that don't override it.
+    void SetDefaultTickInterval(float interval);
+
+    /// Get the current default tick interval.
+    [[nodiscard]] float GetDefaultTickInterval() const noexcept {
+        return defaultTickInterval_;
+    }
+
+    /// Get the number of AI entities updated on the last Execute call.
+    [[nodiscard]] uint32_t GetLastTickUpdateCount() const noexcept {
+        return lastTickUpdateCount_;
+    }
+
+private:
+    cgs::ecs::ComponentStorage<AIBrain>& brains_;
+    cgs::ecs::ComponentStorage<Transform>& transforms_;
+    cgs::ecs::ComponentStorage<Movement>& movements_;
+    cgs::ecs::ComponentStorage<Stats>& stats_;
+    cgs::ecs::ComponentStorage<ThreatList>& threatLists_;
+
+    float defaultTickInterval_;
+    uint32_t lastTickUpdateCount_ = 0;
+};
+
+} // namespace cgs::game

--- a/include/cgs/game/ai_types.hpp
+++ b/include/cgs/game/ai_types.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+/// @file ai_types.hpp
+/// @brief Enumerations and constants for the AI system.
+///
+/// @see SDS-MOD-023
+/// @see SRS-GML-004
+
+#include <cstdint>
+
+namespace cgs::game {
+
+/// Maximum number of waypoints in a patrol path.
+constexpr std::size_t kMaxPatrolWaypoints = 32;
+
+/// Default AI update interval in seconds for throttled updates.
+constexpr float kDefaultAITickInterval = 0.1f;
+
+/// Default distance threshold for MoveTo completion (world units).
+constexpr float kMoveToArrivalDistance = 1.0f;
+
+/// Default flee distance from threat source (world units).
+constexpr float kDefaultFleeDistance = 20.0f;
+
+/// Default melee attack range (world units).
+constexpr float kDefaultAttackRange = 3.0f;
+
+/// Behavior Tree node tick result.
+enum class BTStatus : uint8_t {
+    Success,  ///< Node completed successfully.
+    Failure,  ///< Node failed.
+    Running   ///< Node still in progress (resume next tick).
+};
+
+/// High-level AI state for the AIBrain component.
+enum class AIState : uint8_t {
+    Idle,       ///< Standing still, awaiting stimuli.
+    Patrolling, ///< Walking between waypoints.
+    Chasing,    ///< Moving toward a target.
+    Attacking,  ///< Engaged in combat.
+    Fleeing,    ///< Running away from a threat.
+    Dead        ///< Entity is dead, AI suspended.
+};
+
+/// Parallel node completion policy.
+enum class BTParallelPolicy : uint8_t {
+    RequireAll,  ///< Succeed only when all children succeed.
+    RequireOne   ///< Succeed when at least one child succeeds.
+};
+
+} // namespace cgs::game

--- a/include/cgs/game/behavior_tree.hpp
+++ b/include/cgs/game/behavior_tree.hpp
@@ -1,0 +1,362 @@
+#pragma once
+
+/// @file behavior_tree.hpp
+/// @brief Behavior Tree framework: nodes, blackboard, and execution context.
+///
+/// Header-only BT framework with polymorphic nodes for runtime composition.
+/// Composite nodes (Sequence, Selector, Parallel), decorator nodes
+/// (Inverter, Repeater), and leaf nodes (Condition, Action) form a tree
+/// that is ticked each AI update to drive entity behavior.
+///
+/// @see SRS-GML-004.2, SRS-GML-004.3
+/// @see SDS-MOD-023
+
+#include <any>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cgs/ecs/entity.hpp"
+#include "cgs/game/ai_types.hpp"
+
+namespace cgs::game {
+
+// Forward declaration.
+struct BTContext;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Blackboard
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Key-value store for sharing data between BT nodes.
+///
+/// Each AIBrain holds its own Blackboard instance.  Common keys:
+/// "target" (Entity), "move_target" (Vector3), "waypoints" (vector<Vector3>).
+class Blackboard {
+public:
+    /// Store a value under the given key (overwrites any existing value).
+    template <typename T>
+    void Set(const std::string& key, T value) {
+        data_[key] = std::move(value);
+    }
+
+    /// Retrieve a mutable pointer to the stored value, or nullptr if
+    /// the key is absent or the type does not match.
+    template <typename T>
+    T* Get(const std::string& key) {
+        auto it = data_.find(key);
+        if (it == data_.end()) {
+            return nullptr;
+        }
+        return std::any_cast<T>(&it->second);
+    }
+
+    /// Retrieve a const pointer to the stored value.
+    template <typename T>
+    const T* Get(const std::string& key) const {
+        auto it = data_.find(key);
+        if (it == data_.end()) {
+            return nullptr;
+        }
+        return std::any_cast<T>(&it->second);
+    }
+
+    /// Check whether a key exists in the blackboard.
+    [[nodiscard]] bool Has(const std::string& key) const {
+        return data_.contains(key);
+    }
+
+    /// Remove a single entry.
+    void Erase(const std::string& key) { data_.erase(key); }
+
+    /// Remove all entries.
+    void Clear() { data_.clear(); }
+
+private:
+    std::unordered_map<std::string, std::any> data_;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BTContext
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Execution context passed to every BT node during a tick.
+struct BTContext {
+    cgs::ecs::Entity entity;
+    float deltaTime = 0.0f;
+    Blackboard* blackboard = nullptr;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BTNode base class
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Abstract base for all Behavior Tree nodes.
+class BTNode {
+public:
+    virtual ~BTNode() = default;
+
+    /// Execute this node for one tick.
+    virtual BTStatus Tick(BTContext& context) = 0;
+
+    /// Reset node state (called when parent interrupts/restarts).
+    virtual void Reset() {}
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Composite nodes
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Sequence: runs children left-to-right.
+/// Succeeds when ALL children succeed.
+/// Fails immediately on the first child failure.
+/// Returns Running when a child returns Running (resumes from that child).
+class BTSequence : public BTNode {
+public:
+    void AddChild(std::unique_ptr<BTNode> child) {
+        children_.push_back(std::move(child));
+    }
+
+    BTStatus Tick(BTContext& context) override {
+        while (currentChild_ < children_.size()) {
+            auto status = children_[currentChild_]->Tick(context);
+            if (status == BTStatus::Running) {
+                return BTStatus::Running;
+            }
+            if (status == BTStatus::Failure) {
+                currentChild_ = 0;
+                return BTStatus::Failure;
+            }
+            ++currentChild_;
+        }
+        currentChild_ = 0;
+        return BTStatus::Success;
+    }
+
+    void Reset() override {
+        currentChild_ = 0;
+        for (auto& child : children_) {
+            child->Reset();
+        }
+    }
+
+    [[nodiscard]] std::size_t ChildCount() const { return children_.size(); }
+
+private:
+    std::vector<std::unique_ptr<BTNode>> children_;
+    std::size_t currentChild_ = 0;
+};
+
+/// Selector: tries children left-to-right.
+/// Succeeds immediately on the first child success.
+/// Fails when ALL children fail.
+/// Returns Running when a child returns Running (resumes from that child).
+class BTSelector : public BTNode {
+public:
+    void AddChild(std::unique_ptr<BTNode> child) {
+        children_.push_back(std::move(child));
+    }
+
+    BTStatus Tick(BTContext& context) override {
+        while (currentChild_ < children_.size()) {
+            auto status = children_[currentChild_]->Tick(context);
+            if (status == BTStatus::Running) {
+                return BTStatus::Running;
+            }
+            if (status == BTStatus::Success) {
+                currentChild_ = 0;
+                return BTStatus::Success;
+            }
+            ++currentChild_;
+        }
+        currentChild_ = 0;
+        return BTStatus::Failure;
+    }
+
+    void Reset() override {
+        currentChild_ = 0;
+        for (auto& child : children_) {
+            child->Reset();
+        }
+    }
+
+    [[nodiscard]] std::size_t ChildCount() const { return children_.size(); }
+
+private:
+    std::vector<std::unique_ptr<BTNode>> children_;
+    std::size_t currentChild_ = 0;
+};
+
+/// Parallel: ticks ALL children every call.
+/// Result depends on the configured policy:
+///   RequireAll  — Success when all succeed, Failure on first failure.
+///   RequireOne  — Success on first success, Failure when all fail.
+///   Returns Running when the decisive threshold is not yet met.
+class BTParallel : public BTNode {
+public:
+    explicit BTParallel(BTParallelPolicy policy = BTParallelPolicy::RequireAll)
+        : policy_(policy) {}
+
+    void AddChild(std::unique_ptr<BTNode> child) {
+        children_.push_back(std::move(child));
+    }
+
+    BTStatus Tick(BTContext& context) override {
+        std::size_t successCount = 0;
+        std::size_t failureCount = 0;
+
+        for (auto& child : children_) {
+            auto status = child->Tick(context);
+            if (status == BTStatus::Success) {
+                ++successCount;
+            } else if (status == BTStatus::Failure) {
+                ++failureCount;
+            }
+        }
+
+        if (policy_ == BTParallelPolicy::RequireAll) {
+            if (successCount == children_.size()) {
+                return BTStatus::Success;
+            }
+            if (failureCount > 0) {
+                return BTStatus::Failure;
+            }
+        } else {
+            if (successCount > 0) {
+                return BTStatus::Success;
+            }
+            if (failureCount == children_.size()) {
+                return BTStatus::Failure;
+            }
+        }
+
+        return BTStatus::Running;
+    }
+
+    void Reset() override {
+        for (auto& child : children_) {
+            child->Reset();
+        }
+    }
+
+    [[nodiscard]] std::size_t ChildCount() const { return children_.size(); }
+    [[nodiscard]] BTParallelPolicy GetPolicy() const { return policy_; }
+
+private:
+    std::vector<std::unique_ptr<BTNode>> children_;
+    BTParallelPolicy policy_;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Decorator nodes
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Inverter: inverts the child result (Success <-> Failure).
+/// Running passes through unchanged.
+class BTInverter : public BTNode {
+public:
+    explicit BTInverter(std::unique_ptr<BTNode> child)
+        : child_(std::move(child)) {}
+
+    BTStatus Tick(BTContext& context) override {
+        auto status = child_->Tick(context);
+        if (status == BTStatus::Success) {
+            return BTStatus::Failure;
+        }
+        if (status == BTStatus::Failure) {
+            return BTStatus::Success;
+        }
+        return BTStatus::Running;
+    }
+
+    void Reset() override { child_->Reset(); }
+
+private:
+    std::unique_ptr<BTNode> child_;
+};
+
+/// Repeater: repeats child execution up to maxRepeats times.
+/// Returns Running while repetitions remain.
+/// Returns Success when all repetitions complete successfully.
+/// If maxRepeats is 0, repeats indefinitely (always returns Running).
+class BTRepeater : public BTNode {
+public:
+    explicit BTRepeater(std::unique_ptr<BTNode> child,
+                        uint32_t maxRepeats = 0)
+        : child_(std::move(child)), maxRepeats_(maxRepeats) {}
+
+    BTStatus Tick(BTContext& context) override {
+        auto status = child_->Tick(context);
+        if (status == BTStatus::Running) {
+            return BTStatus::Running;
+        }
+
+        // Child finished (success or failure). Count the iteration.
+        ++currentCount_;
+        child_->Reset();
+
+        if (maxRepeats_ > 0 && currentCount_ >= maxRepeats_) {
+            currentCount_ = 0;
+            return BTStatus::Success;
+        }
+
+        return BTStatus::Running;
+    }
+
+    void Reset() override {
+        currentCount_ = 0;
+        child_->Reset();
+    }
+
+    [[nodiscard]] uint32_t MaxRepeats() const { return maxRepeats_; }
+
+private:
+    std::unique_ptr<BTNode> child_;
+    uint32_t maxRepeats_ = 0;
+    uint32_t currentCount_ = 0;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Leaf nodes
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Condition: evaluates a predicate and returns Success or Failure.
+///
+/// Never returns Running — conditions are instantaneous checks.
+class BTCondition : public BTNode {
+public:
+    using Predicate = std::function<bool(BTContext&)>;
+
+    explicit BTCondition(Predicate predicate)
+        : predicate_(std::move(predicate)) {}
+
+    BTStatus Tick(BTContext& context) override {
+        return predicate_(context) ? BTStatus::Success : BTStatus::Failure;
+    }
+
+private:
+    Predicate predicate_;
+};
+
+/// Action: performs a game action and returns the result.
+///
+/// Actions may return Running to indicate multi-tick operations.
+class BTAction : public BTNode {
+public:
+    using ActionFunc = std::function<BTStatus(BTContext&)>;
+
+    explicit BTAction(ActionFunc action)
+        : action_(std::move(action)) {}
+
+    BTStatus Tick(BTContext& context) override {
+        return action_(context);
+    }
+
+private:
+    ActionFunc action_;
+};
+
+} // namespace cgs::game

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -2,3 +2,4 @@
 add_subdirectory(object_system)
 add_subdirectory(combat_system)
 add_subdirectory(world_system)
+add_subdirectory(ai_system)

--- a/src/game/ai_system/CMakeLists.txt
+++ b/src/game/ai_system/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Game AI System (SDS-MOD-023)
+add_library(cgs_game_ai_system
+    ai_system.cpp
+)
+target_link_libraries(cgs_game_ai_system
+    PUBLIC cgs_ecs_component_storage
+           cgs_ecs_system_scheduler
+           cgs_game_object_system
+           cgs_game_combat_system
+)
+add_library(cgs::game_ai_system ALIAS cgs_game_ai_system)

--- a/src/game/ai_system/ai_system.cpp
+++ b/src/game/ai_system/ai_system.cpp
@@ -1,0 +1,263 @@
+/// @file ai_system.cpp
+/// @brief AISystem implementation.
+///
+/// Executes behavior trees for AI entities with frame-distributed
+/// throttling.  Built-in task factories create reusable BT leaf nodes
+/// that drive Movement, check combat range, and manage patrol paths.
+///
+/// @see SRS-GML-004.4
+/// @see SDS-MOD-023
+
+#include "cgs/game/ai_system.hpp"
+
+#include <vector>
+
+namespace cgs::game {
+
+AISystem::AISystem(
+    cgs::ecs::ComponentStorage<AIBrain>& brains,
+    cgs::ecs::ComponentStorage<Transform>& transforms,
+    cgs::ecs::ComponentStorage<Movement>& movements,
+    cgs::ecs::ComponentStorage<Stats>& stats,
+    cgs::ecs::ComponentStorage<ThreatList>& threatLists,
+    float defaultTickInterval)
+    : brains_(brains),
+      transforms_(transforms),
+      movements_(movements),
+      stats_(stats),
+      threatLists_(threatLists),
+      defaultTickInterval_(defaultTickInterval) {}
+
+void AISystem::Execute(float deltaTime) {
+    uint32_t updateCount = 0;
+
+    for (std::size_t i = 0; i < brains_.Size(); ++i) {
+        auto entityId = brains_.EntityAt(i);
+        cgs::ecs::Entity entity(entityId, 0);
+        auto& brain = brains_.Get(entity);
+
+        // Skip dead AI entities.
+        if (brain.state == AIState::Dead) {
+            continue;
+        }
+
+        // Skip entities without a behavior tree.
+        if (!brain.behaviorTree) {
+            continue;
+        }
+
+        // Accumulate time.
+        brain.timeSinceLastTick += deltaTime;
+
+        // Determine effective tick interval.
+        float interval = brain.tickInterval > 0.0f
+            ? brain.tickInterval
+            : defaultTickInterval_;
+
+        // Only tick when the interval has elapsed.
+        if (brain.timeSinceLastTick < interval) {
+            continue;
+        }
+
+        // Execute the behavior tree.
+        BTContext context;
+        context.entity = entity;
+        context.deltaTime = brain.timeSinceLastTick;
+        context.blackboard = &brain.blackboard;
+
+        brain.behaviorTree->Tick(context);
+        brain.timeSinceLastTick = 0.0f;
+        ++updateCount;
+    }
+
+    lastTickUpdateCount_ = updateCount;
+}
+
+cgs::ecs::SystemAccessInfo AISystem::GetAccessInfo() const {
+    cgs::ecs::SystemAccessInfo info;
+    cgs::ecs::Write<AIBrain, Movement>::Apply(info);
+    cgs::ecs::Read<Transform, Stats, ThreatList>::Apply(info);
+    return info;
+}
+
+// ── Built-in task factories ─────────────────────────────────────────
+
+std::unique_ptr<BTNode> AISystem::CreateMoveToTask() {
+    auto& transforms = transforms_;
+    auto& movements = movements_;
+
+    return std::make_unique<BTAction>(
+        [&transforms, &movements](BTContext& ctx) -> BTStatus {
+            auto* target = ctx.blackboard->Get<Vector3>("move_target");
+            if (!target) {
+                return BTStatus::Failure;
+            }
+
+            if (!transforms.Has(ctx.entity) || !movements.Has(ctx.entity)) {
+                return BTStatus::Failure;
+            }
+
+            auto& transform = transforms.Get(ctx.entity);
+            auto& movement = movements.Get(ctx.entity);
+
+            auto diff = *target - transform.position;
+            float distSq = diff.x * diff.x + diff.z * diff.z;
+
+            if (distSq <= kMoveToArrivalDistance * kMoveToArrivalDistance) {
+                movement.state = MovementState::Idle;
+                movement.direction = Vector3::Zero();
+                return BTStatus::Success;
+            }
+
+            movement.direction = diff.Normalized();
+            movement.state = MovementState::Running;
+            return BTStatus::Running;
+        });
+}
+
+std::unique_ptr<BTNode> AISystem::CreateAttackTask() {
+    auto& transforms = transforms_;
+    auto& stats = stats_;
+
+    return std::make_unique<BTAction>(
+        [&transforms, &stats](BTContext& ctx) -> BTStatus {
+            auto* targetPtr = ctx.blackboard->Get<cgs::ecs::Entity>("target");
+            if (!targetPtr || !targetPtr->isValid()) {
+                return BTStatus::Failure;
+            }
+
+            auto target = *targetPtr;
+
+            if (!transforms.Has(ctx.entity) || !transforms.Has(target)) {
+                return BTStatus::Failure;
+            }
+
+            // Check if target is alive.
+            if (stats.Has(target) && stats.Get(target).health <= 0) {
+                return BTStatus::Failure;
+            }
+
+            const auto& attackerPos = transforms.Get(ctx.entity).position;
+            const auto& targetPos = transforms.Get(target).position;
+
+            auto diff = targetPos - attackerPos;
+            float distSq = diff.x * diff.x + diff.z * diff.z;
+
+            if (distSq > kDefaultAttackRange * kDefaultAttackRange) {
+                return BTStatus::Failure;
+            }
+
+            // In range — signal success.  Actual damage application is
+            // handled by the CombatSystem via DamageEvent components.
+            return BTStatus::Success;
+        });
+}
+
+std::unique_ptr<BTNode> AISystem::CreatePatrolTask() {
+    auto& transforms = transforms_;
+    auto& movements = movements_;
+
+    return std::make_unique<BTAction>(
+        [&transforms, &movements](BTContext& ctx) -> BTStatus {
+            auto* waypoints = ctx.blackboard->Get<std::vector<Vector3>>(
+                "waypoints");
+            if (!waypoints || waypoints->empty()) {
+                return BTStatus::Failure;
+            }
+
+            auto* indexPtr = ctx.blackboard->Get<std::size_t>("patrol_index");
+            std::size_t waypointIndex = indexPtr ? *indexPtr : 0;
+
+            if (waypointIndex >= waypoints->size()) {
+                waypointIndex = 0;
+            }
+
+            if (!transforms.Has(ctx.entity) || !movements.Has(ctx.entity)) {
+                return BTStatus::Failure;
+            }
+
+            auto& transform = transforms.Get(ctx.entity);
+            auto& movement = movements.Get(ctx.entity);
+
+            const auto& target = (*waypoints)[waypointIndex];
+            auto diff = target - transform.position;
+            float distSq = diff.x * diff.x + diff.z * diff.z;
+
+            if (distSq <= kMoveToArrivalDistance * kMoveToArrivalDistance) {
+                // Arrived at current waypoint, advance to next.
+                waypointIndex = (waypointIndex + 1) % waypoints->size();
+                ctx.blackboard->Set<std::size_t>("patrol_index", waypointIndex);
+                return BTStatus::Running;
+            }
+
+            movement.direction = diff.Normalized();
+            movement.state = MovementState::Walking;
+            return BTStatus::Running;
+        });
+}
+
+std::unique_ptr<BTNode> AISystem::CreateFleeTask() {
+    auto& transforms = transforms_;
+    auto& movements = movements_;
+    auto& threatLists = threatLists_;
+
+    return std::make_unique<BTAction>(
+        [&transforms, &movements, &threatLists](BTContext& ctx) -> BTStatus {
+            if (!transforms.Has(ctx.entity) || !movements.Has(ctx.entity)) {
+                return BTStatus::Failure;
+            }
+
+            // Get the top threat source to flee from.
+            cgs::ecs::Entity threatSource = cgs::ecs::Entity::invalid();
+            if (threatLists.Has(ctx.entity)) {
+                threatSource = threatLists.Get(ctx.entity).GetTopThreat();
+            }
+
+            if (!threatSource.isValid() || !transforms.Has(threatSource)) {
+                return BTStatus::Failure;
+            }
+
+            const auto& entityPos = transforms.Get(ctx.entity).position;
+            const auto& threatPos = transforms.Get(threatSource).position;
+
+            auto awayDir = entityPos - threatPos;
+            float distSq = awayDir.x * awayDir.x + awayDir.z * awayDir.z;
+
+            // Already far enough away.
+            if (distSq >= kDefaultFleeDistance * kDefaultFleeDistance) {
+                auto& movement = movements.Get(ctx.entity);
+                movement.state = MovementState::Idle;
+                movement.direction = Vector3::Zero();
+                return BTStatus::Success;
+            }
+
+            auto& movement = movements.Get(ctx.entity);
+            movement.direction = awayDir.Normalized();
+            movement.state = MovementState::Running;
+            return BTStatus::Running;
+        });
+}
+
+std::unique_ptr<BTNode> AISystem::CreateIdleTask() {
+    auto& movements = movements_;
+
+    return std::make_unique<BTAction>(
+        [&movements](BTContext& ctx) -> BTStatus {
+            if (!movements.Has(ctx.entity)) {
+                return BTStatus::Success;
+            }
+
+            auto& movement = movements.Get(ctx.entity);
+            movement.state = MovementState::Idle;
+            movement.direction = Vector3::Zero();
+            return BTStatus::Success;
+        });
+}
+
+void AISystem::SetDefaultTickInterval(float interval) {
+    if (interval > 0.0f) {
+        defaultTickInterval_ = interval;
+    }
+}
+
+} // namespace cgs::game

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,17 @@ target_link_libraries(cgs_game_world_system_tests PRIVATE
 )
 gtest_discover_tests(cgs_game_world_system_tests)
 
+# Unit tests - Game AI system
+add_executable(cgs_game_ai_system_tests
+    unit/game/ai_system_test.cpp
+)
+target_link_libraries(cgs_game_ai_system_tests PRIVATE
+    cgs::game_ai_system
+    cgs::ecs_entity_manager
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_game_ai_system_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/game/ai_system_test.cpp
+++ b/tests/unit/game/ai_system_test.cpp
@@ -1,0 +1,1093 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "cgs/ecs/component_storage.hpp"
+#include "cgs/ecs/entity.hpp"
+#include "cgs/ecs/entity_manager.hpp"
+#include "cgs/ecs/system_scheduler.hpp"
+#include "cgs/game/ai_components.hpp"
+#include "cgs/game/ai_system.hpp"
+#include "cgs/game/ai_types.hpp"
+#include "cgs/game/behavior_tree.hpp"
+#include "cgs/game/combat_components.hpp"
+#include "cgs/game/components.hpp"
+#include "cgs/game/math_types.hpp"
+
+using namespace cgs::ecs;
+using namespace cgs::game;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AI type tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(AITypesTest, BTStatusValues) {
+    EXPECT_NE(BTStatus::Success, BTStatus::Failure);
+    EXPECT_NE(BTStatus::Success, BTStatus::Running);
+    EXPECT_NE(BTStatus::Failure, BTStatus::Running);
+}
+
+TEST(AITypesTest, AIStateValues) {
+    AIState state = AIState::Idle;
+    EXPECT_EQ(state, AIState::Idle);
+    state = AIState::Dead;
+    EXPECT_EQ(state, AIState::Dead);
+}
+
+TEST(AITypesTest, Constants) {
+    EXPECT_GT(kDefaultAITickInterval, 0.0f);
+    EXPECT_GT(kMoveToArrivalDistance, 0.0f);
+    EXPECT_GT(kDefaultFleeDistance, 0.0f);
+    EXPECT_GT(kDefaultAttackRange, 0.0f);
+    EXPECT_GT(kMaxPatrolWaypoints, 0u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Blackboard tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(BlackboardTest, SetAndGetValue) {
+    Blackboard bb;
+    bb.Set<int>("health", 100);
+
+    auto* val = bb.Get<int>("health");
+    ASSERT_NE(val, nullptr);
+    EXPECT_EQ(*val, 100);
+}
+
+TEST(BlackboardTest, GetMissingKeyReturnsNull) {
+    Blackboard bb;
+    auto* val = bb.Get<int>("nonexistent");
+    EXPECT_EQ(val, nullptr);
+}
+
+TEST(BlackboardTest, GetWrongTypeReturnsNull) {
+    Blackboard bb;
+    bb.Set<int>("value", 42);
+    auto* val = bb.Get<float>("value");
+    EXPECT_EQ(val, nullptr);
+}
+
+TEST(BlackboardTest, OverwriteValue) {
+    Blackboard bb;
+    bb.Set<int>("count", 1);
+    bb.Set<int>("count", 2);
+
+    auto* val = bb.Get<int>("count");
+    ASSERT_NE(val, nullptr);
+    EXPECT_EQ(*val, 2);
+}
+
+TEST(BlackboardTest, HasKey) {
+    Blackboard bb;
+    EXPECT_FALSE(bb.Has("key"));
+    bb.Set<int>("key", 0);
+    EXPECT_TRUE(bb.Has("key"));
+}
+
+TEST(BlackboardTest, EraseKey) {
+    Blackboard bb;
+    bb.Set<int>("key", 42);
+    EXPECT_TRUE(bb.Has("key"));
+    bb.Erase("key");
+    EXPECT_FALSE(bb.Has("key"));
+}
+
+TEST(BlackboardTest, Clear) {
+    Blackboard bb;
+    bb.Set<int>("a", 1);
+    bb.Set<float>("b", 2.0f);
+    bb.Clear();
+    EXPECT_FALSE(bb.Has("a"));
+    EXPECT_FALSE(bb.Has("b"));
+}
+
+TEST(BlackboardTest, StoreVector3) {
+    Blackboard bb;
+    bb.Set<Vector3>("position", Vector3(10.0f, 0.0f, 20.0f));
+
+    auto* pos = bb.Get<Vector3>("position");
+    ASSERT_NE(pos, nullptr);
+    EXPECT_FLOAT_EQ(pos->x, 10.0f);
+    EXPECT_FLOAT_EQ(pos->z, 20.0f);
+}
+
+TEST(BlackboardTest, StoreEntity) {
+    Blackboard bb;
+    Entity target(42, 0);
+    bb.Set<Entity>("target", target);
+
+    auto* val = bb.Get<Entity>("target");
+    ASSERT_NE(val, nullptr);
+    EXPECT_EQ(*val, target);
+}
+
+TEST(BlackboardTest, ConstAccess) {
+    Blackboard bb;
+    bb.Set<int>("x", 99);
+
+    const auto& constBb = bb;
+    auto* val = constBb.Get<int>("x");
+    ASSERT_NE(val, nullptr);
+    EXPECT_EQ(*val, 99);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BT leaf node tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(BTConditionTest, TruePredicateReturnsSuccess) {
+    BTCondition node([](BTContext&) { return true; });
+    BTContext ctx;
+    EXPECT_EQ(node.Tick(ctx), BTStatus::Success);
+}
+
+TEST(BTConditionTest, FalsePredicateReturnsFailure) {
+    BTCondition node([](BTContext&) { return false; });
+    BTContext ctx;
+    EXPECT_EQ(node.Tick(ctx), BTStatus::Failure);
+}
+
+TEST(BTActionTest, ReturnsActionResult) {
+    BTAction successAction([](BTContext&) { return BTStatus::Success; });
+    BTAction failAction([](BTContext&) { return BTStatus::Failure; });
+    BTAction runAction([](BTContext&) { return BTStatus::Running; });
+
+    BTContext ctx;
+    EXPECT_EQ(successAction.Tick(ctx), BTStatus::Success);
+    EXPECT_EQ(failAction.Tick(ctx), BTStatus::Failure);
+    EXPECT_EQ(runAction.Tick(ctx), BTStatus::Running);
+}
+
+TEST(BTActionTest, AccessesContext) {
+    BTAction action([](BTContext& ctx) -> BTStatus {
+        auto* val = ctx.blackboard->Get<int>("counter");
+        if (!val) return BTStatus::Failure;
+        ctx.blackboard->Set<int>("counter", *val + 1);
+        return BTStatus::Success;
+    });
+
+    Blackboard bb;
+    bb.Set<int>("counter", 0);
+    BTContext ctx;
+    ctx.blackboard = &bb;
+
+    action.Tick(ctx);
+    auto* val = bb.Get<int>("counter");
+    ASSERT_NE(val, nullptr);
+    EXPECT_EQ(*val, 1);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BT Sequence tests (SRS-GML-004.2)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(BTSequenceTest, EmptySequenceSucceeds) {
+    BTSequence seq;
+    BTContext ctx;
+    EXPECT_EQ(seq.Tick(ctx), BTStatus::Success);
+}
+
+TEST(BTSequenceTest, AllSucceedReturnsSuccess) {
+    BTSequence seq;
+    seq.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+    seq.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+
+    BTContext ctx;
+    EXPECT_EQ(seq.Tick(ctx), BTStatus::Success);
+}
+
+TEST(BTSequenceTest, FailureStopsExecution) {
+    int callCount = 0;
+    BTSequence seq;
+    seq.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+    seq.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Failure; }));
+    seq.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+
+    BTContext ctx;
+    EXPECT_EQ(seq.Tick(ctx), BTStatus::Failure);
+    EXPECT_EQ(callCount, 2);  // Third child should not be called.
+}
+
+TEST(BTSequenceTest, RunningPausesExecution) {
+    int callCount = 0;
+    BTSequence seq;
+    seq.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+    seq.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Running; }));
+    seq.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+
+    BTContext ctx;
+    EXPECT_EQ(seq.Tick(ctx), BTStatus::Running);
+    EXPECT_EQ(callCount, 2);  // Third child should not be called.
+}
+
+TEST(BTSequenceTest, ResumesFromRunningChild) {
+    int tickCount = 0;
+    BTSequence seq;
+    seq.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++tickCount; return BTStatus::Success; }));
+    seq.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) {
+            ++tickCount;
+            return tickCount <= 2 ? BTStatus::Running : BTStatus::Success;
+        }));
+
+    BTContext ctx;
+    EXPECT_EQ(seq.Tick(ctx), BTStatus::Running);   // First tick: child 0 OK, child 1 running
+    EXPECT_EQ(seq.Tick(ctx), BTStatus::Success);    // Second tick: resumes at child 1, succeeds
+}
+
+TEST(BTSequenceTest, ResetClearsState) {
+    BTSequence seq;
+    seq.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+    seq.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Running; }));
+
+    BTContext ctx;
+    seq.Tick(ctx);  // Paused at child 1.
+    seq.Reset();
+    // After reset, should start from child 0 again.
+    // Verify reset doesn't crash and child count is preserved.
+    EXPECT_EQ(seq.ChildCount(), 2u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BT Selector tests (SRS-GML-004.2)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(BTSelectorTest, EmptySelectorFails) {
+    BTSelector sel;
+    BTContext ctx;
+    EXPECT_EQ(sel.Tick(ctx), BTStatus::Failure);
+}
+
+TEST(BTSelectorTest, FirstSuccessStopsExecution) {
+    int callCount = 0;
+    BTSelector sel;
+    sel.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Failure; }));
+    sel.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+    sel.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+
+    BTContext ctx;
+    EXPECT_EQ(sel.Tick(ctx), BTStatus::Success);
+    EXPECT_EQ(callCount, 2);  // Third child should not be called.
+}
+
+TEST(BTSelectorTest, AllFailReturnsFailure) {
+    BTSelector sel;
+    sel.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Failure; }));
+    sel.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Failure; }));
+
+    BTContext ctx;
+    EXPECT_EQ(sel.Tick(ctx), BTStatus::Failure);
+}
+
+TEST(BTSelectorTest, RunningPausesExecution) {
+    BTSelector sel;
+    sel.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Failure; }));
+    sel.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Running; }));
+    sel.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+
+    BTContext ctx;
+    EXPECT_EQ(sel.Tick(ctx), BTStatus::Running);
+}
+
+TEST(BTSelectorTest, ResumesFromRunningChild) {
+    int tickCount = 0;
+    BTSelector sel;
+    sel.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++tickCount; return BTStatus::Failure; }));
+    sel.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) {
+            ++tickCount;
+            return tickCount <= 2 ? BTStatus::Running : BTStatus::Success;
+        }));
+
+    BTContext ctx;
+    EXPECT_EQ(sel.Tick(ctx), BTStatus::Running);    // child 0 fails, child 1 running
+    EXPECT_EQ(sel.Tick(ctx), BTStatus::Success);     // resumes at child 1, succeeds
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BT Parallel tests (SRS-GML-004.2)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(BTParallelTest, RequireAllSucceeds) {
+    BTParallel par(BTParallelPolicy::RequireAll);
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+
+    BTContext ctx;
+    EXPECT_EQ(par.Tick(ctx), BTStatus::Success);
+}
+
+TEST(BTParallelTest, RequireAllFailsOnAnyFailure) {
+    BTParallel par(BTParallelPolicy::RequireAll);
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Failure; }));
+
+    BTContext ctx;
+    EXPECT_EQ(par.Tick(ctx), BTStatus::Failure);
+}
+
+TEST(BTParallelTest, RequireAllRunningWhenNotAllDone) {
+    BTParallel par(BTParallelPolicy::RequireAll);
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Running; }));
+
+    BTContext ctx;
+    EXPECT_EQ(par.Tick(ctx), BTStatus::Running);
+}
+
+TEST(BTParallelTest, RequireOneSucceedsOnFirstSuccess) {
+    BTParallel par(BTParallelPolicy::RequireOne);
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Failure; }));
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; }));
+
+    BTContext ctx;
+    EXPECT_EQ(par.Tick(ctx), BTStatus::Success);
+}
+
+TEST(BTParallelTest, RequireOneFailsWhenAllFail) {
+    BTParallel par(BTParallelPolicy::RequireOne);
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Failure; }));
+    par.AddChild(std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Failure; }));
+
+    BTContext ctx;
+    EXPECT_EQ(par.Tick(ctx), BTStatus::Failure);
+}
+
+TEST(BTParallelTest, TicksAllChildren) {
+    int callCount = 0;
+    BTParallel par(BTParallelPolicy::RequireAll);
+    par.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+    par.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+    par.AddChild(std::make_unique<BTAction>(
+        [&](BTContext&) { ++callCount; return BTStatus::Success; }));
+
+    BTContext ctx;
+    par.Tick(ctx);
+    EXPECT_EQ(callCount, 3);  // All children ticked.
+}
+
+TEST(BTParallelTest, PolicyAccessor) {
+    BTParallel par(BTParallelPolicy::RequireOne);
+    EXPECT_EQ(par.GetPolicy(), BTParallelPolicy::RequireOne);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BT Inverter tests (SRS-GML-004.2)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(BTInverterTest, InvertsSuccess) {
+    auto child = std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; });
+    BTInverter inv(std::move(child));
+
+    BTContext ctx;
+    EXPECT_EQ(inv.Tick(ctx), BTStatus::Failure);
+}
+
+TEST(BTInverterTest, InvertsFailure) {
+    auto child = std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Failure; });
+    BTInverter inv(std::move(child));
+
+    BTContext ctx;
+    EXPECT_EQ(inv.Tick(ctx), BTStatus::Success);
+}
+
+TEST(BTInverterTest, PassesThroughRunning) {
+    auto child = std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Running; });
+    BTInverter inv(std::move(child));
+
+    BTContext ctx;
+    EXPECT_EQ(inv.Tick(ctx), BTStatus::Running);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BT Repeater tests (SRS-GML-004.2)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(BTRepeaterTest, FiniteRepeatCompletesAfterN) {
+    int childTicks = 0;
+    auto child = std::make_unique<BTAction>(
+        [&](BTContext&) { ++childTicks; return BTStatus::Success; });
+    BTRepeater rep(std::move(child), 3);
+
+    BTContext ctx;
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Running);  // 1st
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Running);  // 2nd
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Success);  // 3rd — done
+    EXPECT_EQ(childTicks, 3);
+}
+
+TEST(BTRepeaterTest, InfiniteRepeatNeverCompletes) {
+    auto child = std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; });
+    BTRepeater rep(std::move(child), 0);  // 0 = infinite
+
+    BTContext ctx;
+    for (int i = 0; i < 100; ++i) {
+        EXPECT_EQ(rep.Tick(ctx), BTStatus::Running);
+    }
+}
+
+TEST(BTRepeaterTest, PassesThroughRunning) {
+    auto child = std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Running; });
+    BTRepeater rep(std::move(child), 3);
+
+    BTContext ctx;
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Running);
+}
+
+TEST(BTRepeaterTest, CountsFailuresAsIterations) {
+    int childTicks = 0;
+    auto child = std::make_unique<BTAction>(
+        [&](BTContext&) { ++childTicks; return BTStatus::Failure; });
+    BTRepeater rep(std::move(child), 2);
+
+    BTContext ctx;
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Running);  // 1st (failure still counts)
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Success);  // 2nd — done
+    EXPECT_EQ(childTicks, 2);
+}
+
+TEST(BTRepeaterTest, ResetClearsCount) {
+    auto child = std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; });
+    BTRepeater rep(std::move(child), 3);
+
+    BTContext ctx;
+    rep.Tick(ctx);  // 1st
+    rep.Reset();
+    // After reset, should start fresh (need 3 more).
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Running);  // 1st again
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Running);  // 2nd
+    EXPECT_EQ(rep.Tick(ctx), BTStatus::Success);  // 3rd — done
+}
+
+TEST(BTRepeaterTest, MaxRepeatsAccessor) {
+    auto child = std::make_unique<BTAction>(
+        [](BTContext&) { return BTStatus::Success; });
+    BTRepeater rep(std::move(child), 5);
+    EXPECT_EQ(rep.MaxRepeats(), 5u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AIBrain component tests (SRS-GML-004.1)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(AIBrainTest, DefaultValues) {
+    AIBrain brain;
+    EXPECT_EQ(brain.state, AIState::Idle);
+    EXPECT_EQ(brain.behaviorTree, nullptr);
+    EXPECT_FLOAT_EQ(brain.timeSinceLastTick, 0.0f);
+    EXPECT_FLOAT_EQ(brain.tickInterval, 0.0f);
+    EXPECT_FALSE(brain.target.isValid());
+}
+
+TEST(AIBrainTest, StorageRoundTrip) {
+    ComponentStorage<AIBrain> storage;
+    Entity e(0, 0);
+
+    AIBrain brain;
+    brain.state = AIState::Patrolling;
+    brain.homePosition = Vector3(10.0f, 0.0f, 20.0f);
+    storage.Add(e, std::move(brain));
+
+    const auto& stored = storage.Get(e);
+    EXPECT_EQ(stored.state, AIState::Patrolling);
+    EXPECT_FLOAT_EQ(stored.homePosition.x, 10.0f);
+    EXPECT_FLOAT_EQ(stored.homePosition.z, 20.0f);
+}
+
+TEST(AIBrainTest, SharedBehaviorTree) {
+    auto tree = std::make_shared<BTAction>(
+        [](BTContext&) { return BTStatus::Success; });
+
+    AIBrain brain1;
+    brain1.behaviorTree = tree;
+
+    AIBrain brain2;
+    brain2.behaviorTree = tree;
+
+    // Both brains share the same tree.
+    EXPECT_EQ(brain1.behaviorTree.get(), brain2.behaviorTree.get());
+    EXPECT_EQ(tree.use_count(), 3);  // tree + brain1 + brain2
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AISystem tests (SRS-GML-004.4)
+// ═══════════════════════════════════════════════════════════════════════════
+
+class AISystemTest : public ::testing::Test {
+protected:
+    ComponentStorage<AIBrain> brains;
+    ComponentStorage<Transform> transforms;
+    ComponentStorage<Movement> movements;
+    ComponentStorage<Stats> stats;
+    ComponentStorage<ThreatList> threatLists;
+
+    /// Helper: create an AI entity with a simple always-success BT.
+    Entity createAIEntity(uint32_t id, const Vector3& pos) {
+        Entity e(id, 0);
+        transforms.Add(e, Transform{pos, {}, {1.0f, 1.0f, 1.0f}});
+        movements.Add(e, Movement{5.0f, 5.0f, {}, MovementState::Idle});
+
+        AIBrain brain;
+        brain.behaviorTree = std::make_shared<BTAction>(
+            [](BTContext&) { return BTStatus::Success; });
+        brains.Add(e, std::move(brain));
+
+        return e;
+    }
+};
+
+TEST_F(AISystemTest, ThrottledUpdates) {
+    createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    // Default tick interval is 0.1s.
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.1f);
+
+    // First tick at 0.05s — should NOT trigger AI update.
+    system.Execute(0.05f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 0u);
+
+    // Second tick at 0.05s — total 0.1s, SHOULD trigger.
+    system.Execute(0.05f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 1u);
+}
+
+TEST_F(AISystemTest, PerEntityTickInterval) {
+    Entity fast = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+    Entity slow = createAIEntity(1, Vector3(10.0f, 0.0f, 10.0f));
+
+    // Fast entity updates every 0.05s, slow every 0.2s.
+    brains.Get(fast).tickInterval = 0.05f;
+    brains.Get(slow).tickInterval = 0.2f;
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.1f);
+
+    system.Execute(0.05f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 1u);  // Only fast.
+
+    system.Execute(0.05f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 1u);  // Fast again.
+
+    system.Execute(0.1f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 2u);  // Both (fast=0.15 > 0.05, slow=0.2 >= 0.2).
+}
+
+TEST_F(AISystemTest, SkipsDeadEntities) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+    brains.Get(e).state = AIState::Dead;
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    system.Execute(0.1f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 0u);
+}
+
+TEST_F(AISystemTest, SkipsEntitiesWithoutBT) {
+    Entity e(0, 0);
+    transforms.Add(e, Transform{{}, {}, {1.0f, 1.0f, 1.0f}});
+    movements.Add(e, Movement{});
+
+    AIBrain brain;
+    // No behavior tree set.
+    brains.Add(e, std::move(brain));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    system.Execute(0.1f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 0u);
+}
+
+TEST_F(AISystemTest, BTContextReceivesCorrectData) {
+    Entity e(0, 0);
+    transforms.Add(e, Transform{{}, {}, {1.0f, 1.0f, 1.0f}});
+    movements.Add(e, Movement{});
+
+    Entity capturedEntity;
+    float capturedDelta = 0.0f;
+    bool capturedHasBlackboard = false;
+
+    AIBrain brain;
+    brain.behaviorTree = std::make_shared<BTAction>(
+        [&](BTContext& ctx) -> BTStatus {
+            capturedEntity = ctx.entity;
+            capturedDelta = ctx.deltaTime;
+            capturedHasBlackboard = (ctx.blackboard != nullptr);
+            return BTStatus::Success;
+        });
+    brains.Add(e, std::move(brain));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    system.Execute(0.016f);
+
+    EXPECT_EQ(capturedEntity, e);
+    EXPECT_GT(capturedDelta, 0.0f);
+    EXPECT_TRUE(capturedHasBlackboard);
+}
+
+TEST_F(AISystemTest, TimerResetsAfterTick) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+    brains.Get(e).tickInterval = 0.1f;
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.1f);
+
+    system.Execute(0.15f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 1u);
+    EXPECT_FLOAT_EQ(brains.Get(e).timeSinceLastTick, 0.0f);
+}
+
+// ── Built-in task tests (SRS-GML-004.3) ─────────────────────────────
+
+TEST_F(AISystemTest, MoveToTaskArrivesAtTarget) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto moveToTask = system.CreateMoveToTask();
+
+    Blackboard bb;
+    bb.Set<Vector3>("move_target", Vector3(10.0f, 0.0f, 0.0f));
+    BTContext ctx{e, 0.016f, &bb};
+
+    // Far from target — should be Running.
+    auto status = moveToTask->Tick(ctx);
+    EXPECT_EQ(status, BTStatus::Running);
+    EXPECT_EQ(movements.Get(e).state, MovementState::Running);
+
+    // Move entity close to target.
+    transforms.Get(e).position = Vector3(10.0f, 0.0f, 0.0f);
+    status = moveToTask->Tick(ctx);
+    EXPECT_EQ(status, BTStatus::Success);
+    EXPECT_EQ(movements.Get(e).state, MovementState::Idle);
+}
+
+TEST_F(AISystemTest, MoveToTaskFailsWithoutTarget) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto moveToTask = system.CreateMoveToTask();
+
+    Blackboard bb;  // No "move_target" set.
+    BTContext ctx{e, 0.016f, &bb};
+
+    EXPECT_EQ(moveToTask->Tick(ctx), BTStatus::Failure);
+}
+
+TEST_F(AISystemTest, MoveToTaskSetsDirection) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto moveToTask = system.CreateMoveToTask();
+
+    Blackboard bb;
+    bb.Set<Vector3>("move_target", Vector3(10.0f, 0.0f, 0.0f));
+    BTContext ctx{e, 0.016f, &bb};
+
+    moveToTask->Tick(ctx);
+
+    // Direction should point toward the target (positive X).
+    auto& dir = movements.Get(e).direction;
+    EXPECT_GT(dir.x, 0.0f);
+    EXPECT_NEAR(dir.z, 0.0f, 0.01f);
+}
+
+TEST_F(AISystemTest, AttackTaskInRange) {
+    Entity attacker = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+    Entity target(1, 0);
+    transforms.Add(target, Transform{{2.0f, 0.0f, 0.0f}, {}, {1.0f, 1.0f, 1.0f}});
+    stats.Add(target, Stats{100, 100, 0, 0, {}});
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto attackTask = system.CreateAttackTask();
+
+    Blackboard bb;
+    bb.Set<Entity>("target", target);
+    BTContext ctx{attacker, 0.016f, &bb};
+
+    // Within default attack range (3.0) — distance is 2.0.
+    EXPECT_EQ(attackTask->Tick(ctx), BTStatus::Success);
+}
+
+TEST_F(AISystemTest, AttackTaskOutOfRange) {
+    Entity attacker = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+    Entity target(1, 0);
+    transforms.Add(target, Transform{{50.0f, 0.0f, 0.0f}, {}, {1.0f, 1.0f, 1.0f}});
+    stats.Add(target, Stats{100, 100, 0, 0, {}});
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto attackTask = system.CreateAttackTask();
+
+    Blackboard bb;
+    bb.Set<Entity>("target", target);
+    BTContext ctx{attacker, 0.016f, &bb};
+
+    EXPECT_EQ(attackTask->Tick(ctx), BTStatus::Failure);
+}
+
+TEST_F(AISystemTest, AttackTaskFailsOnDeadTarget) {
+    Entity attacker = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+    Entity target(1, 0);
+    transforms.Add(target, Transform{{1.0f, 0.0f, 0.0f}, {}, {1.0f, 1.0f, 1.0f}});
+    stats.Add(target, Stats{0, 100, 0, 0, {}});  // Dead (health = 0).
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto attackTask = system.CreateAttackTask();
+
+    Blackboard bb;
+    bb.Set<Entity>("target", target);
+    BTContext ctx{attacker, 0.016f, &bb};
+
+    EXPECT_EQ(attackTask->Tick(ctx), BTStatus::Failure);
+}
+
+TEST_F(AISystemTest, AttackTaskFailsWithoutTarget) {
+    Entity attacker = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto attackTask = system.CreateAttackTask();
+
+    Blackboard bb;  // No "target" set.
+    BTContext ctx{attacker, 0.016f, &bb};
+
+    EXPECT_EQ(attackTask->Tick(ctx), BTStatus::Failure);
+}
+
+TEST_F(AISystemTest, PatrolTaskWalksBetweenWaypoints) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto patrolTask = system.CreatePatrolTask();
+
+    std::vector<Vector3> waypoints = {
+        Vector3(10.0f, 0.0f, 0.0f),
+        Vector3(10.0f, 0.0f, 10.0f),
+        Vector3(0.0f, 0.0f, 10.0f)
+    };
+
+    Blackboard bb;
+    bb.Set<std::vector<Vector3>>("waypoints", waypoints);
+    BTContext ctx{e, 0.016f, &bb};
+
+    // Far from first waypoint — walking toward it.
+    auto status = patrolTask->Tick(ctx);
+    EXPECT_EQ(status, BTStatus::Running);
+    EXPECT_EQ(movements.Get(e).state, MovementState::Walking);
+
+    // Arrive at first waypoint.
+    transforms.Get(e).position = Vector3(10.0f, 0.0f, 0.0f);
+    status = patrolTask->Tick(ctx);
+    EXPECT_EQ(status, BTStatus::Running);
+
+    // Patrol index should have advanced to 1.
+    auto* idx = bb.Get<std::size_t>("patrol_index");
+    ASSERT_NE(idx, nullptr);
+    EXPECT_EQ(*idx, 1u);
+}
+
+TEST_F(AISystemTest, PatrolTaskWrapsAround) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 10.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto patrolTask = system.CreatePatrolTask();
+
+    std::vector<Vector3> waypoints = {
+        Vector3(10.0f, 0.0f, 0.0f),
+        Vector3(0.0f, 0.0f, 10.0f)
+    };
+
+    Blackboard bb;
+    bb.Set<std::vector<Vector3>>("waypoints", waypoints);
+    bb.Set<std::size_t>("patrol_index", std::size_t{1});
+    BTContext ctx{e, 0.016f, &bb};
+
+    // At waypoint 1 — should wrap to 0.
+    patrolTask->Tick(ctx);
+    auto* idx = bb.Get<std::size_t>("patrol_index");
+    ASSERT_NE(idx, nullptr);
+    EXPECT_EQ(*idx, 0u);
+}
+
+TEST_F(AISystemTest, PatrolTaskFailsWithoutWaypoints) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto patrolTask = system.CreatePatrolTask();
+
+    Blackboard bb;  // No waypoints.
+    BTContext ctx{e, 0.016f, &bb};
+
+    EXPECT_EQ(patrolTask->Tick(ctx), BTStatus::Failure);
+}
+
+TEST_F(AISystemTest, FleeTaskMovesAwayFromThreat) {
+    Entity e = createAIEntity(0, Vector3(5.0f, 0.0f, 0.0f));
+    Entity threat(1, 0);
+    transforms.Add(threat, Transform{{0.0f, 0.0f, 0.0f}, {}, {1.0f, 1.0f, 1.0f}});
+    threatLists.Add(e, ThreatList{});
+    threatLists.Get(e).AddThreat(threat, 100.0f);
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto fleeTask = system.CreateFleeTask();
+
+    Blackboard bb;
+    BTContext ctx{e, 0.016f, &bb};
+
+    // Entity is at (5,0,0), threat at origin — distance 5 < 20 (flee distance).
+    auto status = fleeTask->Tick(ctx);
+    EXPECT_EQ(status, BTStatus::Running);
+    EXPECT_EQ(movements.Get(e).state, MovementState::Running);
+
+    // Direction should point away from threat (positive X).
+    auto& dir = movements.Get(e).direction;
+    EXPECT_GT(dir.x, 0.0f);
+}
+
+TEST_F(AISystemTest, FleeTaskSucceedsWhenFarEnough) {
+    Entity e = createAIEntity(0, Vector3(50.0f, 0.0f, 0.0f));
+    Entity threat(1, 0);
+    transforms.Add(threat, Transform{{0.0f, 0.0f, 0.0f}, {}, {1.0f, 1.0f, 1.0f}});
+    threatLists.Add(e, ThreatList{});
+    threatLists.Get(e).AddThreat(threat, 100.0f);
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto fleeTask = system.CreateFleeTask();
+
+    Blackboard bb;
+    BTContext ctx{e, 0.016f, &bb};
+
+    // Distance 50 >= 20 (flee distance) — should succeed.
+    EXPECT_EQ(fleeTask->Tick(ctx), BTStatus::Success);
+    EXPECT_EQ(movements.Get(e).state, MovementState::Idle);
+}
+
+TEST_F(AISystemTest, FleeTaskFailsWithoutThreat) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto fleeTask = system.CreateFleeTask();
+
+    Blackboard bb;
+    BTContext ctx{e, 0.016f, &bb};
+
+    EXPECT_EQ(fleeTask->Tick(ctx), BTStatus::Failure);
+}
+
+TEST_F(AISystemTest, IdleTaskSetsIdleState) {
+    Entity e = createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+    movements.Get(e).state = MovementState::Running;
+    movements.Get(e).direction = Vector3(1.0f, 0.0f, 0.0f);
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+    auto idleTask = system.CreateIdleTask();
+
+    Blackboard bb;
+    BTContext ctx{e, 0.016f, &bb};
+
+    EXPECT_EQ(idleTask->Tick(ctx), BTStatus::Success);
+    EXPECT_EQ(movements.Get(e).state, MovementState::Idle);
+    EXPECT_FLOAT_EQ(movements.Get(e).direction.x, 0.0f);
+}
+
+// ── System metadata tests ───────────────────────────────────────────
+
+TEST_F(AISystemTest, SystemMetadata) {
+    AISystem system(brains, transforms, movements, stats, threatLists);
+
+    EXPECT_EQ(system.GetName(), "AISystem");
+    EXPECT_EQ(system.GetStage(), SystemStage::Update);
+
+    auto access = system.GetAccessInfo();
+    EXPECT_FALSE(access.reads.empty());
+    EXPECT_FALSE(access.writes.empty());
+}
+
+TEST_F(AISystemTest, ConfigurableTickInterval) {
+    // Create at least one entity so system has something to process.
+    createAIEntity(0, Vector3(0.0f, 0.0f, 0.0f));
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.5f);
+    EXPECT_FLOAT_EQ(system.GetDefaultTickInterval(), 0.5f);
+
+    system.SetDefaultTickInterval(0.2f);
+    EXPECT_FLOAT_EQ(system.GetDefaultTickInterval(), 0.2f);
+
+    // Negative value should be ignored.
+    system.SetDefaultTickInterval(-1.0f);
+    EXPECT_FLOAT_EQ(system.GetDefaultTickInterval(), 0.2f);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Integration: full AI scenario
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(AIIntegration, FullAIScenario) {
+    ComponentStorage<AIBrain> brains;
+    ComponentStorage<Transform> transforms;
+    ComponentStorage<Movement> movements;
+    ComponentStorage<Stats> stats;
+    ComponentStorage<ThreatList> threatLists;
+
+    EntityManager entityManager;
+    entityManager.RegisterStorage(&brains);
+    entityManager.RegisterStorage(&transforms);
+    entityManager.RegisterStorage(&movements);
+    entityManager.RegisterStorage(&stats);
+    entityManager.RegisterStorage(&threatLists);
+
+    // Create a guard NPC.
+    Entity guard = entityManager.Create();
+    transforms.Add(guard, Transform{{0.0f, 0.0f, 0.0f}, {}, {1.0f, 1.0f, 1.0f}});
+    movements.Add(guard, Movement{3.0f, 3.0f, {}, MovementState::Idle});
+    stats.Add(guard, Stats{100, 100, 50, 50, {}});
+
+    // Build a simple BT: Selector(Attack, Patrol, Idle).
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.0f);
+
+    auto selector = std::make_unique<BTSelector>();
+    selector->AddChild(system.CreateAttackTask());
+    selector->AddChild(system.CreatePatrolTask());
+    selector->AddChild(system.CreateIdleTask());
+
+    AIBrain brain;
+    brain.behaviorTree = std::move(selector);
+    brain.blackboard.Set<std::vector<Vector3>>("waypoints",
+        std::vector<Vector3>{
+            Vector3(10.0f, 0.0f, 0.0f),
+            Vector3(10.0f, 0.0f, 10.0f),
+            Vector3(0.0f, 0.0f, 0.0f)
+        });
+    brains.Add(guard, std::move(brain));
+
+    // Tick 1: No target in blackboard, attack fails -> patrol runs.
+    system.Execute(0.016f);
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 1u);
+    EXPECT_EQ(movements.Get(guard).state, MovementState::Walking);
+
+    // Create an enemy in range.
+    Entity enemy = entityManager.Create();
+    transforms.Add(enemy, Transform{{2.0f, 0.0f, 0.0f}, {}, {1.0f, 1.0f, 1.0f}});
+    stats.Add(enemy, Stats{50, 50, 0, 0, {}});
+
+    // Set target in blackboard.
+    brains.Get(guard).blackboard.Set<Entity>("target", enemy);
+
+    // Tick 2: Attack should succeed (in range), selector stops.
+    system.Execute(0.016f);
+    // Attack returns Success, selector returns Success.
+    EXPECT_EQ(system.GetLastTickUpdateCount(), 1u);
+
+    // Kill the enemy.
+    stats.Get(enemy).SetHealth(0);
+
+    // Tick 3: Attack fails (dead target), patrol resumes.
+    system.Execute(0.016f);
+    EXPECT_EQ(movements.Get(guard).state, MovementState::Walking);
+
+    // Clean up.
+    entityManager.Destroy(guard);
+    entityManager.Destroy(enemy);
+}
+
+TEST(AIIntegration, SchedulerRegistration) {
+    ComponentStorage<AIBrain> brains;
+    ComponentStorage<Transform> transforms;
+    ComponentStorage<Movement> movements;
+    ComponentStorage<Stats> stats;
+    ComponentStorage<ThreatList> threatLists;
+
+    SystemScheduler scheduler;
+    auto& system = scheduler.Register<AISystem>(
+        brains, transforms, movements, stats, threatLists);
+
+    EXPECT_EQ(system.GetName(), "AISystem");
+    EXPECT_EQ(scheduler.SystemCount(), 1u);
+    EXPECT_TRUE(scheduler.Build());
+
+    // Execute with no entities (should not crash).
+    scheduler.Execute(1.0f / 60.0f);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Performance test: throttled AI on many entities (SRS-GML-004.4)
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(AIPerformance, ThrottledUpdateOneThousandEntities) {
+    ComponentStorage<AIBrain> brains;
+    ComponentStorage<Transform> transforms;
+    ComponentStorage<Movement> movements;
+    ComponentStorage<Stats> stats;
+    ComponentStorage<ThreatList> threatLists;
+
+    constexpr uint32_t kEntityCount = 1000;
+
+    // Create 1000 AI entities with staggered tick intervals.
+    for (uint32_t i = 0; i < kEntityCount; ++i) {
+        Entity e(i, 0);
+        float x = static_cast<float>(i % 100) * 5.0f;
+        float z = static_cast<float>(i / 100) * 5.0f;
+        transforms.Add(e, Transform{{x, 0.0f, z}, {}, {1.0f, 1.0f, 1.0f}});
+        movements.Add(e, Movement{3.0f, 3.0f, {}, MovementState::Idle});
+
+        AIBrain brain;
+        brain.behaviorTree = std::make_shared<BTAction>(
+            [](BTContext&) { return BTStatus::Success; });
+        // Stagger tick intervals: 0.1s, 0.2s, 0.3s, 0.4s, ...
+        brain.tickInterval = 0.1f * static_cast<float>((i % 4) + 1);
+        brains.Add(e, std::move(brain));
+    }
+
+    AISystem system(brains, transforms, movements, stats, threatLists, 0.1f);
+
+    // Tick at 0.1s — only entities with 0.1s interval should update.
+    system.Execute(0.1f);
+    uint32_t firstTick = system.GetLastTickUpdateCount();
+    EXPECT_GT(firstTick, 0u);
+    EXPECT_LT(firstTick, kEntityCount);
+
+    // Tick at 0.3s total (0.1 + 0.2) — more entities should update.
+    system.Execute(0.2f);
+    uint32_t secondTick = system.GetLastTickUpdateCount();
+    EXPECT_GT(secondTick, firstTick);
+
+    // After enough time, all stagger groups should tick in a single frame.
+    // Accumulate to 0.4s per entity — groups need 0.1, 0.2, 0.3, 0.4.
+    system.Execute(0.1f);  // 0.4s total: timers = 0.1s:0.1, 0.2s:0.1, 0.3s:0.3, 0.4s:0.4
+    system.Execute(0.4f);  // 0.8s total: all timers exceed their intervals
+    EXPECT_EQ(system.GetLastTickUpdateCount(), kEntityCount);
+}


### PR DESCRIPTION
Closes #19

## Summary
- Add Behavior Tree framework with composite nodes (Sequence, Selector, Parallel), decorators (Inverter, Repeater), and leaf nodes (Condition, Action)
- Add AIBrain ECS component with shared BT root, per-entity Blackboard, and AI state tracking
- Add AISystem with frame-distributed throttled BT execution (configurable per-entity tick intervals)
- Add 5 built-in AI task factories: MoveTo, Attack, Patrol, Flee, Idle
- Add Blackboard key-value store for inter-node data sharing using std::any

## SRS Traceability

| SRS ID | Requirement | Status |
|--------|-------------|--------|
| SRS-GML-004.1 | AIBrain component for AI state | Done |
| SRS-GML-004.2 | Behavior Tree execution (Sequence, Selector, Parallel, Inverter, Repeater) | Done |
| SRS-GML-004.3 | Common AI tasks (MoveTo, Attack, Patrol, Flee, Idle) | Done |
| SRS-GML-004.4 | AI update throttling for performance | Done |

## Files Added
- `include/cgs/game/ai_types.hpp` — BTStatus, AIState, BTParallelPolicy enums and constants
- `include/cgs/game/behavior_tree.hpp` — BT node hierarchy and Blackboard
- `include/cgs/game/ai_components.hpp` — AIBrain ECS component
- `include/cgs/game/ai_system.hpp` — AISystem class declaration
- `src/game/ai_system/ai_system.cpp` — AISystem implementation with built-in tasks
- `src/game/ai_system/CMakeLists.txt` — Build configuration
- `tests/unit/game/ai_system_test.cpp` — 72 unit tests

## Files Modified
- `src/game/CMakeLists.txt` — Add ai_system subdirectory
- `tests/CMakeLists.txt` — Add ai_system test target

## Test Plan
- [x] 72 unit tests covering all BT node types, state transitions, built-in tasks
- [x] Integration test: full AI scenario (guard NPC with Selector tree)
- [x] Integration test: SystemScheduler registration
- [x] Performance test: 1K AI entities with staggered throttled updates
- [x] All 778 existing tests pass (zero regressions)