### PR TITLE
feat(service): add Gateway Types, Session Manager & Token Bucket

### DIFF
--- a/include/cgs/service/gateway_session_manager.hpp
+++ b/include/cgs/service/gateway_session_manager.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+/// @file gateway_session_manager.hpp
+/// @brief Authenticated client session lifecycle management for the Gateway.
+///
+/// Tracks connected clients through their lifecycle:
+/// Unauthenticated → Authenticated → (optionally Migrating) → Disconnecting.
+///
+/// @see SRS-SVC-002.1
+/// @see SRS-SVC-002.4
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/foundation/types.hpp"
+#include "cgs/service/gateway_types.hpp"
+
+namespace cgs::service {
+
+/// Thread-safe manager for gateway client sessions.
+///
+/// Provides creation, authentication, migration, and removal of client
+/// sessions. Used by GatewayServer to track all connected clients.
+///
+/// Example:
+/// @code
+///   GatewaySessionManager mgr(10000);
+///   auto sid = SessionId(42);
+///   mgr.createSession(sid, "192.168.1.1");
+///   mgr.authenticateSession(sid, claims, userId);
+///   auto session = mgr.getSession(sid);
+/// @endcode
+class GatewaySessionManager {
+public:
+    /// Construct with maximum session capacity.
+    explicit GatewaySessionManager(uint32_t maxSessions);
+
+    /// Create a new unauthenticated session.
+    /// Returns false if the max capacity is reached.
+    [[nodiscard]] bool createSession(cgs::foundation::SessionId sessionId,
+                                     std::string remoteAddress);
+
+    /// Promote a session to authenticated state.
+    [[nodiscard]] bool authenticateSession(cgs::foundation::SessionId sessionId,
+                                           TokenClaims claims,
+                                           uint64_t userId);
+
+    /// Transition a session to migrating state.
+    [[nodiscard]] bool beginMigration(cgs::foundation::SessionId sessionId,
+                                      std::string targetService);
+
+    /// Complete migration: update the session's current service.
+    [[nodiscard]] bool completeMigration(cgs::foundation::SessionId sessionId);
+
+    /// Remove a session (disconnect).
+    void removeSession(cgs::foundation::SessionId sessionId);
+
+    /// Get a snapshot of a session. Returns nullopt if not found.
+    [[nodiscard]] std::optional<ClientSession> getSession(
+        cgs::foundation::SessionId sessionId) const;
+
+    /// Update the last activity timestamp for a session.
+    void touchSession(cgs::foundation::SessionId sessionId);
+
+    /// Update the current service for a session.
+    [[nodiscard]] bool setCurrentService(cgs::foundation::SessionId sessionId,
+                                         std::string service);
+
+    /// Get sessions in a specific state.
+    [[nodiscard]] std::vector<ClientSession> getSessionsByState(
+        ClientState state) const;
+
+    /// Get session count.
+    [[nodiscard]] std::size_t sessionCount() const;
+
+    /// Get session count by state.
+    [[nodiscard]] std::size_t sessionCount(ClientState state) const;
+
+    /// Find sessions that have been idle longer than the given duration.
+    [[nodiscard]] std::vector<cgs::foundation::SessionId> findIdleSessions(
+        std::chrono::seconds idleTimeout) const;
+
+    /// Find unauthenticated sessions older than the given duration.
+    [[nodiscard]] std::vector<cgs::foundation::SessionId> findExpiredAuthSessions(
+        std::chrono::seconds authTimeout) const;
+
+private:
+    uint32_t maxSessions_;
+    mutable std::mutex mutex_;
+    std::unordered_map<cgs::foundation::SessionId, ClientSession> sessions_;
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/gateway_types.hpp
+++ b/include/cgs/service/gateway_types.hpp
@@ -1,0 +1,142 @@
+#pragma once
+
+/// @file gateway_types.hpp
+/// @brief Core type definitions for the Gateway Server.
+///
+/// Defines configuration, client session state, route entries, and
+/// gateway-specific opcode constants.
+///
+/// @see SRS-SVC-002
+/// @see SDS-MOD-041
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "cgs/foundation/types.hpp"
+#include "cgs/service/auth_types.hpp"
+
+namespace cgs::service {
+
+// -- Client state -------------------------------------------------------------
+
+/// Connection lifecycle state for a gateway client.
+enum class ClientState : uint8_t {
+    /// Connected but not yet authenticated.
+    Unauthenticated,
+    /// Token validated, ready for message routing.
+    Authenticated,
+    /// Being transferred to another game server.
+    Migrating,
+    /// Disconnecting.
+    Disconnecting
+};
+
+/// Return the string name for a client state.
+constexpr std::string_view clientStateName(ClientState state) {
+    switch (state) {
+        case ClientState::Unauthenticated: return "Unauthenticated";
+        case ClientState::Authenticated:   return "Authenticated";
+        case ClientState::Migrating:       return "Migrating";
+        case ClientState::Disconnecting:   return "Disconnecting";
+    }
+    return "Unknown";
+}
+
+// -- Client session -----------------------------------------------------------
+
+/// Authenticated client session tracked by the gateway.
+struct ClientSession {
+    /// Network-level session identifier.
+    cgs::foundation::SessionId sessionId;
+
+    /// Current connection state.
+    ClientState state = ClientState::Unauthenticated;
+
+    /// Decoded JWT claims (populated after authentication).
+    TokenClaims claims;
+
+    /// User ID extracted from claims.subject (0 if unauthenticated).
+    uint64_t userId = 0;
+
+    /// Client IP address for rate limiting and logging.
+    std::string remoteAddress;
+
+    /// Identifier of the downstream service currently handling this client.
+    std::string currentService;
+
+    /// When the connection was established.
+    std::chrono::steady_clock::time_point connectedAt{};
+
+    /// When the last message was received.
+    std::chrono::steady_clock::time_point lastActivity{};
+};
+
+// -- Route table types --------------------------------------------------------
+
+/// Mapping from an opcode range to a downstream service.
+struct RouteEntry {
+    /// First opcode in the range (inclusive).
+    uint16_t opcodeMin = 0;
+
+    /// Last opcode in the range (inclusive).
+    uint16_t opcodeMax = 0;
+
+    /// Downstream service identifier (e.g., "game", "lobby", "chat").
+    std::string service;
+
+    /// Whether this route requires authentication.
+    bool requiresAuth = true;
+};
+
+// -- Gateway opcodes ----------------------------------------------------------
+
+/// Reserved gateway-level opcodes (0x0000-0x00FF).
+namespace GatewayOpcode {
+    /// Client → Gateway: authenticate with JWT access token.
+    constexpr uint16_t Authenticate = 0x0001;
+
+    /// Gateway → Client: authentication result.
+    constexpr uint16_t AuthResult = 0x0002;
+
+    /// Gateway → Client: server transfer notification.
+    constexpr uint16_t ServerTransfer = 0x0010;
+
+    /// Client → Gateway: migration acknowledgement.
+    constexpr uint16_t MigrationAck = 0x0011;
+
+    /// Gateway → Client: heartbeat ping.
+    constexpr uint16_t Ping = 0x00FE;
+
+    /// Client → Gateway: heartbeat pong.
+    constexpr uint16_t Pong = 0x00FF;
+} // namespace GatewayOpcode
+
+// -- Configuration ------------------------------------------------------------
+
+/// Configuration for the Gateway Server.
+struct GatewayConfig {
+    /// TCP listener port.
+    uint16_t tcpPort = 8080;
+
+    /// WebSocket listener port.
+    uint16_t webSocketPort = 8081;
+
+    /// Maximum time allowed for authentication after connecting.
+    std::chrono::seconds authTimeout{10};
+
+    /// Token bucket: maximum burst capacity per client.
+    uint32_t rateLimitCapacity = 100;
+
+    /// Token bucket: tokens refilled per second per client.
+    uint32_t rateLimitRefillRate = 50;
+
+    /// Maximum concurrent connections.
+    uint32_t maxConnections = 10000;
+
+    /// Idle timeout before disconnecting an authenticated client.
+    std::chrono::seconds idleTimeout{300};
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/route_table.hpp
+++ b/include/cgs/service/route_table.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+/// @file route_table.hpp
+/// @brief Opcode-range-based message routing for the Gateway Server.
+///
+/// Maps incoming message opcodes to downstream service identifiers
+/// so the gateway can forward traffic to the correct backend.
+///
+/// @see SRS-SVC-002.3
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "cgs/service/gateway_types.hpp"
+
+namespace cgs::service {
+
+/// Lookup result from a route table query.
+struct RouteMatch {
+    /// Downstream service identifier.
+    std::string service;
+
+    /// Whether this route requires the client to be authenticated.
+    bool requiresAuth = true;
+};
+
+/// Opcode-range-based routing table.
+///
+/// Example:
+/// @code
+///   RouteTable routes;
+///   routes.addRoute(0x0100, 0x01FF, "game");
+///   routes.addRoute(0x0200, 0x02FF, "lobby");
+///
+///   auto match = routes.resolve(0x0150);
+///   // match->service == "game"
+/// @endcode
+class RouteTable {
+public:
+    /// Add a route mapping an opcode range to a service.
+    void addRoute(uint16_t opcodeMin, uint16_t opcodeMax,
+                  std::string service, bool requiresAuth = true);
+
+    /// Add a route from a RouteEntry.
+    void addRoute(RouteEntry entry);
+
+    /// Resolve an opcode to the matching route, if any.
+    [[nodiscard]] std::optional<RouteMatch> resolve(uint16_t opcode) const;
+
+    /// Check whether an opcode is a reserved gateway-level opcode (0x0000-0x00FF).
+    [[nodiscard]] static bool isGatewayOpcode(uint16_t opcode);
+
+    /// Get all registered routes.
+    [[nodiscard]] const std::vector<RouteEntry>& routes() const;
+
+    /// Remove all routes for a specific service.
+    void removeRoutesForService(std::string_view service);
+
+    /// Remove all routes.
+    void clear();
+
+private:
+    mutable std::mutex mutex_;
+    std::vector<RouteEntry> routes_;
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/token_bucket.hpp
+++ b/include/cgs/service/token_bucket.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+/// @file token_bucket.hpp
+/// @brief Token bucket rate limiter for per-client message throttling.
+///
+/// Unlike the sliding-window RateLimiter used in AuthServer (which counts
+/// discrete attempts), this token bucket implementation controls sustained
+/// throughput with configurable burst capacity.
+///
+/// @see SRS-SVC-002.5
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace cgs::service {
+
+/// Token bucket rate limiter for per-key message throttling.
+///
+/// Each key (typically a session or IP) maintains a bucket that fills
+/// at a constant rate and can burst up to a configured capacity.
+///
+/// Example:
+/// @code
+///   TokenBucket bucket(100, 50); // 100 burst, 50 tokens/sec refill
+///   if (bucket.consume("session-1")) {
+///       // Message allowed
+///   }
+/// @endcode
+class TokenBucket {
+public:
+    /// Construct with capacity (max burst) and refill rate (tokens/second).
+    TokenBucket(uint32_t capacity, uint32_t refillRate);
+
+    /// Try to consume one token for the given key.
+    /// Returns true if allowed, false if rate limit exceeded.
+    [[nodiscard]] bool consume(const std::string& key);
+
+    /// Try to consume N tokens for the given key.
+    [[nodiscard]] bool consume(const std::string& key, uint32_t tokens);
+
+    /// Get current available tokens for the given key.
+    [[nodiscard]] uint32_t available(const std::string& key) const;
+
+    /// Remove tracking for the given key (e.g., on disconnect).
+    void remove(const std::string& key);
+
+    /// Reset a key's bucket to full capacity.
+    void reset(const std::string& key);
+
+private:
+    struct Bucket {
+        double tokens;
+        std::chrono::steady_clock::time_point lastRefill;
+    };
+
+    void refill(Bucket& bucket) const;
+
+    uint32_t capacity_;
+    uint32_t refillRate_;
+    mutable std::mutex mutex_;
+    mutable std::unordered_map<std::string, Bucket> buckets_;
+};
+
+} // namespace cgs::service

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -1,2 +1,3 @@
 # Layer 3: Services
 add_subdirectory(auth)
+add_subdirectory(gateway)

--- a/src/services/gateway/CMakeLists.txt
+++ b/src/services/gateway/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Gateway Service - Types, Session Manager, Token Bucket, Route Table (SDS-MOD-041)
+add_library(cgs_service_gateway
+    token_bucket.cpp
+    route_table.cpp
+    gateway_session_manager.cpp
+)
+target_link_libraries(cgs_service_gateway
+    PUBLIC cgs_core
+)
+add_library(cgs::service_gateway ALIAS cgs_service_gateway)

--- a/src/services/gateway/gateway_session_manager.cpp
+++ b/src/services/gateway/gateway_session_manager.cpp
@@ -1,0 +1,196 @@
+/// @file gateway_session_manager.cpp
+/// @brief GatewaySessionManager implementation.
+
+#include "cgs/service/gateway_session_manager.hpp"
+
+#include <chrono>
+
+namespace cgs::service {
+
+GatewaySessionManager::GatewaySessionManager(uint32_t maxSessions)
+    : maxSessions_(maxSessions) {}
+
+bool GatewaySessionManager::createSession(
+    cgs::foundation::SessionId sessionId, std::string remoteAddress) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (sessions_.size() >= static_cast<std::size_t>(maxSessions_)) {
+        return false;
+    }
+
+    if (sessions_.count(sessionId) > 0) {
+        return false;
+    }
+
+    ClientSession session;
+    session.sessionId = sessionId;
+    session.state = ClientState::Unauthenticated;
+    session.remoteAddress = std::move(remoteAddress);
+    session.connectedAt = std::chrono::steady_clock::now();
+    session.lastActivity = session.connectedAt;
+
+    sessions_.emplace(sessionId, std::move(session));
+    return true;
+}
+
+bool GatewaySessionManager::authenticateSession(
+    cgs::foundation::SessionId sessionId, TokenClaims claims,
+    uint64_t userId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(sessionId);
+    if (it == sessions_.end()) {
+        return false;
+    }
+
+    if (it->second.state != ClientState::Unauthenticated) {
+        return false;
+    }
+
+    it->second.state = ClientState::Authenticated;
+    it->second.claims = std::move(claims);
+    it->second.userId = userId;
+    it->second.lastActivity = std::chrono::steady_clock::now();
+    return true;
+}
+
+bool GatewaySessionManager::beginMigration(
+    cgs::foundation::SessionId sessionId, std::string targetService) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(sessionId);
+    if (it == sessions_.end()) {
+        return false;
+    }
+
+    if (it->second.state != ClientState::Authenticated) {
+        return false;
+    }
+
+    it->second.state = ClientState::Migrating;
+    it->second.currentService = std::move(targetService);
+    it->second.lastActivity = std::chrono::steady_clock::now();
+    return true;
+}
+
+bool GatewaySessionManager::completeMigration(
+    cgs::foundation::SessionId sessionId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(sessionId);
+    if (it == sessions_.end()) {
+        return false;
+    }
+
+    if (it->second.state != ClientState::Migrating) {
+        return false;
+    }
+
+    it->second.state = ClientState::Authenticated;
+    it->second.lastActivity = std::chrono::steady_clock::now();
+    return true;
+}
+
+void GatewaySessionManager::removeSession(
+    cgs::foundation::SessionId sessionId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    sessions_.erase(sessionId);
+}
+
+std::optional<ClientSession> GatewaySessionManager::getSession(
+    cgs::foundation::SessionId sessionId) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(sessionId);
+    if (it == sessions_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+void GatewaySessionManager::touchSession(
+    cgs::foundation::SessionId sessionId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(sessionId);
+    if (it != sessions_.end()) {
+        it->second.lastActivity = std::chrono::steady_clock::now();
+    }
+}
+
+bool GatewaySessionManager::setCurrentService(
+    cgs::foundation::SessionId sessionId, std::string service) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = sessions_.find(sessionId);
+    if (it == sessions_.end()) {
+        return false;
+    }
+
+    it->second.currentService = std::move(service);
+    return true;
+}
+
+std::vector<ClientSession> GatewaySessionManager::getSessionsByState(
+    ClientState state) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    std::vector<ClientSession> result;
+    for (const auto& [id, session] : sessions_) {
+        if (session.state == state) {
+            result.push_back(session);
+        }
+    }
+    return result;
+}
+
+std::size_t GatewaySessionManager::sessionCount() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return sessions_.size();
+}
+
+std::size_t GatewaySessionManager::sessionCount(ClientState state) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    std::size_t count = 0;
+    for (const auto& [id, session] : sessions_) {
+        if (session.state == state) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+std::vector<cgs::foundation::SessionId>
+GatewaySessionManager::findIdleSessions(
+    std::chrono::seconds idleTimeout) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto cutoff = std::chrono::steady_clock::now() - idleTimeout;
+    std::vector<cgs::foundation::SessionId> result;
+    for (const auto& [id, session] : sessions_) {
+        if (session.state == ClientState::Authenticated &&
+            session.lastActivity < cutoff) {
+            result.push_back(id);
+        }
+    }
+    return result;
+}
+
+std::vector<cgs::foundation::SessionId>
+GatewaySessionManager::findExpiredAuthSessions(
+    std::chrono::seconds authTimeout) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto cutoff = std::chrono::steady_clock::now() - authTimeout;
+    std::vector<cgs::foundation::SessionId> result;
+    for (const auto& [id, session] : sessions_) {
+        if (session.state == ClientState::Unauthenticated &&
+            session.connectedAt < cutoff) {
+            result.push_back(id);
+        }
+    }
+    return result;
+}
+
+} // namespace cgs::service

--- a/src/services/gateway/route_table.cpp
+++ b/src/services/gateway/route_table.cpp
@@ -1,0 +1,59 @@
+/// @file route_table.cpp
+/// @brief RouteTable implementation.
+
+#include "cgs/service/route_table.hpp"
+
+#include <algorithm>
+
+namespace cgs::service {
+
+void RouteTable::addRoute(uint16_t opcodeMin, uint16_t opcodeMax,
+                          std::string service, bool requiresAuth) {
+    RouteEntry entry;
+    entry.opcodeMin = opcodeMin;
+    entry.opcodeMax = opcodeMax;
+    entry.service = std::move(service);
+    entry.requiresAuth = requiresAuth;
+    addRoute(std::move(entry));
+}
+
+void RouteTable::addRoute(RouteEntry entry) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    routes_.push_back(std::move(entry));
+}
+
+std::optional<RouteMatch> RouteTable::resolve(uint16_t opcode) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    for (const auto& route : routes_) {
+        if (opcode >= route.opcodeMin && opcode <= route.opcodeMax) {
+            return RouteMatch{route.service, route.requiresAuth};
+        }
+    }
+    return std::nullopt;
+}
+
+bool RouteTable::isGatewayOpcode(uint16_t opcode) {
+    return opcode <= 0x00FF;
+}
+
+const std::vector<RouteEntry>& RouteTable::routes() const {
+    return routes_;
+}
+
+void RouteTable::removeRoutesForService(std::string_view service) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    routes_.erase(
+        std::remove_if(routes_.begin(), routes_.end(),
+                       [&](const RouteEntry& e) {
+                           return e.service == service;
+                       }),
+        routes_.end());
+}
+
+void RouteTable::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    routes_.clear();
+}
+
+} // namespace cgs::service

