### PR TITLE
feat(service): add Authentication Server (SRS-SVC-001)

### DIFF
--- a/include/cgs/service/rate_limiter.hpp
+++ b/include/cgs/service/rate_limiter.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+/// @file rate_limiter.hpp
+/// @brief Sliding-window rate limiter for login attempt throttling.
+///
+/// Tracks timestamps of recent attempts per key (typically client IP)
+/// within a configurable time window.
+///
+/// @see SRS-SVC-001 (rate limiting on login attempts)
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace cgs::service {
+
+/// Sliding-window rate limiter.
+///
+/// Example:
+/// @code
+///   RateLimiter limiter(5, std::chrono::seconds{60});
+///   if (!limiter.allow("192.168.1.1")) {
+///       // Rate limit exceeded
+///   }
+/// @endcode
+class RateLimiter {
+public:
+    /// Construct with max attempts allowed per window duration.
+    RateLimiter(uint32_t maxAttempts, std::chrono::seconds window);
+
+    /// Record an attempt for the given key.
+    /// Returns true if the attempt is allowed, false if rate limit exceeded.
+    [[nodiscard]] bool allow(const std::string& key);
+
+    /// Get remaining attempts for the given key within the current window.
+    [[nodiscard]] uint32_t remaining(const std::string& key) const;
+
+    /// Reset all tracked attempts for the given key.
+    void reset(const std::string& key);
+
+private:
+    using TimePoint = std::chrono::steady_clock::time_point;
+
+    void purgeExpired(std::deque<TimePoint>& timestamps) const;
+
+    uint32_t maxAttempts_;
+    std::chrono::seconds window_;
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, std::deque<TimePoint>> attempts_;
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/token_store.hpp
+++ b/include/cgs/service/token_store.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+/// @file token_store.hpp
+/// @brief Refresh token persistence interface and in-memory implementation.
+///
+/// Abstracts refresh token storage so the AuthServer can work with any
+/// backend (in-memory, Redis, SQL database, etc.).
+///
+/// @see SRS-SVC-001.4
+/// @see SRS-SVC-001.5
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "cgs/service/auth_types.hpp"
+
+namespace cgs::service {
+
+/// Abstract interface for refresh token persistence.
+///
+/// Implementations must be thread-safe when shared across threads.
+class ITokenStore {
+public:
+    virtual ~ITokenStore() = default;
+
+    /// Store a new refresh token record.
+    virtual void store(RefreshTokenRecord record) = 0;
+
+    /// Find a refresh token by its value.
+    [[nodiscard]] virtual std::optional<RefreshTokenRecord> find(
+        std::string_view token) const = 0;
+
+    /// Revoke a specific refresh token. Returns false if not found.
+    virtual bool revoke(std::string_view token) = 0;
+
+    /// Revoke all refresh tokens belonging to a user.
+    virtual void revokeAllForUser(uint64_t userId) = 0;
+
+    /// Remove expired tokens to reclaim memory.
+    virtual void removeExpired() = 0;
+};
+
+/// Thread-safe in-memory refresh token store for testing and development.
+///
+/// Production deployments should use a persistent store (Redis, database).
+class InMemoryTokenStore : public ITokenStore {
+public:
+    void store(RefreshTokenRecord record) override;
+
+    [[nodiscard]] std::optional<RefreshTokenRecord> find(
+        std::string_view token) const override;
+
+    bool revoke(std::string_view token) override;
+
+    void revokeAllForUser(uint64_t userId) override;
+
+    void removeExpired() override;
+
+private:
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, RefreshTokenRecord> tokens_;
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/user_repository.hpp
+++ b/include/cgs/service/user_repository.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+/// @file user_repository.hpp
+/// @brief User persistence interface and in-memory implementation.
+///
+/// Abstracts user storage so the AuthServer can work with any backend
+/// (in-memory, SQL database via DatabaseAdapter, etc.).
+///
+/// @see SRS-SVC-001.1
+/// @see SRS-SVC-001.2
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+
+#include "cgs/service/auth_types.hpp"
+
+namespace cgs::service {
+
+/// Abstract interface for user persistence.
+///
+/// Implementations must be thread-safe when shared across threads.
+class IUserRepository {
+public:
+    virtual ~IUserRepository() = default;
+
+    /// Find a user by their unique ID.
+    [[nodiscard]] virtual std::optional<UserRecord> findById(
+        uint64_t id) const = 0;
+
+    /// Find a user by username (case-sensitive).
+    [[nodiscard]] virtual std::optional<UserRecord> findByUsername(
+        std::string_view username) const = 0;
+
+    /// Find a user by email (case-sensitive).
+    [[nodiscard]] virtual std::optional<UserRecord> findByEmail(
+        std::string_view email) const = 0;
+
+    /// Create a new user, returning the assigned ID.
+    virtual uint64_t create(UserRecord record) = 0;
+
+    /// Update an existing user record. Returns false if user not found.
+    virtual bool update(const UserRecord& record) = 0;
+};
+
+/// Thread-safe in-memory user repository for testing and development.
+///
+/// Production deployments should use a DatabaseAdapter-backed implementation.
+class InMemoryUserRepository : public IUserRepository {
+public:
+    [[nodiscard]] std::optional<UserRecord> findById(
+        uint64_t id) const override;
+
+    [[nodiscard]] std::optional<UserRecord> findByUsername(
+        std::string_view username) const override;
+
+    [[nodiscard]] std::optional<UserRecord> findByEmail(
+        std::string_view email) const override;
+
+    uint64_t create(UserRecord record) override;
+
+    bool update(const UserRecord& record) override;
+
+private:
+    mutable std::mutex mutex_;
+    std::unordered_map<uint64_t, UserRecord> users_;
+    uint64_t nextId_ = 1;
+};
+
+} // namespace cgs::service

--- a/src/services/auth/CMakeLists.txt
+++ b/src/services/auth/CMakeLists.txt
@@ -1,7 +1,11 @@
-# Auth Service - Types, Password Hashing, Token Provider (SDS-MOD-040)
+# Auth Service - Authentication Server (SDS-MOD-040)
 add_library(cgs_service_auth
     password_hasher.cpp
     token_provider.cpp
+    user_repository.cpp
+    token_store.cpp
+    rate_limiter.cpp
+    auth_server.cpp
 )
 target_include_directories(cgs_service_auth
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/services/auth/rate_limiter.cpp
+++ b/src/services/auth/rate_limiter.cpp
@@ -1,0 +1,50 @@
+/// @file rate_limiter.cpp
+/// @brief Sliding-window RateLimiter implementation.
+
+#include "cgs/service/rate_limiter.hpp"
+
+namespace cgs::service {
+
+RateLimiter::RateLimiter(uint32_t maxAttempts, std::chrono::seconds window)
+    : maxAttempts_(maxAttempts), window_(window) {}
+
+bool RateLimiter::allow(const std::string& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto& timestamps = attempts_[key];
+    purgeExpired(timestamps);
+
+    if (timestamps.size() >= static_cast<std::size_t>(maxAttempts_)) {
+        return false;
+    }
+
+    timestamps.push_back(std::chrono::steady_clock::now());
+    return true;
+}
+
+uint32_t RateLimiter::remaining(const std::string& key) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = attempts_.find(key);
+    if (it == attempts_.end()) {
+        return maxAttempts_;
+    }
+
+    auto timestamps = it->second; // copy to purge
+    purgeExpired(timestamps);
+
+    auto used = static_cast<uint32_t>(timestamps.size());
+    return (used >= maxAttempts_) ? 0u : (maxAttempts_ - used);
+}
+
+void RateLimiter::reset(const std::string& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    attempts_.erase(key);
+}
+
+void RateLimiter::purgeExpired(std::deque<TimePoint>& timestamps) const {
+    auto cutoff = std::chrono::steady_clock::now() - window_;
+    while (!timestamps.empty() && timestamps.front() < cutoff) {
+        timestamps.pop_front();
+    }
+}
+
+} // namespace cgs::service

--- a/src/services/auth/token_store.cpp
+++ b/src/services/auth/token_store.cpp
@@ -1,0 +1,57 @@
+/// @file token_store.cpp
+/// @brief InMemoryTokenStore implementation.
+
+#include "cgs/service/token_store.hpp"
+
+#include <chrono>
+
+namespace cgs::service {
+
+void InMemoryTokenStore::store(RefreshTokenRecord record) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto key = record.token;
+    tokens_.emplace(std::move(key), std::move(record));
+}
+
+std::optional<RefreshTokenRecord> InMemoryTokenStore::find(
+    std::string_view token) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = tokens_.find(std::string(token));
+    if (it == tokens_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+bool InMemoryTokenStore::revoke(std::string_view token) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = tokens_.find(std::string(token));
+    if (it == tokens_.end()) {
+        return false;
+    }
+    it->second.revoked = true;
+    return true;
+}
+
+void InMemoryTokenStore::revokeAllForUser(uint64_t userId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& [key, record] : tokens_) {
+        if (record.userId == userId) {
+            record.revoked = true;
+        }
+    }
+}
+
+void InMemoryTokenStore::removeExpired() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto now = std::chrono::system_clock::now();
+    for (auto it = tokens_.begin(); it != tokens_.end();) {
+        if (it->second.expiresAt <= now || it->second.revoked) {
+            it = tokens_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+} // namespace cgs::service

--- a/src/services/auth/user_repository.cpp
+++ b/src/services/auth/user_repository.cpp
@@ -1,0 +1,63 @@
+/// @file user_repository.cpp
+/// @brief InMemoryUserRepository implementation.
+
+#include "cgs/service/user_repository.hpp"
+
+#include <chrono>
+
+namespace cgs::service {
+
+std::optional<UserRecord> InMemoryUserRepository::findById(uint64_t id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = users_.find(id);
+    if (it == users_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::optional<UserRecord> InMemoryUserRepository::findByUsername(
+    std::string_view username) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& [id, user] : users_) {
+        if (user.username == username) {
+            return user;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<UserRecord> InMemoryUserRepository::findByEmail(
+    std::string_view email) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& [id, user] : users_) {
+        if (user.email == email) {
+            return user;
+        }
+    }
+    return std::nullopt;
+}
+
+uint64_t InMemoryUserRepository::create(UserRecord record) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto id = nextId_++;
+    record.id = id;
+    auto now = std::chrono::system_clock::now();
+    record.createdAt = now;
+    record.updatedAt = now;
+    users_.emplace(id, std::move(record));
+    return id;
+}
+
+bool InMemoryUserRepository::update(const UserRecord& record) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = users_.find(record.id);
+    if (it == users_.end()) {
+        return false;
+    }
+    it->second = record;
+    it->second.updatedAt = std::chrono::system_clock::now();
+    return true;
+}
+
+} // namespace cgs::service

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -229,6 +229,16 @@ target_link_libraries(cgs_service_auth_tests PRIVATE
 )
 gtest_discover_tests(cgs_service_auth_tests)
 
+# Unit tests - Service auth server (registration, login, token management)
+add_executable(cgs_service_auth_server_tests
+    unit/service/auth_server_test.cpp
+)
+target_link_libraries(cgs_service_auth_server_tests PRIVATE
+    cgs::service_auth
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_service_auth_server_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/service/auth_server_test.cpp
+++ b/tests/unit/service/auth_server_test.cpp
@@ -1,0 +1,559 @@
+#include <gtest/gtest.h>
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/service/auth_server.hpp"
+#include "cgs/service/auth_types.hpp"
+#include "cgs/service/rate_limiter.hpp"
+#include "cgs/service/token_store.hpp"
+#include "cgs/service/user_repository.hpp"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+using namespace cgs::service;
+using cgs::foundation::ErrorCode;
+
+// =============================================================================
+// Test fixture
+// =============================================================================
+
+class AuthServerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        userRepo_ = std::make_shared<InMemoryUserRepository>();
+        tokenStore_ = std::make_shared<InMemoryTokenStore>();
+
+        AuthConfig config;
+        config.signingKey = "test-key-must-be-at-least-32-bytes-long!!";
+        config.accessTokenExpiry = std::chrono::seconds{300};
+        config.refreshTokenExpiry = std::chrono::seconds{3600};
+        config.minPasswordLength = 8;
+        config.rateLimitMaxAttempts = 3;
+        config.rateLimitWindow = std::chrono::seconds{60};
+
+        server_ = std::make_unique<AuthServer>(
+            std::move(config), userRepo_, tokenStore_);
+    }
+
+    static UserCredentials validCredentials() {
+        return {"testuser", "test@example.com", "StrongPass1!"};
+    }
+
+    /// Register and assert success (avoids nodiscard warnings in setup).
+    void registerTestUser() {
+        auto result = server_->registerUser(validCredentials());
+        ASSERT_TRUE(result.hasValue());
+    }
+
+    std::shared_ptr<InMemoryUserRepository> userRepo_;
+    std::shared_ptr<InMemoryTokenStore> tokenStore_;
+    std::unique_ptr<AuthServer> server_;
+};
+
+// =============================================================================
+// Registration tests (SRS-SVC-001.1)
+// =============================================================================
+
+TEST_F(AuthServerTest, RegisterUserSuccess) {
+    auto result = server_->registerUser(validCredentials());
+    ASSERT_TRUE(result.hasValue());
+
+    auto& user = result.value();
+    EXPECT_EQ(user.username, "testuser");
+    EXPECT_EQ(user.email, "test@example.com");
+    EXPECT_EQ(user.status, UserStatus::Active);
+    EXPECT_GT(user.id, 0u);
+    EXPECT_FALSE(user.passwordHash.empty());
+    EXPECT_FALSE(user.salt.empty());
+}
+
+TEST_F(AuthServerTest, RegisterAssignsDefaultRole) {
+    auto result = server_->registerUser(validCredentials());
+    ASSERT_TRUE(result.hasValue());
+    ASSERT_EQ(result.value().roles.size(), 1u);
+    EXPECT_EQ(result.value().roles[0], "player");
+}
+
+TEST_F(AuthServerTest, RegisterDuplicateUsername) {
+    registerTestUser();
+
+    UserCredentials dup{"testuser", "other@example.com", "AnotherPass1!"};
+    auto result = server_->registerUser(dup);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::UserAlreadyExists);
+}
+
+TEST_F(AuthServerTest, RegisterDuplicateEmail) {
+    registerTestUser();
+
+    UserCredentials dup{"otheruser", "test@example.com", "AnotherPass1!"};
+    auto result = server_->registerUser(dup);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::UserAlreadyExists);
+}
+
+TEST_F(AuthServerTest, RegisterInvalidEmail) {
+    UserCredentials cred{"user1", "not-an-email", "StrongPass1!"};
+    auto result = server_->registerUser(cred);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidEmail);
+}
+
+TEST_F(AuthServerTest, RegisterEmailMissingAt) {
+    UserCredentials cred{"user1", "noemail.com", "StrongPass1!"};
+    auto result = server_->registerUser(cred);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidEmail);
+}
+
+TEST_F(AuthServerTest, RegisterEmailMissingDomain) {
+    UserCredentials cred{"user1", "user@", "StrongPass1!"};
+    auto result = server_->registerUser(cred);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidEmail);
+}
+
+TEST_F(AuthServerTest, RegisterWeakPassword) {
+    UserCredentials cred{"user1", "user@example.com", "short"};
+    auto result = server_->registerUser(cred);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::WeakPassword);
+}
+
+TEST_F(AuthServerTest, RegisterPasswordExactlyMinLength) {
+    UserCredentials cred{"user1", "user@example.com", "12345678"};
+    auto result = server_->registerUser(cred);
+    ASSERT_TRUE(result.hasValue());
+}
+
+TEST_F(AuthServerTest, PasswordNotStoredInPlaintext) {
+    auto result = server_->registerUser(validCredentials());
+    ASSERT_TRUE(result.hasValue());
+
+    auto& user = result.value();
+    EXPECT_EQ(user.passwordHash.find("StrongPass1!"), std::string::npos);
+    EXPECT_EQ(user.salt.find("StrongPass1!"), std::string::npos);
+}
+
+// =============================================================================
+// Login tests (SRS-SVC-001.2, SRS-SVC-001.3)
+// =============================================================================
+
+TEST_F(AuthServerTest, LoginSuccess) {
+    registerTestUser();
+
+    auto result = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(result.hasValue());
+
+    auto& tokens = result.value();
+    EXPECT_FALSE(tokens.accessToken.empty());
+    EXPECT_FALSE(tokens.refreshToken.empty());
+    EXPECT_EQ(tokens.accessExpiresIn, std::chrono::seconds{300});
+    EXPECT_EQ(tokens.refreshExpiresIn, std::chrono::seconds{3600});
+}
+
+TEST_F(AuthServerTest, LoginWrongPassword) {
+    registerTestUser();
+
+    auto result = server_->login("testuser", "WrongPass!!", "127.0.0.1");
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidCredentials);
+}
+
+TEST_F(AuthServerTest, LoginNonexistentUser) {
+    auto result = server_->login("nobody", "Password1!", "127.0.0.1");
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidCredentials);
+}
+
+TEST_F(AuthServerTest, LoginAccessTokenIsValidJwt) {
+    registerTestUser();
+    auto loginResult = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(loginResult.hasValue());
+
+    auto validateResult =
+        server_->validateToken(loginResult.value().accessToken);
+    ASSERT_TRUE(validateResult.hasValue());
+
+    auto& claims = validateResult.value();
+    EXPECT_EQ(claims.username, "testuser");
+    EXPECT_FALSE(claims.subject.empty());
+}
+
+TEST_F(AuthServerTest, LoginReturnsUniqueTokens) {
+    registerTestUser();
+
+    auto r1 = server_->login("testuser", "StrongPass1!", "10.0.0.1");
+    auto r2 = server_->login("testuser", "StrongPass1!", "10.0.0.2");
+    ASSERT_TRUE(r1.hasValue());
+    ASSERT_TRUE(r2.hasValue());
+
+    EXPECT_NE(r1.value().refreshToken, r2.value().refreshToken);
+}
+
+// =============================================================================
+// Rate limiting tests
+// =============================================================================
+
+TEST_F(AuthServerTest, RateLimitAfterMaxAttempts) {
+    registerTestUser();
+    const std::string ip = "192.168.1.100";
+
+    // Exhaust rate limit (3 failed attempts).
+    for (int i = 0; i < 3; ++i) {
+        (void)server_->login("testuser", "WrongPass!!", ip);
+    }
+
+    // Fourth attempt should be rate-limited even with correct password.
+    auto result = server_->login("testuser", "StrongPass1!", ip);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::RateLimitExceeded);
+}
+
+TEST_F(AuthServerTest, RateLimitPerIp) {
+    registerTestUser();
+
+    // Exhaust rate limit for one IP.
+    for (int i = 0; i < 3; ++i) {
+        (void)server_->login("testuser", "WrongPass!!", "192.168.1.1");
+    }
+
+    // Different IP should still work.
+    auto result = server_->login("testuser", "StrongPass1!", "192.168.1.2");
+    ASSERT_TRUE(result.hasValue());
+}
+
+TEST_F(AuthServerTest, RateLimitResetsOnSuccess) {
+    registerTestUser();
+    const std::string ip = "10.0.0.1";
+
+    // Two failed attempts.
+    (void)server_->login("testuser", "WrongPass!!", ip);
+    (void)server_->login("testuser", "WrongPass!!", ip);
+
+    // Successful login resets counter.
+    auto success = server_->login("testuser", "StrongPass1!", ip);
+    ASSERT_TRUE(success.hasValue());
+
+    // Two more failed attempts should be allowed (counter was reset).
+    (void)server_->login("testuser", "WrongPass!!", ip);
+    (void)server_->login("testuser", "WrongPass!!", ip);
+
+    // Third failed attempt after reset should still be allowed (limit is 3).
+    auto result = server_->login("testuser", "WrongPass!!", ip);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidCredentials);
+}
+
+// =============================================================================
+// Token refresh tests (SRS-SVC-001.4)
+// =============================================================================
+
+TEST_F(AuthServerTest, RefreshTokenSuccess) {
+    registerTestUser();
+    auto loginResult = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(loginResult.hasValue());
+
+    auto refreshResult =
+        server_->refreshToken(loginResult.value().refreshToken);
+    ASSERT_TRUE(refreshResult.hasValue());
+
+    auto& newTokens = refreshResult.value();
+    EXPECT_FALSE(newTokens.accessToken.empty());
+    EXPECT_FALSE(newTokens.refreshToken.empty());
+
+    // New tokens should be different from original.
+    EXPECT_NE(newTokens.refreshToken, loginResult.value().refreshToken);
+}
+
+TEST_F(AuthServerTest, RefreshTokenRotation) {
+    registerTestUser();
+    auto loginResult = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(loginResult.hasValue());
+
+    auto oldRefresh = loginResult.value().refreshToken;
+
+    // Refresh once.
+    auto refreshResult = server_->refreshToken(oldRefresh);
+    ASSERT_TRUE(refreshResult.hasValue());
+
+    // Old refresh token should now be revoked.
+    auto reuse = server_->refreshToken(oldRefresh);
+    ASSERT_TRUE(reuse.hasError());
+    EXPECT_EQ(reuse.error().code(), ErrorCode::TokenRevoked);
+}
+
+TEST_F(AuthServerTest, RefreshInvalidToken) {
+    auto result = server_->refreshToken("nonexistent-token");
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidToken);
+}
+
+TEST_F(AuthServerTest, RefreshNewAccessTokenIsValid) {
+    registerTestUser();
+    auto loginResult = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(loginResult.hasValue());
+
+    auto refreshResult =
+        server_->refreshToken(loginResult.value().refreshToken);
+    ASSERT_TRUE(refreshResult.hasValue());
+
+    // The new access token should be valid.
+    auto validateResult =
+        server_->validateToken(refreshResult.value().accessToken);
+    ASSERT_TRUE(validateResult.hasValue());
+    EXPECT_EQ(validateResult.value().username, "testuser");
+}
+
+// =============================================================================
+// Logout tests (SRS-SVC-001.5)
+// =============================================================================
+
+TEST_F(AuthServerTest, LogoutSuccess) {
+    registerTestUser();
+    auto loginResult = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(loginResult.hasValue());
+
+    auto logoutResult = server_->logout(loginResult.value().refreshToken);
+    ASSERT_TRUE(logoutResult.hasValue());
+}
+
+TEST_F(AuthServerTest, LogoutRevokesRefreshToken) {
+    registerTestUser();
+    auto loginResult = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(loginResult.hasValue());
+
+    (void)server_->logout(loginResult.value().refreshToken);
+
+    // Cannot refresh with revoked token.
+    auto refreshResult =
+        server_->refreshToken(loginResult.value().refreshToken);
+    ASSERT_TRUE(refreshResult.hasError());
+    EXPECT_EQ(refreshResult.error().code(), ErrorCode::TokenRevoked);
+}
+
+TEST_F(AuthServerTest, LogoutNonexistentToken) {
+    auto result = server_->logout("nonexistent-token");
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidToken);
+}
+
+// =============================================================================
+// Token validation tests
+// =============================================================================
+
+TEST_F(AuthServerTest, ValidateValidToken) {
+    registerTestUser();
+    auto loginResult = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(loginResult.hasValue());
+
+    auto result = server_->validateToken(loginResult.value().accessToken);
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value().username, "testuser");
+    EXPECT_FALSE(result.value().roles.empty());
+}
+
+TEST_F(AuthServerTest, ValidateInvalidToken) {
+    auto result = server_->validateToken("invalid.jwt.token");
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidToken);
+}
+
+TEST_F(AuthServerTest, ValidateExpiredToken) {
+    // Create server with very short token expiry.
+    auto shortRepo = std::make_shared<InMemoryUserRepository>();
+    auto shortStore = std::make_shared<InMemoryTokenStore>();
+    AuthConfig shortConfig;
+    shortConfig.signingKey = "test-key-must-be-at-least-32-bytes-long!!";
+    shortConfig.accessTokenExpiry = std::chrono::seconds{0};
+    AuthServer shortServer(std::move(shortConfig), shortRepo, shortStore);
+
+    auto reg = shortServer.registerUser(validCredentials());
+    ASSERT_TRUE(reg.hasValue());
+
+    auto loginResult =
+        shortServer.login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(loginResult.hasValue());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto result = shortServer.validateToken(loginResult.value().accessToken);
+    ASSERT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::TokenExpired);
+}
+
+// =============================================================================
+// User repository direct tests
+// =============================================================================
+
+TEST_F(AuthServerTest, UserRepositoryFindByIdAfterRegister) {
+    auto reg = server_->registerUser(validCredentials());
+    ASSERT_TRUE(reg.hasValue());
+
+    auto found = userRepo_->findById(reg.value().id);
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(found->username, "testuser");
+}
+
+TEST_F(AuthServerTest, UserRepositoryFindByEmail) {
+    registerTestUser();
+
+    auto found = userRepo_->findByEmail("test@example.com");
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(found->username, "testuser");
+}
+
+// =============================================================================
+// Token store direct tests
+// =============================================================================
+
+TEST_F(AuthServerTest, TokenStoreRemoveExpired) {
+    RefreshTokenRecord expired;
+    expired.token = "expired-token";
+    expired.userId = 1;
+    expired.expiresAt = std::chrono::system_clock::now() - std::chrono::hours{1};
+    expired.revoked = false;
+    tokenStore_->store(std::move(expired));
+
+    EXPECT_TRUE(tokenStore_->find("expired-token").has_value());
+
+    tokenStore_->removeExpired();
+
+    EXPECT_FALSE(tokenStore_->find("expired-token").has_value());
+}
+
+TEST_F(AuthServerTest, TokenStoreRevokeAllForUser) {
+    registerTestUser();
+
+    // Login multiple times to create multiple refresh tokens.
+    auto r1 = server_->login("testuser", "StrongPass1!", "10.0.0.1");
+    auto r2 = server_->login("testuser", "StrongPass1!", "10.0.0.2");
+    ASSERT_TRUE(r1.hasValue());
+    ASSERT_TRUE(r2.hasValue());
+
+    // Get user ID.
+    auto user = userRepo_->findByUsername("testuser");
+    ASSERT_TRUE(user.has_value());
+
+    tokenStore_->revokeAllForUser(user->id);
+
+    // Both refresh tokens should now be revoked.
+    auto check1 = tokenStore_->find(r1.value().refreshToken);
+    auto check2 = tokenStore_->find(r2.value().refreshToken);
+    ASSERT_TRUE(check1.has_value());
+    ASSERT_TRUE(check2.has_value());
+    EXPECT_TRUE(check1->revoked);
+    EXPECT_TRUE(check2->revoked);
+}
+
+// =============================================================================
+// Rate limiter direct tests
+// =============================================================================
+
+TEST(RateLimiterTest, AllowWithinLimit) {
+    RateLimiter limiter(3, std::chrono::seconds{60});
+    EXPECT_TRUE(limiter.allow("key1"));
+    EXPECT_TRUE(limiter.allow("key1"));
+    EXPECT_TRUE(limiter.allow("key1"));
+    EXPECT_FALSE(limiter.allow("key1"));
+}
+
+TEST(RateLimiterTest, RemainingCount) {
+    RateLimiter limiter(5, std::chrono::seconds{60});
+    EXPECT_EQ(limiter.remaining("key1"), 5u);
+    (void)limiter.allow("key1");
+    EXPECT_EQ(limiter.remaining("key1"), 4u);
+}
+
+TEST(RateLimiterTest, ResetClearsAttempts) {
+    RateLimiter limiter(2, std::chrono::seconds{60});
+    (void)limiter.allow("key1");
+    (void)limiter.allow("key1");
+    EXPECT_FALSE(limiter.allow("key1"));
+
+    limiter.reset("key1");
+    EXPECT_TRUE(limiter.allow("key1"));
+}
+
+TEST(RateLimiterTest, IndependentKeys) {
+    RateLimiter limiter(1, std::chrono::seconds{60});
+    EXPECT_TRUE(limiter.allow("key1"));
+    EXPECT_FALSE(limiter.allow("key1"));
+    EXPECT_TRUE(limiter.allow("key2"));
+}
+
+// =============================================================================
+// Full auth flow integration test
+// =============================================================================
+
+TEST_F(AuthServerTest, FullAuthFlow) {
+    // 1. Register.
+    auto reg = server_->registerUser(validCredentials());
+    ASSERT_TRUE(reg.hasValue());
+
+    // 2. Login.
+    auto login = server_->login("testuser", "StrongPass1!", "127.0.0.1");
+    ASSERT_TRUE(login.hasValue());
+
+    // 3. Validate access token.
+    auto validate = server_->validateToken(login.value().accessToken);
+    ASSERT_TRUE(validate.hasValue());
+    EXPECT_EQ(validate.value().username, "testuser");
+
+    // 4. Refresh token.
+    auto refresh = server_->refreshToken(login.value().refreshToken);
+    ASSERT_TRUE(refresh.hasValue());
+
+    // 5. Validate new access token.
+    auto validateNew = server_->validateToken(refresh.value().accessToken);
+    ASSERT_TRUE(validateNew.hasValue());
+    EXPECT_EQ(validateNew.value().username, "testuser");
+
+    // 6. Old refresh token should be revoked.
+    auto reuseOld = server_->refreshToken(login.value().refreshToken);
+    ASSERT_TRUE(reuseOld.hasError());
+
+    // 7. Logout.
+    auto logoutResult = server_->logout(refresh.value().refreshToken);
+    ASSERT_TRUE(logoutResult.hasValue());
+
+    // 8. Cannot refresh after logout.
+    auto afterLogout = server_->refreshToken(refresh.value().refreshToken);
+    ASSERT_TRUE(afterLogout.hasError());
+}
+
+// =============================================================================
+// Multiple users integration test
+// =============================================================================
+
+TEST_F(AuthServerTest, MultipleUsersIsolation) {
+    // Register two users.
+    UserCredentials alice{"alice", "alice@example.com", "AlicePass1!"};
+    UserCredentials bob{"bob", "bob@example.com", "BobPass123!"};
+
+    auto regAlice = server_->registerUser(alice);
+    auto regBob = server_->registerUser(bob);
+    ASSERT_TRUE(regAlice.hasValue());
+    ASSERT_TRUE(regBob.hasValue());
+    EXPECT_NE(regAlice.value().id, regBob.value().id);
+
+    // Login as Alice.
+    auto loginAlice = server_->login("alice", "AlicePass1!", "10.0.0.1");
+    ASSERT_TRUE(loginAlice.hasValue());
+
+    // Login as Bob.
+    auto loginBob = server_->login("bob", "BobPass123!", "10.0.0.2");
+    ASSERT_TRUE(loginBob.hasValue());
+
+    // Validate Alice's token contains Alice's claims.
+    auto claimsAlice = server_->validateToken(loginAlice.value().accessToken);
+    ASSERT_TRUE(claimsAlice.hasValue());
+    EXPECT_EQ(claimsAlice.value().username, "alice");
+
+    // Validate Bob's token contains Bob's claims.
+    auto claimsBob = server_->validateToken(loginBob.value().accessToken);
+    ASSERT_TRUE(claimsBob.hasValue());
+    EXPECT_EQ(claimsBob.value().username, "bob");
+}


