### PR TITLE
feat(service): add Auth Types, Password Hashing & Token Provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ target_link_libraries(cgs_core INTERFACE cgs_warnings)
 add_subdirectory(src/foundation)
 
 # Layer 3: Services
-# add_subdirectory(src/services)
+add_subdirectory(src/services)
 
 # Layer 4: ECS core
 add_subdirectory(src/ecs)

--- a/include/cgs/foundation/error_code.hpp
+++ b/include/cgs/foundation/error_code.hpp
@@ -59,6 +59,13 @@ enum class ErrorCode : uint32_t {
     TokenExpired = 0x0501,
     InvalidToken = 0x0502,
     PermissionDenied = 0x0503,
+    UserAlreadyExists = 0x0504,
+    InvalidEmail = 0x0505,
+    WeakPassword = 0x0506,
+    RateLimitExceeded = 0x0507,
+    TokenRevoked = 0x0508,
+    InvalidCredentials = 0x0509,
+    RefreshTokenExpired = 0x050A,
 
     // Config (0x0600 - 0x06FF)
     ConfigLoadFailed = 0x0600,

--- a/include/cgs/service/auth_types.hpp
+++ b/include/cgs/service/auth_types.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+/// @file auth_types.hpp
+/// @brief Core type definitions for the Authentication Server.
+///
+/// Defines user records, token structures, and configuration types
+/// used throughout the auth service layer.
+///
+/// @see SRS-SVC-001
+/// @see SDS-MOD-040
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace cgs::service {
+
+// -- User model ---------------------------------------------------------------
+
+/// Account status for a registered user.
+enum class UserStatus : uint8_t {
+    Active,
+    Suspended,
+    Deleted
+};
+
+/// Stored user record containing hashed credentials.
+///
+/// Passwords are never stored in plaintext.  The password_hash and salt
+/// fields are produced by PasswordHasher and verified through it.
+struct UserRecord {
+    uint64_t id = 0;
+    std::string username;
+    std::string email;
+    std::string passwordHash;
+    std::string salt;
+    UserStatus status = UserStatus::Active;
+    std::vector<std::string> roles;
+    std::chrono::system_clock::time_point createdAt{};
+    std::chrono::system_clock::time_point updatedAt{};
+};
+
+// -- Token structures ---------------------------------------------------------
+
+/// Decoded JWT claims payload.
+struct TokenClaims {
+    std::string subject;                              ///< User ID ("sub").
+    std::string username;                             ///< Username.
+    std::vector<std::string> roles;                   ///< Granted roles.
+    std::chrono::system_clock::time_point issuedAt{}; ///< Issued-at ("iat").
+    std::chrono::system_clock::time_point expiresAt{};///< Expiry ("exp").
+};
+
+/// Access + refresh token pair returned on successful authentication.
+struct TokenPair {
+    std::string accessToken;
+    std::string refreshToken;
+    std::chrono::seconds accessExpiresIn{};
+    std::chrono::seconds refreshExpiresIn{};
+};
+
+/// Stored refresh token record for revocation support.
+struct RefreshTokenRecord {
+    std::string token;
+    uint64_t userId = 0;
+    std::chrono::system_clock::time_point expiresAt{};
+    bool revoked = false;
+};
+
+// -- Configuration ------------------------------------------------------------
+
+/// Configuration for the authentication service.
+struct AuthConfig {
+    /// Secret key for HMAC-SHA256 token signing (min 32 bytes recommended).
+    std::string signingKey = "change-me-in-production";
+
+    /// Access token lifetime.
+    std::chrono::seconds accessTokenExpiry{900}; // 15 minutes
+
+    /// Refresh token lifetime.
+    std::chrono::seconds refreshTokenExpiry{604800}; // 7 days
+
+    /// Minimum password length.
+    uint32_t minPasswordLength = 8;
+
+    /// Maximum login attempts per key within the rate window.
+    uint32_t rateLimitMaxAttempts = 5;
+
+    /// Sliding window duration for rate limiting.
+    std::chrono::seconds rateLimitWindow{60}; // 1 minute
+};
+
+// -- Credential input ---------------------------------------------------------
+
+/// Credentials submitted for registration or login.
+struct UserCredentials {
+    std::string username;
+    std::string email;
+    std::string password;
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/password_hasher.hpp
+++ b/include/cgs/service/password_hasher.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+/// @file password_hasher.hpp
+/// @brief Password hashing and verification using SHA-256 with salt.
+///
+/// Provides secure password storage by generating a random salt per user
+/// and computing SHA-256(salt + password).  The interface is designed to be
+/// swappable with bcrypt or argon2id implementations via a foundation
+/// crypto adapter in production deployments.
+///
+/// @see SRS-SVC-001.6
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace cgs::service {
+
+/// Result of a password hashing operation.
+struct HashedPassword {
+    std::string hash;
+    std::string salt;
+};
+
+/// Password hashing utility using SHA-256 + random salt.
+///
+/// Example:
+/// @code
+///   PasswordHasher hasher;
+///   auto hashed = hasher.hash("my_password");
+///   bool ok = hasher.verify("my_password", hashed.hash, hashed.salt);
+/// @endcode
+class PasswordHasher {
+public:
+    /// Hash a plaintext password with a newly generated random salt.
+    [[nodiscard]] HashedPassword hash(std::string_view password) const;
+
+    /// Hash a plaintext password with the given salt (for verification).
+    [[nodiscard]] std::string hashWithSalt(std::string_view password,
+                                           std::string_view salt) const;
+
+    /// Verify a plaintext password against a stored hash and salt.
+    [[nodiscard]] bool verify(std::string_view password,
+                              std::string_view storedHash,
+                              std::string_view salt) const;
+
+    /// Generate a cryptographically random salt (hex-encoded).
+    [[nodiscard]] static std::string generateSalt();
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/token_provider.hpp
+++ b/include/cgs/service/token_provider.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+/// @file token_provider.hpp
+/// @brief JWT token generation and validation using HMAC-SHA256.
+///
+/// Generates RFC 7519 compliant JWT tokens with HS256 signing.
+/// The token format is: base64url(header).base64url(payload).base64url(signature)
+///
+/// @see SRS-SVC-001.3
+/// @see SRS-SVC-001.4
+
+#include <string>
+#include <string_view>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/service/auth_types.hpp"
+
+namespace cgs::service {
+
+/// JWT token provider for access and refresh token management.
+///
+/// Access tokens are signed JWTs containing user claims.
+/// Refresh tokens are opaque secure-random hex strings.
+///
+/// Example:
+/// @code
+///   TokenProvider provider("my-secret-key-32-bytes-minimum!!");
+///   auto token = provider.generateAccessToken(claims, std::chrono::seconds{900});
+///   auto result = provider.validateAccessToken(token);
+///   if (result.hasValue()) {
+///       auto& decoded = result.value();
+///   }
+/// @endcode
+class TokenProvider {
+public:
+    /// Construct with the HMAC signing key.
+    explicit TokenProvider(std::string signingKey);
+
+    /// Generate a signed JWT access token from the given claims.
+    [[nodiscard]] std::string generateAccessToken(
+        const TokenClaims& claims,
+        std::chrono::seconds expiry) const;
+
+    /// Validate and decode a JWT access token.
+    ///
+    /// Returns the decoded claims on success, or a GameError on failure
+    /// (expired, malformed, invalid signature).
+    [[nodiscard]] cgs::foundation::GameResult<TokenClaims> validateAccessToken(
+        std::string_view token) const;
+
+    /// Generate a cryptographically random refresh token (hex string).
+    [[nodiscard]] static std::string generateRefreshToken();
+
+private:
+    std::string signingKey_;
+};
+
+} // namespace cgs::service

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Layer 3: Services
+add_subdirectory(auth)

--- a/src/services/auth/CMakeLists.txt
+++ b/src/services/auth/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Auth Service - Types, Password Hashing, Token Provider (SDS-MOD-040)
+add_library(cgs_service_auth
+    password_hasher.cpp
+    token_provider.cpp
+)
+target_include_directories(cgs_service_auth
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(cgs_service_auth
+    PUBLIC cgs_core
+)
+add_library(cgs::service_auth ALIAS cgs_service_auth)

--- a/src/services/auth/crypto_utils.hpp
+++ b/src/services/auth/crypto_utils.hpp
@@ -1,0 +1,307 @@
+#pragma once
+
+/// @file crypto_utils.hpp
+/// @brief Internal cryptographic primitives: SHA-256, HMAC-SHA256, Base64URL.
+///
+/// Portable C++ implementation with no external dependencies.
+/// Used internally by PasswordHasher and TokenProvider.
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace cgs::service::detail {
+
+// =============================================================================
+// SHA-256 (FIPS 180-4)
+// =============================================================================
+
+/// Compute SHA-256 digest of the input data.
+/// Returns 32-byte raw digest.
+[[nodiscard]] inline std::array<uint8_t, 32> sha256(const uint8_t* data,
+                                                     std::size_t length) {
+    // Initial hash values (first 32 bits of fractional parts of square roots
+    // of the first 8 primes).
+    uint32_t h0 = 0x6a09e667, h1 = 0xbb67ae85, h2 = 0x3c6ef372,
+             h3 = 0xa54ff53a, h4 = 0x510e527f, h5 = 0x9b05688c,
+             h6 = 0x1f83d9ab, h7 = 0x5be0cd19;
+
+    // Round constants (first 32 bits of fractional parts of cube roots
+    // of the first 64 primes).
+    static constexpr uint32_t k[64] = {
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b,
+        0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01,
+        0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7,
+        0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152,
+        0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+        0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819,
+        0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08,
+        0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f,
+        0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+    auto rotr = [](uint32_t x, unsigned n) -> uint32_t {
+        return (x >> n) | (x << (32 - n));
+    };
+
+    // Pre-processing: pad the message.
+    const uint64_t bitLen = static_cast<uint64_t>(length) * 8;
+    std::vector<uint8_t> msg(data, data + length);
+    msg.push_back(0x80);
+    while ((msg.size() % 64) != 56) {
+        msg.push_back(0x00);
+    }
+    for (int i = 7; i >= 0; --i) {
+        msg.push_back(static_cast<uint8_t>((bitLen >> (i * 8)) & 0xFF));
+    }
+
+    // Process each 512-bit (64-byte) block.
+    for (std::size_t offset = 0; offset < msg.size(); offset += 64) {
+        uint32_t w[64]{};
+        for (int i = 0; i < 16; ++i) {
+            auto base = offset + static_cast<std::size_t>(i) * 4;
+            w[i] = (static_cast<uint32_t>(msg[base]) << 24) |
+                   (static_cast<uint32_t>(msg[base + 1]) << 16) |
+                   (static_cast<uint32_t>(msg[base + 2]) << 8) |
+                   static_cast<uint32_t>(msg[base + 3]);
+        }
+        for (int i = 16; i < 64; ++i) {
+            uint32_t s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^
+                          (w[i - 15] >> 3);
+            uint32_t s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^
+                          (w[i - 2] >> 10);
+            w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+        }
+
+        uint32_t a = h0, b = h1, c = h2, d = h3;
+        uint32_t e = h4, f = h5, g = h6, hh = h7;
+
+        for (int i = 0; i < 64; ++i) {
+            uint32_t S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+            uint32_t ch = (e & f) ^ (~e & g);
+            uint32_t temp1 = hh + S1 + ch + k[i] + w[i];
+            uint32_t S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+            uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+            uint32_t temp2 = S0 + maj;
+
+            hh = g;
+            g = f;
+            f = e;
+            e = d + temp1;
+            d = c;
+            c = b;
+            b = a;
+            a = temp1 + temp2;
+        }
+
+        h0 += a; h1 += b; h2 += c; h3 += d;
+        h4 += e; h5 += f; h6 += g; h7 += hh;
+    }
+
+    std::array<uint8_t, 32> digest{};
+    auto store = [&](int idx, uint32_t val) {
+        digest[static_cast<std::size_t>(idx * 4)] =
+            static_cast<uint8_t>((val >> 24) & 0xFF);
+        digest[static_cast<std::size_t>(idx * 4 + 1)] =
+            static_cast<uint8_t>((val >> 16) & 0xFF);
+        digest[static_cast<std::size_t>(idx * 4 + 2)] =
+            static_cast<uint8_t>((val >> 8) & 0xFF);
+        digest[static_cast<std::size_t>(idx * 4 + 3)] =
+            static_cast<uint8_t>(val & 0xFF);
+    };
+    store(0, h0); store(1, h1); store(2, h2); store(3, h3);
+    store(4, h4); store(5, h5); store(6, h6); store(7, h7);
+    return digest;
+}
+
+/// SHA-256 overload for string_view input.
+[[nodiscard]] inline std::array<uint8_t, 32> sha256(std::string_view input) {
+    return sha256(reinterpret_cast<const uint8_t*>(input.data()), input.size());
+}
+
+// =============================================================================
+// HMAC-SHA256 (RFC 2104)
+// =============================================================================
+
+/// Compute HMAC-SHA256(key, message).
+/// Returns 32-byte raw MAC.
+[[nodiscard]] inline std::array<uint8_t, 32> hmacSha256(
+    std::string_view key, std::string_view message) {
+    constexpr std::size_t blockSize = 64;
+
+    // If key is longer than block size, hash it first.
+    std::array<uint8_t, 32> keyHash{};
+    const uint8_t* keyPtr = nullptr;
+    std::size_t keyLen = 0;
+
+    if (key.size() > blockSize) {
+        keyHash = sha256(key);
+        keyPtr = keyHash.data();
+        keyLen = keyHash.size();
+    } else {
+        keyPtr = reinterpret_cast<const uint8_t*>(key.data());
+        keyLen = key.size();
+    }
+
+    // Zero-pad the key to block size.
+    std::array<uint8_t, blockSize> paddedKey{};
+    std::memcpy(paddedKey.data(), keyPtr, keyLen);
+
+    // Inner and outer padded keys.
+    std::array<uint8_t, blockSize> ipad{};
+    std::array<uint8_t, blockSize> opad{};
+    for (std::size_t i = 0; i < blockSize; ++i) {
+        ipad[i] = paddedKey[i] ^ 0x36;
+        opad[i] = paddedKey[i] ^ 0x5C;
+    }
+
+    // Inner hash: SHA-256(ipad || message)
+    std::vector<uint8_t> innerMsg(ipad.begin(), ipad.end());
+    innerMsg.insert(innerMsg.end(),
+                    reinterpret_cast<const uint8_t*>(message.data()),
+                    reinterpret_cast<const uint8_t*>(message.data()) +
+                        message.size());
+    auto innerHash = sha256(innerMsg.data(), innerMsg.size());
+
+    // Outer hash: SHA-256(opad || innerHash)
+    std::vector<uint8_t> outerMsg(opad.begin(), opad.end());
+    outerMsg.insert(outerMsg.end(), innerHash.begin(), innerHash.end());
+    return sha256(outerMsg.data(), outerMsg.size());
+}
+
+// =============================================================================
+// Base64URL encoding/decoding (RFC 4648 §5)
+// =============================================================================
+
+/// Encode bytes to base64url (no padding).
+[[nodiscard]] inline std::string base64urlEncode(const uint8_t* data,
+                                                  std::size_t length) {
+    static constexpr char table[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    std::string result;
+    result.reserve((length * 4 + 2) / 3);
+
+    for (std::size_t i = 0; i < length; i += 3) {
+        uint32_t n = static_cast<uint32_t>(data[i]) << 16;
+        if (i + 1 < length) {
+            n |= static_cast<uint32_t>(data[i + 1]) << 8;
+        }
+        if (i + 2 < length) {
+            n |= static_cast<uint32_t>(data[i + 2]);
+        }
+
+        result.push_back(table[(n >> 18) & 0x3F]);
+        result.push_back(table[(n >> 12) & 0x3F]);
+        if (i + 1 < length) {
+            result.push_back(table[(n >> 6) & 0x3F]);
+        }
+        if (i + 2 < length) {
+            result.push_back(table[n & 0x3F]);
+        }
+    }
+    return result;
+}
+
+/// Encode a string to base64url.
+[[nodiscard]] inline std::string base64urlEncode(std::string_view input) {
+    return base64urlEncode(reinterpret_cast<const uint8_t*>(input.data()),
+                           input.size());
+}
+
+/// Decode base64url to bytes. Returns empty vector on invalid input.
+[[nodiscard]] inline std::vector<uint8_t> base64urlDecode(
+    std::string_view input) {
+    auto decodeChar = [](char c) -> int {
+        if (c >= 'A' && c <= 'Z') { return c - 'A'; }
+        if (c >= 'a' && c <= 'z') { return c - 'a' + 26; }
+        if (c >= '0' && c <= '9') { return c - '0' + 52; }
+        if (c == '-') { return 62; }
+        if (c == '_') { return 63; }
+        return -1;
+    };
+
+    std::vector<uint8_t> result;
+    result.reserve((input.size() * 3) / 4);
+
+    uint32_t buf = 0;
+    int bits = 0;
+    for (char c : input) {
+        if (c == '=') { break; }
+        int val = decodeChar(c);
+        if (val < 0) { return {}; }
+        buf = (buf << 6) | static_cast<uint32_t>(val);
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            result.push_back(static_cast<uint8_t>((buf >> bits) & 0xFF));
+        }
+    }
+    return result;
+}
+
+/// Decode base64url to string. Returns empty string on invalid input.
+[[nodiscard]] inline std::string base64urlDecodeString(std::string_view input) {
+    auto bytes = base64urlDecode(input);
+    return {bytes.begin(), bytes.end()};
+}
+
+// =============================================================================
+// Hex encoding
+// =============================================================================
+
+/// Encode bytes to lowercase hex string.
+[[nodiscard]] inline std::string toHex(const uint8_t* data,
+                                        std::size_t length) {
+    static constexpr char hexChars[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(length * 2);
+    for (std::size_t i = 0; i < length; ++i) {
+        result.push_back(hexChars[(data[i] >> 4) & 0x0F]);
+        result.push_back(hexChars[data[i] & 0x0F]);
+    }
+    return result;
+}
+
+/// Encode a 32-byte array to hex string.
+[[nodiscard]] inline std::string toHex(const std::array<uint8_t, 32>& data) {
+    return toHex(data.data(), data.size());
+}
+
+// =============================================================================
+// Secure random generation
+// =============================================================================
+
+/// Generate N bytes of cryptographic-quality random data (hex-encoded).
+[[nodiscard]] inline std::string secureRandomHex(std::size_t numBytes) {
+    std::random_device rd;
+    std::vector<uint8_t> buf(numBytes);
+    for (auto& b : buf) {
+        b = static_cast<uint8_t>(rd());
+    }
+    return toHex(buf.data(), buf.size());
+}
+
+// =============================================================================
+// Constant-time comparison
+// =============================================================================
+
+/// Compare two strings in constant time to prevent timing attacks.
+[[nodiscard]] inline bool constantTimeEqual(std::string_view a,
+                                             std::string_view b) {
+    if (a.size() != b.size()) { return false; }
+    volatile uint8_t diff = 0;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        diff |= static_cast<uint8_t>(a[i]) ^ static_cast<uint8_t>(b[i]);
+    }
+    return diff == 0;
+}
+
+} // namespace cgs::service::detail

--- a/src/services/auth/password_hasher.cpp
+++ b/src/services/auth/password_hasher.cpp
@@ -1,0 +1,43 @@
+/// @file password_hasher.cpp
+/// @brief PasswordHasher implementation using SHA-256 + random salt.
+///
+/// Production deployments should replace this with bcrypt (cost >= 12)
+/// or argon2id via a foundation CryptoAdapter.
+///
+/// @see SRS-SVC-001.6
+
+#include "cgs/service/password_hasher.hpp"
+
+#include "crypto_utils.hpp"
+
+namespace cgs::service {
+
+HashedPassword PasswordHasher::hash(std::string_view password) const {
+    auto salt = generateSalt();
+    auto digest = hashWithSalt(password, salt);
+    return {std::move(digest), std::move(salt)};
+}
+
+std::string PasswordHasher::hashWithSalt(std::string_view password,
+                                          std::string_view salt) const {
+    // SHA-256(salt + password)
+    std::string combined;
+    combined.reserve(salt.size() + password.size());
+    combined.append(salt);
+    combined.append(password);
+    auto digest = detail::sha256(combined);
+    return detail::toHex(digest);
+}
+
+bool PasswordHasher::verify(std::string_view password,
+                             std::string_view storedHash,
+                             std::string_view salt) const {
+    auto computed = hashWithSalt(password, salt);
+    return detail::constantTimeEqual(computed, storedHash);
+}
+
+std::string PasswordHasher::generateSalt() {
+    return detail::secureRandomHex(16); // 16 bytes → 32 hex chars
+}
+
+} // namespace cgs::service

--- a/src/services/auth/token_provider.cpp
+++ b/src/services/auth/token_provider.cpp
@@ -1,0 +1,228 @@
+/// @file token_provider.cpp
+/// @brief TokenProvider implementation generating HMAC-SHA256 signed JWTs.
+///
+/// Token format (RFC 7519):
+///   base64url(header) . base64url(payload) . base64url(signature)
+///
+/// Header:  {"alg":"HS256","typ":"JWT"}
+/// Payload: {"sub":"...","usr":"...","roles":[...],"iat":N,"exp":N}
+///
+/// @see SRS-SVC-001.3
+/// @see SRS-SVC-001.4
+
+#include "cgs/service/token_provider.hpp"
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/foundation/game_error.hpp"
+#include "crypto_utils.hpp"
+
+#include <charconv>
+#include <sstream>
+#include <string>
+
+namespace cgs::service {
+
+using cgs::foundation::ErrorCode;
+using cgs::foundation::GameError;
+
+// ---------------------------------------------------------------------------
+// Minimal JSON helpers (no external dependency)
+// ---------------------------------------------------------------------------
+namespace {
+
+/// Escape a string for JSON output.
+std::string jsonEscape(std::string_view s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    out.push_back('"');
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:   out.push_back(c); break;
+        }
+    }
+    out.push_back('"');
+    return out;
+}
+
+/// Convert time_point to seconds since epoch.
+int64_t toEpoch(std::chrono::system_clock::time_point tp) {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               tp.time_since_epoch())
+        .count();
+}
+
+/// Convert seconds-since-epoch to time_point.
+std::chrono::system_clock::time_point fromEpoch(int64_t epoch) {
+    return std::chrono::system_clock::time_point(std::chrono::seconds(epoch));
+}
+
+/// Split a string by delimiter, returning up to maxParts parts.
+std::vector<std::string> split(std::string_view s, char delim,
+                                std::size_t maxParts = 0) {
+    std::vector<std::string> parts;
+    std::size_t start = 0;
+    while (start < s.size()) {
+        if (maxParts > 0 && parts.size() + 1 >= maxParts) {
+            parts.emplace_back(s.substr(start));
+            return parts;
+        }
+        auto pos = s.find(delim, start);
+        if (pos == std::string_view::npos) {
+            parts.emplace_back(s.substr(start));
+            break;
+        }
+        parts.emplace_back(s.substr(start, pos - start));
+        start = pos + 1;
+    }
+    return parts;
+}
+
+/// Extract a JSON string value by key (simple parser for flat objects).
+std::string extractJsonString(std::string_view json, std::string_view key) {
+    std::string needle = "\"" + std::string(key) + "\":\"";
+    auto pos = json.find(needle);
+    if (pos == std::string_view::npos) { return {}; }
+    pos += needle.size();
+    auto end = json.find('"', pos);
+    if (end == std::string_view::npos) { return {}; }
+    return std::string(json.substr(pos, end - pos));
+}
+
+/// Extract a JSON integer value by key.
+int64_t extractJsonInt(std::string_view json, std::string_view key) {
+    std::string needle = "\"" + std::string(key) + "\":";
+    auto pos = json.find(needle);
+    if (pos == std::string_view::npos) { return 0; }
+    pos += needle.size();
+    // Skip whitespace
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t')) {
+        ++pos;
+    }
+    int64_t result = 0;
+    auto [ptr, ec] = std::from_chars(json.data() + pos,
+                                      json.data() + json.size(), result);
+    if (ec != std::errc{}) { return 0; }
+    return result;
+}
+
+/// Extract a JSON string array by key (simple parser).
+std::vector<std::string> extractJsonStringArray(std::string_view json,
+                                                 std::string_view key) {
+    std::vector<std::string> result;
+    std::string needle = "\"" + std::string(key) + "\":[";
+    auto pos = json.find(needle);
+    if (pos == std::string_view::npos) { return result; }
+    pos += needle.size();
+    auto end = json.find(']', pos);
+    if (end == std::string_view::npos) { return result; }
+    auto arrayContent = json.substr(pos, end - pos);
+
+    std::size_t cur = 0;
+    while (cur < arrayContent.size()) {
+        auto qStart = arrayContent.find('"', cur);
+        if (qStart == std::string_view::npos) { break; }
+        auto qEnd = arrayContent.find('"', qStart + 1);
+        if (qEnd == std::string_view::npos) { break; }
+        result.emplace_back(arrayContent.substr(qStart + 1, qEnd - qStart - 1));
+        cur = qEnd + 1;
+    }
+    return result;
+}
+
+} // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// TokenProvider
+// ---------------------------------------------------------------------------
+
+TokenProvider::TokenProvider(std::string signingKey)
+    : signingKey_(std::move(signingKey)) {}
+
+std::string TokenProvider::generateAccessToken(
+    const TokenClaims& claims, std::chrono::seconds expiry) const {
+    // Header (fixed for HS256).
+    static const std::string header = R"({"alg":"HS256","typ":"JWT"})";
+    auto encodedHeader = detail::base64urlEncode(header);
+
+    // Compute timestamps.
+    auto now = std::chrono::system_clock::now();
+    auto iat = toEpoch(claims.issuedAt.time_since_epoch().count() > 0
+                           ? claims.issuedAt
+                           : now);
+    auto exp = toEpoch(now + expiry);
+
+    // Build payload JSON.
+    std::ostringstream payload;
+    payload << "{\"sub\":" << jsonEscape(claims.subject)
+            << ",\"usr\":" << jsonEscape(claims.username)
+            << ",\"roles\":[";
+    for (std::size_t i = 0; i < claims.roles.size(); ++i) {
+        if (i > 0) { payload << ","; }
+        payload << jsonEscape(claims.roles[i]);
+    }
+    payload << "],\"iat\":" << iat << ",\"exp\":" << exp << "}";
+
+    auto encodedPayload = detail::base64urlEncode(payload.str());
+
+    // Sign: HMAC-SHA256(key, header.payload)
+    std::string signingInput = encodedHeader + "." + encodedPayload;
+    auto mac = detail::hmacSha256(signingKey_, signingInput);
+    auto encodedSignature = detail::base64urlEncode(mac.data(), mac.size());
+
+    return signingInput + "." + encodedSignature;
+}
+
+cgs::foundation::GameResult<TokenClaims> TokenProvider::validateAccessToken(
+    std::string_view token) const {
+    // Split into 3 parts: header.payload.signature
+    auto parts = split(token, '.', 3);
+    if (parts.size() != 3) {
+        return cgs::foundation::GameResult<TokenClaims>::err(
+            GameError(ErrorCode::InvalidToken, "malformed JWT: expected 3 parts"));
+    }
+
+    // Verify signature.
+    std::string signingInput = parts[0] + "." + parts[1];
+    auto expectedMac = detail::hmacSha256(signingKey_, signingInput);
+    auto expectedSig = detail::base64urlEncode(expectedMac.data(),
+                                                expectedMac.size());
+    if (!detail::constantTimeEqual(expectedSig, parts[2])) {
+        return cgs::foundation::GameResult<TokenClaims>::err(
+            GameError(ErrorCode::InvalidToken, "invalid signature"));
+    }
+
+    // Decode payload.
+    auto payloadJson = detail::base64urlDecodeString(parts[1]);
+    if (payloadJson.empty()) {
+        return cgs::foundation::GameResult<TokenClaims>::err(
+            GameError(ErrorCode::InvalidToken, "failed to decode payload"));
+    }
+
+    // Parse claims.
+    TokenClaims claims;
+    claims.subject = extractJsonString(payloadJson, "sub");
+    claims.username = extractJsonString(payloadJson, "usr");
+    claims.roles = extractJsonStringArray(payloadJson, "roles");
+    claims.issuedAt = fromEpoch(extractJsonInt(payloadJson, "iat"));
+    claims.expiresAt = fromEpoch(extractJsonInt(payloadJson, "exp"));
+
+    // Check expiry.
+    auto now = std::chrono::system_clock::now();
+    if (now > claims.expiresAt) {
+        return cgs::foundation::GameResult<TokenClaims>::err(
+            GameError(ErrorCode::TokenExpired, "access token has expired"));
+    }
+
+    return cgs::foundation::GameResult<TokenClaims>::ok(std::move(claims));
+}
+
+std::string TokenProvider::generateRefreshToken() {
+    return detail::secureRandomHex(32); // 32 bytes → 64 hex chars
+}
+
+} // namespace cgs::service

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -219,6 +219,16 @@ target_link_libraries(cgs_game_inventory_system_tests PRIVATE
 )
 gtest_discover_tests(cgs_game_inventory_system_tests)
 
+# Unit tests - Service auth (password hashing, token provider)
+add_executable(cgs_service_auth_tests
+    unit/service/auth_crypto_test.cpp
+)
+target_link_libraries(cgs_service_auth_tests PRIVATE
+    cgs::service_auth
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_service_auth_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/service/auth_crypto_test.cpp
+++ b/tests/unit/service/auth_crypto_test.cpp
@@ -1,0 +1,299 @@
+#include <gtest/gtest.h>
+
+#include "cgs/service/auth_types.hpp"
+#include "cgs/service/password_hasher.hpp"
+#include "cgs/service/token_provider.hpp"
+
+#include <chrono>
+#include <set>
+#include <string>
+#include <thread>
+
+using namespace cgs::service;
+
+// =============================================================================
+// AuthTypes tests
+// =============================================================================
+
+TEST(AuthTypesTest, DefaultAuthConfig) {
+    AuthConfig config;
+    EXPECT_EQ(config.accessTokenExpiry, std::chrono::seconds{900});
+    EXPECT_EQ(config.refreshTokenExpiry, std::chrono::seconds{604800});
+    EXPECT_EQ(config.minPasswordLength, 8u);
+    EXPECT_EQ(config.rateLimitMaxAttempts, 5u);
+    EXPECT_EQ(config.rateLimitWindow, std::chrono::seconds{60});
+}
+
+TEST(AuthTypesTest, DefaultUserRecord) {
+    UserRecord record;
+    EXPECT_EQ(record.id, 0u);
+    EXPECT_TRUE(record.username.empty());
+    EXPECT_TRUE(record.email.empty());
+    EXPECT_TRUE(record.passwordHash.empty());
+    EXPECT_TRUE(record.salt.empty());
+    EXPECT_EQ(record.status, UserStatus::Active);
+    EXPECT_TRUE(record.roles.empty());
+}
+
+TEST(AuthTypesTest, DefaultTokenPair) {
+    TokenPair pair;
+    EXPECT_TRUE(pair.accessToken.empty());
+    EXPECT_TRUE(pair.refreshToken.empty());
+    EXPECT_EQ(pair.accessExpiresIn, std::chrono::seconds{0});
+    EXPECT_EQ(pair.refreshExpiresIn, std::chrono::seconds{0});
+}
+
+TEST(AuthTypesTest, DefaultRefreshTokenRecord) {
+    RefreshTokenRecord record;
+    EXPECT_TRUE(record.token.empty());
+    EXPECT_EQ(record.userId, 0u);
+    EXPECT_FALSE(record.revoked);
+}
+
+// =============================================================================
+// PasswordHasher tests (SRS-SVC-001.6)
+// =============================================================================
+
+class PasswordHasherTest : public ::testing::Test {
+protected:
+    PasswordHasher hasher;
+};
+
+TEST_F(PasswordHasherTest, HashProducesSaltAndHash) {
+    auto result = hasher.hash("password123");
+    EXPECT_FALSE(result.hash.empty());
+    EXPECT_FALSE(result.salt.empty());
+    // SHA-256 hex output is 64 characters.
+    EXPECT_EQ(result.hash.size(), 64u);
+    // Salt is 16 bytes → 32 hex chars.
+    EXPECT_EQ(result.salt.size(), 32u);
+}
+
+TEST_F(PasswordHasherTest, SamePasswordDifferentSalts) {
+    auto r1 = hasher.hash("password123");
+    auto r2 = hasher.hash("password123");
+
+    // Salts should differ (random).
+    EXPECT_NE(r1.salt, r2.salt);
+    // Hashes should differ (different salts).
+    EXPECT_NE(r1.hash, r2.hash);
+}
+
+TEST_F(PasswordHasherTest, VerifyCorrectPassword) {
+    auto result = hasher.hash("my_secret_pass");
+    EXPECT_TRUE(hasher.verify("my_secret_pass", result.hash, result.salt));
+}
+
+TEST_F(PasswordHasherTest, VerifyWrongPassword) {
+    auto result = hasher.hash("correct_password");
+    EXPECT_FALSE(hasher.verify("wrong_password", result.hash, result.salt));
+}
+
+TEST_F(PasswordHasherTest, VerifyWrongSalt) {
+    auto result = hasher.hash("password123");
+    auto otherSalt = PasswordHasher::generateSalt();
+    EXPECT_FALSE(hasher.verify("password123", result.hash, otherSalt));
+}
+
+TEST_F(PasswordHasherTest, VerifyEmptyPassword) {
+    auto result = hasher.hash("");
+    EXPECT_TRUE(hasher.verify("", result.hash, result.salt));
+    EXPECT_FALSE(hasher.verify("not_empty", result.hash, result.salt));
+}
+
+TEST_F(PasswordHasherTest, DeterministicWithSameSalt) {
+    auto salt = PasswordHasher::generateSalt();
+    auto hash1 = hasher.hashWithSalt("test_password", salt);
+    auto hash2 = hasher.hashWithSalt("test_password", salt);
+    EXPECT_EQ(hash1, hash2);
+}
+
+TEST_F(PasswordHasherTest, PasswordNotStoredInPlaintext) {
+    auto result = hasher.hash("plaintext_password");
+    // Hash should not contain the original password.
+    EXPECT_EQ(result.hash.find("plaintext_password"), std::string::npos);
+    EXPECT_EQ(result.salt.find("plaintext_password"), std::string::npos);
+}
+
+TEST_F(PasswordHasherTest, GenerateSaltUniqueness) {
+    std::set<std::string> salts;
+    for (int i = 0; i < 100; ++i) {
+        salts.insert(PasswordHasher::generateSalt());
+    }
+    // All 100 salts should be unique.
+    EXPECT_EQ(salts.size(), 100u);
+}
+
+// =============================================================================
+// TokenProvider tests (SRS-SVC-001.3, SRS-SVC-001.4)
+// =============================================================================
+
+class TokenProviderTest : public ::testing::Test {
+protected:
+    static constexpr auto kSigningKey =
+        "test-signing-key-must-be-at-least-32-bytes!!";
+    TokenProvider provider{kSigningKey};
+
+    TokenClaims makeTestClaims() {
+        TokenClaims claims;
+        claims.subject = "user-123";
+        claims.username = "testuser";
+        claims.roles = {"player", "admin"};
+        return claims;
+    }
+};
+
+TEST_F(TokenProviderTest, GenerateAccessToken) {
+    auto claims = makeTestClaims();
+    auto token = provider.generateAccessToken(claims, std::chrono::seconds{900});
+
+    EXPECT_FALSE(token.empty());
+    // JWT has 3 parts separated by dots.
+    int dotCount = 0;
+    for (char c : token) {
+        if (c == '.') { ++dotCount; }
+    }
+    EXPECT_EQ(dotCount, 2);
+}
+
+TEST_F(TokenProviderTest, ValidateAccessToken) {
+    auto claims = makeTestClaims();
+    auto token = provider.generateAccessToken(claims, std::chrono::seconds{900});
+
+    auto result = provider.validateAccessToken(token);
+    ASSERT_TRUE(result.hasValue());
+
+    auto& decoded = result.value();
+    EXPECT_EQ(decoded.subject, "user-123");
+    EXPECT_EQ(decoded.username, "testuser");
+    ASSERT_EQ(decoded.roles.size(), 2u);
+    EXPECT_EQ(decoded.roles[0], "player");
+    EXPECT_EQ(decoded.roles[1], "admin");
+}
+
+TEST_F(TokenProviderTest, ValidateExpiredToken) {
+    auto claims = makeTestClaims();
+    // Token that expires in 0 seconds (immediately expired).
+    auto token = provider.generateAccessToken(claims, std::chrono::seconds{0});
+
+    // Wait a moment to ensure expiry.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto result = provider.validateAccessToken(token);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(),
+              cgs::foundation::ErrorCode::TokenExpired);
+}
+
+TEST_F(TokenProviderTest, ValidateTamperedToken) {
+    auto claims = makeTestClaims();
+    auto token = provider.generateAccessToken(claims, std::chrono::seconds{900});
+
+    // Tamper with the payload (change a character).
+    auto tampered = token;
+    auto firstDot = tampered.find('.');
+    auto secondDot = tampered.find('.', firstDot + 1);
+    if (secondDot > firstDot + 2) {
+        tampered[firstDot + 1] =
+            (tampered[firstDot + 1] == 'A') ? 'B' : 'A';
+    }
+
+    auto result = provider.validateAccessToken(tampered);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(),
+              cgs::foundation::ErrorCode::InvalidToken);
+}
+
+TEST_F(TokenProviderTest, ValidateMalformedToken) {
+    auto result = provider.validateAccessToken("not.a.valid.jwt.token");
+    ASSERT_TRUE(result.hasError());
+
+    auto result2 = provider.validateAccessToken("no-dots-at-all");
+    ASSERT_TRUE(result2.hasError());
+
+    auto result3 = provider.validateAccessToken("only.one");
+    ASSERT_TRUE(result3.hasError());
+}
+
+TEST_F(TokenProviderTest, ValidateWrongSigningKey) {
+    auto claims = makeTestClaims();
+    auto token = provider.generateAccessToken(claims, std::chrono::seconds{900});
+
+    // Validate with a different key.
+    TokenProvider otherProvider("different-signing-key-also-32-bytes!!");
+    auto result = otherProvider.validateAccessToken(token);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(),
+              cgs::foundation::ErrorCode::InvalidToken);
+}
+
+TEST_F(TokenProviderTest, GenerateRefreshTokenIsRandom) {
+    std::set<std::string> tokens;
+    for (int i = 0; i < 100; ++i) {
+        tokens.insert(TokenProvider::generateRefreshToken());
+    }
+    EXPECT_EQ(tokens.size(), 100u);
+}
+
+TEST_F(TokenProviderTest, RefreshTokenLength) {
+    auto token = TokenProvider::generateRefreshToken();
+    // 32 bytes → 64 hex chars.
+    EXPECT_EQ(token.size(), 64u);
+}
+
+TEST_F(TokenProviderTest, TokenClaimsTimestamps) {
+    auto claims = makeTestClaims();
+    auto beforeGen = std::chrono::system_clock::now();
+    auto token = provider.generateAccessToken(claims, std::chrono::seconds{300});
+    auto afterGen = std::chrono::system_clock::now();
+
+    auto result = provider.validateAccessToken(token);
+    ASSERT_TRUE(result.hasValue());
+
+    auto& decoded = result.value();
+
+    // iat should be approximately now.
+    auto iatDiff = std::chrono::duration_cast<std::chrono::seconds>(
+                       decoded.issuedAt - beforeGen)
+                       .count();
+    EXPECT_GE(iatDiff, -1);
+    EXPECT_LE(iatDiff, 2);
+
+    // exp should be approximately now + 300s.
+    auto expDiff = std::chrono::duration_cast<std::chrono::seconds>(
+                       decoded.expiresAt - afterGen)
+                       .count();
+    EXPECT_GE(expDiff, 298);
+    EXPECT_LE(expDiff, 302);
+}
+
+TEST_F(TokenProviderTest, EmptyRoles) {
+    TokenClaims claims;
+    claims.subject = "user-456";
+    claims.username = "noroles";
+
+    auto token = provider.generateAccessToken(claims, std::chrono::seconds{60});
+    auto result = provider.validateAccessToken(token);
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_TRUE(result.value().roles.empty());
+}
+
+TEST_F(TokenProviderTest, SpecialCharactersInClaims) {
+    TokenClaims claims;
+    claims.subject = "user with spaces";
+    claims.username = "user@domain.com";
+    claims.roles = {"role\"with\"quotes"};
+
+    auto token = provider.generateAccessToken(claims, std::chrono::seconds{60});
+    auto result = provider.validateAccessToken(token);
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().subject, "user with spaces");
+    EXPECT_EQ(result.value().username, "user@domain.com");
+}
+
+TEST_F(TokenProviderTest, EmptyTokenString) {
+    auto result = provider.validateAccessToken("");
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(),
+              cgs::foundation::ErrorCode::InvalidToken);
+}