--- a/src/services/gateway/token_bucket.cpp
+++ b/src/services/gateway/token_bucket.cpp
@@ -1,0 +1,73 @@
+/// @file token_bucket.cpp
+/// @brief TokenBucket implementation.
+
+#include "cgs/service/token_bucket.hpp"
+
+#include <algorithm>
+
+namespace cgs::service {
+
+TokenBucket::TokenBucket(uint32_t capacity, uint32_t refillRate)
+    : capacity_(capacity), refillRate_(refillRate) {}
+
+bool TokenBucket::consume(const std::string& key) {
+    return consume(key, 1);
+}
+
+bool TokenBucket::consume(const std::string& key, uint32_t tokens) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = buckets_.find(key);
+    if (it == buckets_.end()) {
+        auto cap = static_cast<double>(capacity_);
+        auto [inserted, _] = buckets_.emplace(
+            key, Bucket{cap, std::chrono::steady_clock::now()});
+        it = inserted;
+    }
+
+    refill(it->second);
+
+    auto required = static_cast<double>(tokens);
+    if (it->second.tokens < required) {
+        return false;
+    }
+
+    it->second.tokens -= required;
+    return true;
+}
+
+uint32_t TokenBucket::available(const std::string& key) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = buckets_.find(key);
+    if (it == buckets_.end()) {
+        return capacity_;
+    }
+
+    refill(it->second);
+    return static_cast<uint32_t>(it->second.tokens);
+}
+
+void TokenBucket::remove(const std::string& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buckets_.erase(key);
+}
+
+void TokenBucket::reset(const std::string& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buckets_[key] = Bucket{static_cast<double>(capacity_),
+                           std::chrono::steady_clock::now()};
+}
+
+void TokenBucket::refill(Bucket& bucket) const {
+    auto now = std::chrono::steady_clock::now();
+    auto elapsed =
+        std::chrono::duration<double>(now - bucket.lastRefill).count();
+
+    auto added = elapsed * static_cast<double>(refillRate_);
+    bucket.tokens = std::min(bucket.tokens + added,
+                             static_cast<double>(capacity_));
+    bucket.lastRefill = now;
+}
+
+} // namespace cgs::service

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -239,6 +239,16 @@ target_link_libraries(cgs_service_auth_server_tests PRIVATE
 )
 gtest_discover_tests(cgs_service_auth_server_tests)
 