### PR DESCRIPTION
## Summary

Implements the Authentication Server microservice (Issue #22 / SRS-SVC-001), building on the auth foundation types, password hashing, and token provider from #58/#60.

### New Components
- **AuthServer**: Orchestrates the full authentication workflow — register, login, token refresh, logout, and token validation
- **IUserRepository / InMemoryUserRepository**: Abstract user persistence with thread-safe in-memory implementation
- **ITokenStore / InMemoryTokenStore**: Abstract refresh token persistence with thread-safe in-memory implementation  
- **RateLimiter**: Sliding-window rate limiter for login attempt throttling (configurable per-IP)

### Key Features
- User registration with email format validation and duplicate checking
- Password hashing via PasswordHasher (SHA-256 + random salt)
- JWT access token issuance with configurable expiry (default 15min)
- Refresh token rotation — old tokens are automatically revoked on refresh
- Rate limiting on login attempts (default: 5 per minute per IP)
- All operations return `GameResult<T>` with proper `ErrorCode` values (no exceptions)

### SRS Coverage
| SRS ID | Requirement | Status |
|--------|-------------|--------|
| SRS-SVC-001.1 | User registration with email validation | Implemented |
| SRS-SVC-001.2 | User login with username/password | Implemented |
| SRS-SVC-001.3 | JWT access token with configurable expiry | Implemented |
| SRS-SVC-001.4 | Refresh token for token renewal | Implemented |
| SRS-SVC-001.5 | Token revocation | Implemented |
| SRS-SVC-001.6 | Password hashing (SHA-256 + salt) | Implemented (#60) |

### Files Changed (11 files, +1300 lines)

**Headers** (public API):
- `include/cgs/service/auth_server.hpp`
- `include/cgs/service/user_repository.hpp`
- `include/cgs/service/token_store.hpp`
- `include/cgs/service/rate_limiter.hpp`

**Implementations**:
- `src/services/auth/auth_server.cpp`
- `src/services/auth/user_repository.cpp`
- `src/services/auth/token_store.cpp`
- `src/services/auth/rate_limiter.cpp`

**Tests**:
- `tests/unit/service/auth_server_test.cpp` — 38 tests

**Build**:
- `src/services/auth/CMakeLists.txt` — added new source files
- `tests/CMakeLists.txt` — added new test target

## Test Plan

- [x] 38 new tests pass (registration, login, refresh, logout, validation, rate limiting, token rotation, multi-user isolation)
- [x] 25 existing auth crypto tests pass (regression check)
- [x] Build with `-Werror -Wall -Wextra -Wpedantic -Wconversion` passes cleanly

Closes #22