### PR DESCRIPTION
## Summary

Implements the foundation layer for the Authentication Server (Part 1 of #22):

- **Auth type definitions** (`include/cgs/service/auth_types.hpp`): UserRecord, TokenPair, TokenClaims, AuthConfig, UserCredentials, RefreshTokenRecord
- **Password hashing** (`password_hasher.hpp/.cpp`): SHA-256 + random salt with constant-time verification
- **JWT token provider** (`token_provider.hpp/.cpp`): HMAC-SHA256 (HS256) signed tokens with expiry validation
- **Internal crypto utilities** (`crypto_utils.hpp`): Portable SHA-256, HMAC-SHA256, Base64URL, secure random
- **Error codes**: Added 7 new auth error codes (UserAlreadyExists, InvalidEmail, WeakPassword, etc.)
- **Service layer CMake**: Created `src/services/` infrastructure, enabled in root CMakeLists.txt

Closes #58

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| HMAC-SHA256 (HS256) over RS256 | Self-contained without RSA dependency; interface ready for RS256 via crypto adapter |
| SHA-256 + salt over bcrypt | No external crypto library; documented upgrade path to bcrypt/argon2id |
| Header-only crypto utils | Minimal build complexity, portable across platforms |
| Constant-time comparison | Prevents timing side-channel attacks on hash/signature verification |

## Test Plan

- [x] 25 unit tests all passing (AuthTypes: 4, PasswordHasher: 9, TokenProvider: 12)
- [x] Full project build succeeds (899/899 tests pass)
- [x] Tests cover: hash determinism, salt uniqueness, token expiry, signature tampering, wrong key, special characters, empty inputs