+# Unit tests - Service gateway components (session manager, token bucket, route table)
+add_executable(cgs_service_gateway_tests
+    unit/service/gateway_components_test.cpp
+)
+target_link_libraries(cgs_service_gateway_tests PRIVATE
+    cgs::service_gateway
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_service_gateway_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/service/gateway_components_test.cpp
+++ b/tests/unit/service/gateway_components_test.cpp
@@ -1,0 +1,436 @@
+#include <gtest/gtest.h>
+
+#include "cgs/foundation/types.hpp"
+#include "cgs/service/gateway_session_manager.hpp"
+#include "cgs/service/gateway_types.hpp"
+#include "cgs/service/route_table.hpp"
+#include "cgs/service/token_bucket.hpp"
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace cgs::service;
+using cgs::foundation::SessionId;
+
+// =============================================================================
+// Gateway types tests
+// =============================================================================
+
+TEST(GatewayTypesTest, DefaultConfig) {
+    GatewayConfig config;
+    EXPECT_EQ(config.tcpPort, 8080);
+    EXPECT_EQ(config.webSocketPort, 8081);
+    EXPECT_EQ(config.authTimeout, std::chrono::seconds{10});
+    EXPECT_EQ(config.rateLimitCapacity, 100u);
+    EXPECT_EQ(config.rateLimitRefillRate, 50u);
+    EXPECT_EQ(config.maxConnections, 10000u);
+    EXPECT_EQ(config.idleTimeout, std::chrono::seconds{300});
+}
+
+TEST(GatewayTypesTest, ClientStateNames) {
+    EXPECT_EQ(clientStateName(ClientState::Unauthenticated), "Unauthenticated");
+    EXPECT_EQ(clientStateName(ClientState::Authenticated), "Authenticated");
+    EXPECT_EQ(clientStateName(ClientState::Migrating), "Migrating");
+    EXPECT_EQ(clientStateName(ClientState::Disconnecting), "Disconnecting");
+}
+
+TEST(GatewayTypesTest, GatewayOpcodes) {
+    EXPECT_EQ(GatewayOpcode::Authenticate, 0x0001);
+    EXPECT_EQ(GatewayOpcode::AuthResult, 0x0002);
+    EXPECT_EQ(GatewayOpcode::ServerTransfer, 0x0010);
+    EXPECT_EQ(GatewayOpcode::MigrationAck, 0x0011);
+    EXPECT_EQ(GatewayOpcode::Ping, 0x00FE);
+    EXPECT_EQ(GatewayOpcode::Pong, 0x00FF);
+}
+
+TEST(GatewayTypesTest, DefaultClientSession) {
+    ClientSession session;
+    EXPECT_EQ(session.state, ClientState::Unauthenticated);
+    EXPECT_EQ(session.userId, 0u);
+    EXPECT_TRUE(session.remoteAddress.empty());
+    EXPECT_TRUE(session.currentService.empty());
+}
+
+// =============================================================================
+// Token bucket tests
+// =============================================================================
+
+class TokenBucketTest : public ::testing::Test {
+protected:
+    // 10 burst, 5 tokens/sec refill
+    TokenBucket bucket{10, 5};
+};
+
+TEST_F(TokenBucketTest, InitialCapacityAvailable) {
+    EXPECT_EQ(bucket.available("key1"), 10u);
+}
+
+TEST_F(TokenBucketTest, ConsumeReducesTokens) {
+    EXPECT_TRUE(bucket.consume("key1"));
+    EXPECT_EQ(bucket.available("key1"), 9u);
+}
+
+TEST_F(TokenBucketTest, ConsumeMultipleTokens) {
+    EXPECT_TRUE(bucket.consume("key1", 5));
+    // Available will be ~5 (minus tiny refill offset)
+    EXPECT_LE(bucket.available("key1"), 5u);
+}
+
+TEST_F(TokenBucketTest, ExhaustBucket) {
+    EXPECT_TRUE(bucket.consume("key1", 10));
+    EXPECT_FALSE(bucket.consume("key1"));
+}
+
+TEST_F(TokenBucketTest, RefillOverTime) {
+    EXPECT_TRUE(bucket.consume("key1", 10));
+    EXPECT_FALSE(bucket.consume("key1"));
+
+    // Wait 200ms for ~1 token refill (5 tokens/sec * 0.2s = 1 token)
+    std::this_thread::sleep_for(std::chrono::milliseconds(220));
+
+    EXPECT_TRUE(bucket.consume("key1"));
+}
+
+TEST_F(TokenBucketTest, CapacityCap) {
+    // Wait to ensure refill doesn't exceed capacity
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_EQ(bucket.available("key1"), 10u);
+}
+
+TEST_F(TokenBucketTest, IndependentKeys) {
+    EXPECT_TRUE(bucket.consume("key1", 10));
+    EXPECT_FALSE(bucket.consume("key1"));
+
+    // Different key should have full capacity.
+    EXPECT_TRUE(bucket.consume("key2", 10));
+}
+
+TEST_F(TokenBucketTest, RemoveKey) {
+    EXPECT_TRUE(bucket.consume("key1", 10));
+    bucket.remove("key1");
+
+    // After removal, key gets fresh bucket with full capacity.
+    EXPECT_EQ(bucket.available("key1"), 10u);
+}
+
+TEST_F(TokenBucketTest, ResetKey) {
+    EXPECT_TRUE(bucket.consume("key1", 8));
+    bucket.reset("key1");
+    EXPECT_EQ(bucket.available("key1"), 10u);
+}
+
+TEST_F(TokenBucketTest, ConsumeMoreThanAvailable) {
+    EXPECT_FALSE(bucket.consume("key1", 11));
+    // Tokens should not be consumed on failure.
+    EXPECT_EQ(bucket.available("key1"), 10u);
+}
+
+// =============================================================================
+// Route table tests
+// =============================================================================
+
+class RouteTableTest : public ::testing::Test {
+protected:
+    RouteTable routes;
+
+    void SetUp() override {
+        routes.addRoute(0x0100, 0x01FF, "game");
+        routes.addRoute(0x0200, 0x02FF, "lobby");
+        routes.addRoute(0x0300, 0x03FF, "chat", false);
+    }
+};
+
+TEST_F(RouteTableTest, ResolveGameOpcode) {
+    auto match = routes.resolve(0x0150);
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->service, "game");
+    EXPECT_TRUE(match->requiresAuth);
+}
+
+TEST_F(RouteTableTest, ResolveLobbyOpcode) {
+    auto match = routes.resolve(0x0200);
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->service, "lobby");
+}
+
+TEST_F(RouteTableTest, ResolveChatNoAuth) {
+    auto match = routes.resolve(0x0350);
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->service, "chat");
+    EXPECT_FALSE(match->requiresAuth);
+}
+
+TEST_F(RouteTableTest, ResolveUnknownOpcode) {
+    auto match = routes.resolve(0x0500);
+    EXPECT_FALSE(match.has_value());
+}
+
+TEST_F(RouteTableTest, ResolveBoundaryOpcodes) {
+    // Min boundary
+    auto matchMin = routes.resolve(0x0100);
+    ASSERT_TRUE(matchMin.has_value());
+    EXPECT_EQ(matchMin->service, "game");
+
+    // Max boundary
+    auto matchMax = routes.resolve(0x01FF);
+    ASSERT_TRUE(matchMax.has_value());
+    EXPECT_EQ(matchMax->service, "game");
+}
+
+TEST_F(RouteTableTest, IsGatewayOpcode) {
+    EXPECT_TRUE(RouteTable::isGatewayOpcode(0x0000));
+    EXPECT_TRUE(RouteTable::isGatewayOpcode(0x0001));
+    EXPECT_TRUE(RouteTable::isGatewayOpcode(0x00FF));
+    EXPECT_FALSE(RouteTable::isGatewayOpcode(0x0100));
+    EXPECT_FALSE(RouteTable::isGatewayOpcode(0xFFFF));
+}
+
+TEST_F(RouteTableTest, GetRoutes) {
+    EXPECT_EQ(routes.routes().size(), 3u);
+}
+
+TEST_F(RouteTableTest, RemoveRoutesForService) {
+    routes.removeRoutesForService("game");
+    EXPECT_EQ(routes.routes().size(), 2u);
+    EXPECT_FALSE(routes.resolve(0x0150).has_value());
+    EXPECT_TRUE(routes.resolve(0x0250).has_value());
+}
+
+TEST_F(RouteTableTest, Clear) {
+    routes.clear();
+    EXPECT_EQ(routes.routes().size(), 0u);
+    EXPECT_FALSE(routes.resolve(0x0150).has_value());
+}
+
+TEST_F(RouteTableTest, AddRouteEntry) {
+    RouteEntry entry;
+    entry.opcodeMin = 0x0400;
+    entry.opcodeMax = 0x04FF;
+    entry.service = "inventory";
+    entry.requiresAuth = true;
+    routes.addRoute(std::move(entry));
+
+    auto match = routes.resolve(0x0450);
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->service, "inventory");
+}
+
+// =============================================================================
+// Gateway session manager tests
+// =============================================================================
+
+class GatewaySessionManagerTest : public ::testing::Test {
+protected:
+    GatewaySessionManager mgr{100};
+
+    static SessionId sid(uint64_t id) {
+        return SessionId(id);
+    }
+
+    static TokenClaims testClaims(const std::string& username) {
+        TokenClaims claims;
+        claims.subject = "user-1";
+        claims.username = username;
+        claims.roles = {"player"};
+        return claims;
+    }
+};
+
+TEST_F(GatewaySessionManagerTest, CreateSession) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_EQ(mgr.sessionCount(), 1u);
+
+    auto session = mgr.getSession(sid(1));
+    ASSERT_TRUE(session.has_value());
+    EXPECT_EQ(session->state, ClientState::Unauthenticated);
+    EXPECT_EQ(session->remoteAddress, "10.0.0.1");
+}
+
+TEST_F(GatewaySessionManagerTest, CreateDuplicateSession) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_FALSE(mgr.createSession(sid(1), "10.0.0.2"));
+    EXPECT_EQ(mgr.sessionCount(), 1u);
+}
+
+TEST_F(GatewaySessionManagerTest, CreateSessionCapacityLimit) {
+    GatewaySessionManager small(2);
+    EXPECT_TRUE(small.createSession(sid(1), "10.0.0.1"));
+    EXPECT_TRUE(small.createSession(sid(2), "10.0.0.2"));
+    EXPECT_FALSE(small.createSession(sid(3), "10.0.0.3"));
+}
+
+TEST_F(GatewaySessionManagerTest, AuthenticateSession) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+
+    auto claims = testClaims("alice");
+    EXPECT_TRUE(mgr.authenticateSession(sid(1), claims, 42));
+
+    auto session = mgr.getSession(sid(1));
+    ASSERT_TRUE(session.has_value());
+    EXPECT_EQ(session->state, ClientState::Authenticated);
+    EXPECT_EQ(session->userId, 42u);
+    EXPECT_EQ(session->claims.username, "alice");
+}
+
+TEST_F(GatewaySessionManagerTest, AuthenticateNonexistentSession) {
+    EXPECT_FALSE(mgr.authenticateSession(sid(99), testClaims("bob"), 1));
+}
+
+TEST_F(GatewaySessionManagerTest, AuthenticateAlreadyAuthenticated) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_TRUE(mgr.authenticateSession(sid(1), testClaims("alice"), 1));
+
+    // Cannot authenticate again.
+    EXPECT_FALSE(mgr.authenticateSession(sid(1), testClaims("bob"), 2));
+}
+
+TEST_F(GatewaySessionManagerTest, MigrationLifecycle) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_TRUE(mgr.authenticateSession(sid(1), testClaims("alice"), 1));
+
+    // Begin migration.
+    EXPECT_TRUE(mgr.beginMigration(sid(1), "game-server-2"));
+    auto session = mgr.getSession(sid(1));
+    ASSERT_TRUE(session.has_value());
+    EXPECT_EQ(session->state, ClientState::Migrating);
+    EXPECT_EQ(session->currentService, "game-server-2");
+
+    // Complete migration.
+    EXPECT_TRUE(mgr.completeMigration(sid(1)));
+    session = mgr.getSession(sid(1));
+    EXPECT_EQ(session->state, ClientState::Authenticated);
+}
+
+TEST_F(GatewaySessionManagerTest, MigrationRequiresAuthenticated) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    // Cannot migrate unauthenticated session.
+    EXPECT_FALSE(mgr.beginMigration(sid(1), "game-server-2"));
+}
+
+TEST_F(GatewaySessionManagerTest, CompleteMigrationRequiresMigrating) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_TRUE(mgr.authenticateSession(sid(1), testClaims("alice"), 1));
+    // Cannot complete migration when not migrating.
+    EXPECT_FALSE(mgr.completeMigration(sid(1)));
+}
+
+TEST_F(GatewaySessionManagerTest, RemoveSession) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_EQ(mgr.sessionCount(), 1u);
+
+    mgr.removeSession(sid(1));
+    EXPECT_EQ(mgr.sessionCount(), 0u);
+    EXPECT_FALSE(mgr.getSession(sid(1)).has_value());
+}
+
+TEST_F(GatewaySessionManagerTest, TouchSession) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+
+    auto before = mgr.getSession(sid(1))->lastActivity;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    mgr.touchSession(sid(1));
+    auto after = mgr.getSession(sid(1))->lastActivity;
+
+    EXPECT_GT(after, before);
+}
+
+TEST_F(GatewaySessionManagerTest, SetCurrentService) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_TRUE(mgr.setCurrentService(sid(1), "game-1"));
+
+    auto session = mgr.getSession(sid(1));
+    EXPECT_EQ(session->currentService, "game-1");
+}
+
+TEST_F(GatewaySessionManagerTest, GetSessionsByState) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_TRUE(mgr.createSession(sid(2), "10.0.0.2"));
+    EXPECT_TRUE(mgr.authenticateSession(sid(2), testClaims("bob"), 2));
+
+    auto unauth = mgr.getSessionsByState(ClientState::Unauthenticated);
+    EXPECT_EQ(unauth.size(), 1u);
+    EXPECT_EQ(unauth[0].sessionId, sid(1));
+
+    auto auth = mgr.getSessionsByState(ClientState::Authenticated);
+    EXPECT_EQ(auth.size(), 1u);
+    EXPECT_EQ(auth[0].sessionId, sid(2));
+}
+
+TEST_F(GatewaySessionManagerTest, SessionCountByState) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_TRUE(mgr.createSession(sid(2), "10.0.0.2"));
+    EXPECT_TRUE(mgr.authenticateSession(sid(2), testClaims("bob"), 2));
+
+    EXPECT_EQ(mgr.sessionCount(ClientState::Unauthenticated), 1u);
+    EXPECT_EQ(mgr.sessionCount(ClientState::Authenticated), 1u);
+    EXPECT_EQ(mgr.sessionCount(ClientState::Migrating), 0u);
+}
+
+TEST_F(GatewaySessionManagerTest, FindExpiredAuthSessions) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+
+    // With a very short timeout, the session should be expired.
+    auto expired = mgr.findExpiredAuthSessions(std::chrono::seconds{0});
+    EXPECT_EQ(expired.size(), 1u);
+    EXPECT_EQ(expired[0], sid(1));
+
+    // With a long timeout, nothing should be expired.
+    auto notExpired = mgr.findExpiredAuthSessions(std::chrono::seconds{3600});
+    EXPECT_TRUE(notExpired.empty());
+}
+
+TEST_F(GatewaySessionManagerTest, FindIdleSessions) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    EXPECT_TRUE(mgr.authenticateSession(sid(1), testClaims("alice"), 1));
+
+    // With 0s timeout, authenticated session should be idle.
+    auto idle = mgr.findIdleSessions(std::chrono::seconds{0});
+    EXPECT_EQ(idle.size(), 1u);
+
+    // Touch it and check again with longer timeout.
+    mgr.touchSession(sid(1));
+    auto notIdle = mgr.findIdleSessions(std::chrono::seconds{3600});
+    EXPECT_TRUE(notIdle.empty());
+}
+
+TEST_F(GatewaySessionManagerTest, FindIdleExcludesUnauthenticated) {
+    EXPECT_TRUE(mgr.createSession(sid(1), "10.0.0.1"));
+    // Unauthenticated sessions should not appear in idle list.
+    auto idle = mgr.findIdleSessions(std::chrono::seconds{0});
+    EXPECT_TRUE(idle.empty());
+}
+
+// =============================================================================
+// Integration: session lifecycle with state transitions
+// =============================================================================
+
+TEST_F(GatewaySessionManagerTest, FullSessionLifecycle) {
+    // 1. Client connects.
+    EXPECT_TRUE(mgr.createSession(sid(1), "192.168.1.10"));
+    EXPECT_EQ(mgr.sessionCount(), 1u);
+    EXPECT_EQ(mgr.sessionCount(ClientState::Unauthenticated), 1u);
+
+    // 2. Client authenticates.
+    auto claims = testClaims("player1");
+    EXPECT_TRUE(mgr.authenticateSession(sid(1), claims, 100));
+    EXPECT_EQ(mgr.sessionCount(ClientState::Authenticated), 1u);
+    EXPECT_EQ(mgr.sessionCount(ClientState::Unauthenticated), 0u);
+
+    // 3. Client gets routed to game service.
+    EXPECT_TRUE(mgr.setCurrentService(sid(1), "game-server-1"));
+
+    // 4. Server transfer (migration).
+    EXPECT_TRUE(mgr.beginMigration(sid(1), "game-server-2"));
+    EXPECT_EQ(mgr.sessionCount(ClientState::Migrating), 1u);
+
+    // 5. Migration completes.
+    EXPECT_TRUE(mgr.completeMigration(sid(1)));
+    auto session = mgr.getSession(sid(1));
+    EXPECT_EQ(session->state, ClientState::Authenticated);
+    EXPECT_EQ(session->currentService, "game-server-2");
+
+    // 6. Client disconnects.
+    mgr.removeSession(sid(1));
+    EXPECT_EQ(mgr.sessionCount(), 0u);
+}


### PR DESCRIPTION
Closes #62
Part of #23

## Summary

- Add `gateway_types.hpp` with core types: `ClientState`, `ClientSession`, `RouteEntry`, `GatewayOpcode` constants, and `GatewayConfig`
- Implement `TokenBucket` rate limiter with per-client token bucket algorithm (capacity + continuous refill)
- Implement `RouteTable` for opcode-range based message routing to downstream services
- Implement `GatewaySessionManager` for full session lifecycle (create → authenticate → migrate → disconnect)
- 42 unit tests covering all components with edge cases

## Design Decisions

- **Token Bucket vs Sliding Window**: Gateway uses token bucket (burst-tolerant, message throughput control) while AuthServer uses sliding window (strict attempt counting). Different rate limiting strategies for different use cases.
- **Opcode Space**: 0x0000-0x00FF reserved for gateway control messages (auth, migration, ping/pong), higher ranges routed to downstream services.
- **Session State Machine**: `Unauthenticated → Authenticated ⇄ Migrating → (removed)` with strict state transition validation.

## Test Plan

- [x] TokenBucket: capacity limits, multi-token consume, refill over time, per-client isolation, remove/reset
- [x] RouteTable: single route, overlapping ranges, auth requirements, gateway opcode detection, service removal
- [x] GatewaySessionManager: create/auth/migrate lifecycle, max session limits, idle/expired session detection, state filtering
- [x] GatewayTypes: enum values, opcode constants, default config values
- [x] All 42 tests pass with zero warnings under strict compiler flags