### PR TITLE
feat(service): add Game Loop & Map Instance Manager

### DIFF
--- a/include/cgs/foundation/error_code.hpp
+++ b/include/cgs/foundation/error_code.hpp
@@ -95,6 +95,14 @@ enum class ErrorCode : uint32_t {
     SerializationError = 0x0A00,
     InvalidBinaryData = 0x0A01,
     InvalidJsonData = 0x0A02,
+
+    // GameServer (0x0B00 - 0x0BFF)
+    GameServerError = 0x0B00,
+    MapInstanceNotFound = 0x0B01,
+    MapInstanceLimitReached = 0x0B02,
+    MapInstanceInvalidState = 0x0B03,
+    GameLoopAlreadyRunning = 0x0B04,
+    GameLoopNotRunning = 0x0B05,
 };
 
 /// Return the subsystem name for a given error code.
@@ -113,6 +121,7 @@ constexpr std::string_view errorSubsystem(ErrorCode code) {
         case 0x0800: return "Logger";
         case 0x0900: return "Monitoring";
         case 0x0A00: return "Serialization";
+        case 0x0B00: return "GameServer";
         default: return "Unknown";
     }
 }

--- a/include/cgs/service/game_loop.hpp
+++ b/include/cgs/service/game_loop.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+/// @file game_loop.hpp
+/// @brief Fixed-rate game loop with frame timing and metrics.
+///
+/// GameLoop runs a user-provided tick callback at a configurable rate
+/// (default 20 Hz = 50 ms per tick) on a dedicated thread.  Each tick
+/// measures frame time, reports budget utilization, and detects
+/// overruns (ticks that exceed the target frame time).
+///
+/// @see SRS-SVC-003.1, SRS-NFR-002
+/// @see SDS-MOD-032
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+namespace cgs::service {
+
+/// Per-tick performance metrics.
+struct TickMetrics {
+    /// Actual time spent in the tick callback.
+    std::chrono::microseconds updateTime{0};
+
+    /// Total frame time including sleep.
+    std::chrono::microseconds frameTime{0};
+
+    /// Ratio of updateTime to target frame time (1.0 = full budget).
+    float budgetUtilization = 0.0f;
+
+    /// Monotonically increasing tick counter (starts at 0).
+    uint64_t tickNumber = 0;
+
+    /// True when updateTime exceeded the target frame time.
+    bool overrun = false;
+};
+
+/// Fixed-rate game loop with dedicated thread.
+///
+/// Usage:
+/// @code
+///   GameLoop loop(20); // 20 Hz
+///   loop.setTickCallback([&](float dt) {
+///       scheduler.Execute(dt);
+///   });
+///   loop.start();
+///   // ...
+///   loop.stop();
+/// @endcode
+class GameLoop {
+public:
+    using TickCallback = std::function<void(float deltaTime)>;
+    using MetricsCallback = std::function<void(const TickMetrics&)>;
+
+    /// Construct a game loop with the given tick rate.
+    ///
+    /// @param tickRate  Ticks per second (default: 20).
+    explicit GameLoop(uint32_t tickRate = 20);
+
+    ~GameLoop();
+
+    // Non-copyable, non-movable (owns a thread).
+    GameLoop(const GameLoop&) = delete;
+    GameLoop& operator=(const GameLoop&) = delete;
+    GameLoop(GameLoop&&) = delete;
+    GameLoop& operator=(GameLoop&&) = delete;
+
+    /// Set the callback invoked each tick with the delta time in seconds.
+    void setTickCallback(TickCallback callback);
+
+    /// Set an optional callback invoked after each tick with metrics.
+    void setMetricsCallback(MetricsCallback callback);
+
+    /// Start the game loop on a dedicated thread.
+    ///
+    /// @return true on success, false if already running.
+    [[nodiscard]] bool start();
+
+    /// Signal the loop to stop and wait for the thread to join.
+    void stop();
+
+    /// Execute a single tick manually (for testing).
+    ///
+    /// The loop must not be running on a thread when calling this.
+    /// @return The metrics for the executed tick.
+    TickMetrics tick();
+
+    /// Check whether the loop is currently running.
+    [[nodiscard]] bool isRunning() const noexcept;
+
+    /// Get the configured tick rate (ticks per second).
+    [[nodiscard]] uint32_t tickRate() const noexcept;
+
+    /// Get the target frame duration.
+    [[nodiscard]] std::chrono::microseconds targetFrameTime() const noexcept;
+
+    /// Get the total number of ticks executed.
+    [[nodiscard]] uint64_t tickCount() const noexcept;
+
+    /// Get the metrics from the last completed tick.
+    [[nodiscard]] TickMetrics lastMetrics() const;
+
+private:
+    /// Main loop body run on the dedicated thread.
+    void run();
+
+    /// Execute one tick and return its metrics.
+    TickMetrics executeTick();
+
+    uint32_t tickRate_;
+    std::chrono::microseconds targetFrameTime_;
+
+    TickCallback tickCallback_;
+    MetricsCallback metricsCallback_;
+
+    std::atomic<bool> running_{false};
+    std::atomic<uint64_t> tickCount_{0};
+    std::thread thread_;
+
+    mutable std::mutex metricsMutex_;
+    TickMetrics lastMetrics_;
+
+    mutable std::mutex callbackMutex_;
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/map_instance_manager.hpp
+++ b/include/cgs/service/map_instance_manager.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+/// @file map_instance_manager.hpp
+/// @brief Map instance lifecycle management for the Game Server.
+///
+/// MapInstanceManager tracks logical map instances, their states,
+/// and player counts.  It does not own ECS entities; the WorldSystem
+/// manages the spatial data.  This class provides service-level
+/// orchestration: instance creation, draining, and shutdown.
+///
+/// @see SRS-SVC-003.2
+/// @see SDS-MOD-032
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/game/world_types.hpp"
+
+namespace cgs::service {
+
+/// Lifecycle state of a map instance.
+enum class InstanceState : uint8_t {
+    Active,       ///< Running normally, accepting new players.
+    Draining,     ///< No new players, waiting for existing to leave.
+    ShuttingDown  ///< About to be destroyed.
+};
+
+/// Metadata for a single map instance.
+struct MapInstanceInfo {
+    uint32_t instanceId = 0;
+    uint32_t mapId = 0;
+    cgs::game::MapType type = cgs::game::MapType::OpenWorld;
+    InstanceState state = InstanceState::Active;
+    uint32_t playerCount = 0;
+    uint32_t maxPlayers = 100;
+    std::chrono::steady_clock::time_point createdAt;
+};
+
+/// Manages map instance creation, state transitions, and player tracking.
+///
+/// Thread-safe: all public methods are guarded by an internal mutex.
+class MapInstanceManager {
+public:
+    /// @param maxInstances  Maximum number of concurrent instances.
+    explicit MapInstanceManager(uint32_t maxInstances = 1000);
+
+    /// Create a new map instance.
+    ///
+    /// @param mapId       Logical map identifier.
+    /// @param type        Map type classification.
+    /// @param maxPlayers  Maximum players for this instance.
+    /// @return The new instance ID, or error if limit reached.
+    [[nodiscard]] cgs::foundation::GameResult<uint32_t> createInstance(
+        uint32_t mapId,
+        cgs::game::MapType type = cgs::game::MapType::OpenWorld,
+        uint32_t maxPlayers = 100);
+
+    /// Destroy an instance immediately.
+    ///
+    /// Fails if the instance has players (must drain first).
+    [[nodiscard]] cgs::foundation::GameResult<void> destroyInstance(
+        uint32_t instanceId);
+
+    /// Transition an instance to a new state.
+    ///
+    /// Valid transitions: Active → Draining → ShuttingDown.
+    [[nodiscard]] bool setInstanceState(
+        uint32_t instanceId, InstanceState state);
+
+    /// Get metadata for a specific instance.
+    [[nodiscard]] std::optional<MapInstanceInfo> getInstance(
+        uint32_t instanceId) const;
+
+    /// Get all instances for a given map ID.
+    [[nodiscard]] std::vector<MapInstanceInfo> getInstancesByMap(
+        uint32_t mapId) const;
+
+    /// Get all instances in a given state.
+    [[nodiscard]] std::vector<MapInstanceInfo> getInstancesByState(
+        InstanceState state) const;
+
+    /// Increment the player count for an instance.
+    ///
+    /// Fails if the instance is not Active, does not exist, or is full.
+    [[nodiscard]] bool addPlayer(uint32_t instanceId);
+
+    /// Decrement the player count for an instance.
+    ///
+    /// Fails if the instance does not exist or has zero players.
+    [[nodiscard]] bool removePlayer(uint32_t instanceId);
+
+    /// Get the total number of instances.
+    [[nodiscard]] uint32_t instanceCount() const;
+
+    /// Get the number of instances in a given state.
+    [[nodiscard]] uint32_t instanceCount(InstanceState state) const;
+
+    /// Find all instances with zero players.
+    [[nodiscard]] std::vector<uint32_t> findEmptyInstances() const;
+
+    /// Find instances that can accept more players.
+    [[nodiscard]] std::vector<uint32_t> findAvailableInstances(
+        uint32_t mapId) const;
+
+private:
+    uint32_t maxInstances_;
+    uint32_t nextInstanceId_ = 1;
+    std::unordered_map<uint32_t, MapInstanceInfo> instances_;
+    mutable std::mutex mutex_;
+};
+
+} // namespace cgs::service

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -1,3 +1,4 @@
 # Layer 3: Services
 add_subdirectory(auth)
 add_subdirectory(gateway)
+add_subdirectory(game)

--- a/src/services/game/CMakeLists.txt
+++ b/src/services/game/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Game Service - Game Loop & Map Instance Manager (SDS-MOD-032)
+add_library(cgs_service_game
+    game_loop.cpp
+    map_instance_manager.cpp
+)
+target_link_libraries(cgs_service_game
+    PUBLIC cgs_core
+)
+add_library(cgs::service_game ALIAS cgs_service_game)

--- a/src/services/game/game_loop.cpp
+++ b/src/services/game/game_loop.cpp
@@ -1,0 +1,141 @@
+/// @file game_loop.cpp
+/// @brief GameLoop implementation.
+
+#include "cgs/service/game_loop.hpp"
+
+namespace cgs::service {
+
+GameLoop::GameLoop(uint32_t tickRate)
+    : tickRate_(tickRate > 0 ? tickRate : 20),
+      targetFrameTime_(std::chrono::microseconds(
+          1'000'000 / (tickRate > 0 ? tickRate : 20))) {}
+
+GameLoop::~GameLoop() {
+    stop();
+}
+
+void GameLoop::setTickCallback(TickCallback callback) {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    tickCallback_ = std::move(callback);
+}
+
+void GameLoop::setMetricsCallback(MetricsCallback callback) {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    metricsCallback_ = std::move(callback);
+}
+
+bool GameLoop::start() {
+    bool expected = false;
+    if (!running_.compare_exchange_strong(expected, true)) {
+        return false;
+    }
+
+    thread_ = std::thread([this] { run(); });
+    return true;
+}
+
+void GameLoop::stop() {
+    running_.store(false);
+    if (thread_.joinable()) {
+        thread_.join();
+    }
+}
+
+TickMetrics GameLoop::tick() {
+    return executeTick();
+}
+
+bool GameLoop::isRunning() const noexcept {
+    return running_.load();
+}
+
+uint32_t GameLoop::tickRate() const noexcept {
+    return tickRate_;
+}
+
+std::chrono::microseconds GameLoop::targetFrameTime() const noexcept {
+    return targetFrameTime_;
+}
+
+uint64_t GameLoop::tickCount() const noexcept {
+    return tickCount_.load();
+}
+
+TickMetrics GameLoop::lastMetrics() const {
+    std::lock_guard<std::mutex> lock(metricsMutex_);
+    return lastMetrics_;
+}
+
+void GameLoop::run() {
+    auto nextTick = std::chrono::steady_clock::now();
+
+    while (running_.load()) {
+        nextTick += targetFrameTime_;
+
+        auto metrics = executeTick();
+
+        // Store metrics for external queries.
+        {
+            std::lock_guard<std::mutex> lock(metricsMutex_);
+            lastMetrics_ = metrics;
+        }
+
+        // Notify metrics observer.
+        {
+            std::lock_guard<std::mutex> lock(callbackMutex_);
+            if (metricsCallback_) {
+                metricsCallback_(metrics);
+            }
+        }
+
+        // Sleep until next tick, but skip if we already overran.
+        auto now = std::chrono::steady_clock::now();
+        if (now < nextTick) {
+            std::this_thread::sleep_until(nextTick);
+        } else {
+            // Overrun: reset the target to avoid cascading catch-up.
+            nextTick = now;
+        }
+    }
+}
+
+TickMetrics GameLoop::executeTick() {
+    auto frameStart = std::chrono::steady_clock::now();
+
+    // Invoke the tick callback.
+    {
+        std::lock_guard<std::mutex> lock(callbackMutex_);
+        if (tickCallback_) {
+            auto dtSeconds = static_cast<float>(
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    targetFrameTime_)
+                    .count()) /
+                1'000'000.0f;
+            tickCallback_(dtSeconds);
+        }
+    }
+
+    auto updateEnd = std::chrono::steady_clock::now();
+
+    auto updateDuration =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            updateEnd - frameStart);
+
+    auto targetUs =
+        std::chrono::duration_cast<std::chrono::microseconds>(targetFrameTime_);
+
+    TickMetrics metrics;
+    metrics.updateTime = updateDuration;
+    metrics.frameTime = updateDuration; // For manual tick(), frame = update.
+    metrics.budgetUtilization =
+        targetUs.count() > 0
+            ? static_cast<float>(updateDuration.count()) /
+                  static_cast<float>(targetUs.count())
+            : 0.0f;
+    metrics.tickNumber = tickCount_.fetch_add(1);
+    metrics.overrun = updateDuration > targetFrameTime_;
+
+    return metrics;
+}
+
+} // namespace cgs::service

--- a/src/services/game/map_instance_manager.cpp
+++ b/src/services/game/map_instance_manager.cpp
@@ -1,0 +1,209 @@
+/// @file map_instance_manager.cpp
+/// @brief MapInstanceManager implementation.
+
+#include "cgs/service/map_instance_manager.hpp"
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/foundation/game_error.hpp"
+
+namespace cgs::service {
+
+MapInstanceManager::MapInstanceManager(uint32_t maxInstances)
+    : maxInstances_(maxInstances) {}
+
+cgs::foundation::GameResult<uint32_t> MapInstanceManager::createInstance(
+    uint32_t mapId, cgs::game::MapType type, uint32_t maxPlayers) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (instances_.size() >= static_cast<std::size_t>(maxInstances_)) {
+        return cgs::Result<uint32_t, cgs::foundation::GameError>::err(
+            cgs::foundation::GameError(
+                cgs::foundation::ErrorCode::MapInstanceLimitReached,
+                "Maximum number of map instances reached"));
+    }
+
+    MapInstanceInfo info;
+    info.instanceId = nextInstanceId_++;
+    info.mapId = mapId;
+    info.type = type;
+    info.state = InstanceState::Active;
+    info.playerCount = 0;
+    info.maxPlayers = maxPlayers;
+    info.createdAt = std::chrono::steady_clock::now();
+
+    uint32_t id = info.instanceId;
+    instances_.emplace(id, std::move(info));
+
+    return cgs::Result<uint32_t, cgs::foundation::GameError>::ok(id);
+}
+
+cgs::foundation::GameResult<void> MapInstanceManager::destroyInstance(
+    uint32_t instanceId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = instances_.find(instanceId);
+    if (it == instances_.end()) {
+        return cgs::Result<void, cgs::foundation::GameError>::err(
+            cgs::foundation::GameError(
+                cgs::foundation::ErrorCode::MapInstanceNotFound,
+                "Map instance not found"));
+    }
+
+    if (it->second.playerCount > 0) {
+        return cgs::Result<void, cgs::foundation::GameError>::err(
+            cgs::foundation::GameError(
+                cgs::foundation::ErrorCode::MapInstanceInvalidState,
+                "Cannot destroy instance with active players"));
+    }
+
+    instances_.erase(it);
+    return cgs::Result<void, cgs::foundation::GameError>::ok();
+}
+
+bool MapInstanceManager::setInstanceState(
+    uint32_t instanceId, InstanceState state) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = instances_.find(instanceId);
+    if (it == instances_.end()) {
+        return false;
+    }
+
+    auto current = it->second.state;
+
+    // Enforce valid transitions: Active → Draining → ShuttingDown.
+    if (state == InstanceState::Draining &&
+        current != InstanceState::Active) {
+        return false;
+    }
+    if (state == InstanceState::ShuttingDown &&
+        current != InstanceState::Draining) {
+        return false;
+    }
+    if (state == InstanceState::Active) {
+        // Cannot transition back to Active.
+        return false;
+    }
+
+    it->second.state = state;
+    return true;
+}
+
+std::optional<MapInstanceInfo> MapInstanceManager::getInstance(
+    uint32_t instanceId) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = instances_.find(instanceId);
+    if (it == instances_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::vector<MapInstanceInfo> MapInstanceManager::getInstancesByMap(
+    uint32_t mapId) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    std::vector<MapInstanceInfo> result;
+    for (const auto& [id, info] : instances_) {
+        if (info.mapId == mapId) {
+            result.push_back(info);
+        }
+    }
+    return result;
+}
+
+std::vector<MapInstanceInfo> MapInstanceManager::getInstancesByState(
+    InstanceState state) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    std::vector<MapInstanceInfo> result;
+    for (const auto& [id, info] : instances_) {
+        if (info.state == state) {
+            result.push_back(info);
+        }
+    }
+    return result;
+}
+
+bool MapInstanceManager::addPlayer(uint32_t instanceId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = instances_.find(instanceId);
+    if (it == instances_.end()) {
+        return false;
+    }
+
+    if (it->second.state != InstanceState::Active) {
+        return false;
+    }
+
+    if (it->second.playerCount >= it->second.maxPlayers) {
+        return false;
+    }
+
+    ++it->second.playerCount;
+    return true;
+}
+
+bool MapInstanceManager::removePlayer(uint32_t instanceId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = instances_.find(instanceId);
+    if (it == instances_.end()) {
+        return false;
+    }
+
+    if (it->second.playerCount == 0) {
+        return false;
+    }
+
+    --it->second.playerCount;
+    return true;
+}
+
+uint32_t MapInstanceManager::instanceCount() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return static_cast<uint32_t>(instances_.size());
+}
+
+uint32_t MapInstanceManager::instanceCount(InstanceState state) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    uint32_t count = 0;
+    for (const auto& [id, info] : instances_) {
+        if (info.state == state) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+std::vector<uint32_t> MapInstanceManager::findEmptyInstances() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    std::vector<uint32_t> result;
+    for (const auto& [id, info] : instances_) {
+        if (info.playerCount == 0) {
+            result.push_back(id);
+        }
+    }
+    return result;
+}
+
+std::vector<uint32_t> MapInstanceManager::findAvailableInstances(
+    uint32_t mapId) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    std::vector<uint32_t> result;
+    for (const auto& [id, info] : instances_) {
+        if (info.mapId == mapId &&
+            info.state == InstanceState::Active &&
+            info.playerCount < info.maxPlayers) {
+            result.push_back(id);
+        }
+    }
+    return result;
+}
+
+} // namespace cgs::service

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -249,6 +249,16 @@ target_link_libraries(cgs_service_gateway_tests PRIVATE
 )
 gtest_discover_tests(cgs_service_gateway_tests)
 
+# Unit tests - Service game (game loop, map instance manager)
+add_executable(cgs_service_game_tests
+    unit/service/game_loop_test.cpp
+)
+target_link_libraries(cgs_service_game_tests PRIVATE
+    cgs::service_game
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_service_game_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/service/game_loop_test.cpp
+++ b/tests/unit/service/game_loop_test.cpp
@@ -1,0 +1,509 @@
+/// @file game_loop_test.cpp
+/// @brief Unit tests for GameLoop and MapInstanceManager.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "cgs/service/game_loop.hpp"
+#include "cgs/service/map_instance_manager.hpp"
+
+using namespace cgs::service;
+using namespace std::chrono_literals;
+
+// ============================================================================
+// GameLoop Tests
+// ============================================================================
+
+class GameLoopTest : public ::testing::Test {
+protected:
+    GameLoop loop_{20}; // 20 Hz
+};
+
+TEST_F(GameLoopTest, DefaultTickRate) {
+    EXPECT_EQ(loop_.tickRate(), 20u);
+}
+
+TEST_F(GameLoopTest, TargetFrameTimeForTwentyHz) {
+    EXPECT_EQ(loop_.targetFrameTime(), 50000us);
+}
+
+TEST_F(GameLoopTest, CustomTickRate) {
+    GameLoop custom(60);
+    EXPECT_EQ(custom.tickRate(), 60u);
+    // 1'000'000 / 60 = 16666 us
+    EXPECT_EQ(custom.targetFrameTime().count(), 16666);
+}
+
+TEST_F(GameLoopTest, ZeroTickRateDefaultsToTwenty) {
+    GameLoop zeroRate(0);
+    EXPECT_EQ(zeroRate.tickRate(), 20u);
+}
+
+TEST_F(GameLoopTest, InitialTickCountIsZero) {
+    EXPECT_EQ(loop_.tickCount(), 0u);
+}
+
+TEST_F(GameLoopTest, NotRunningByDefault) {
+    EXPECT_FALSE(loop_.isRunning());
+}
+
+TEST_F(GameLoopTest, ManualTickIncreasesCount) {
+    (void)loop_.tick();
+    EXPECT_EQ(loop_.tickCount(), 1u);
+
+    (void)loop_.tick();
+    EXPECT_EQ(loop_.tickCount(), 2u);
+}
+
+TEST_F(GameLoopTest, ManualTickReturnsMetrics) {
+    auto metrics = loop_.tick();
+
+    EXPECT_EQ(metrics.tickNumber, 0u);
+    EXPECT_GE(metrics.updateTime.count(), 0);
+    EXPECT_GE(metrics.frameTime.count(), 0);
+    EXPECT_GE(metrics.budgetUtilization, 0.0f);
+}
+
+TEST_F(GameLoopTest, TickCallbackIsInvoked) {
+    int callCount = 0;
+    float receivedDt = 0.0f;
+
+    loop_.setTickCallback([&](float dt) {
+        ++callCount;
+        receivedDt = dt;
+    });
+
+    (void)loop_.tick();
+
+    EXPECT_EQ(callCount, 1);
+    EXPECT_NEAR(receivedDt, 0.05f, 0.001f); // 20Hz → 50ms → 0.05s
+}
+
+TEST_F(GameLoopTest, MetricsCallbackNotCalledOnManualTick) {
+    // Metrics callback is only invoked from the thread loop,
+    // not from manual tick().
+    int metricsCount = 0;
+    loop_.setMetricsCallback([&](const TickMetrics&) {
+        ++metricsCount;
+    });
+
+    (void)loop_.tick();
+    EXPECT_EQ(metricsCount, 0);
+}
+
+TEST_F(GameLoopTest, StartAndStopLifecycle) {
+    EXPECT_TRUE(loop_.start());
+    EXPECT_TRUE(loop_.isRunning());
+
+    // Let it run for a few ticks.
+    std::this_thread::sleep_for(120ms);
+
+    loop_.stop();
+    EXPECT_FALSE(loop_.isRunning());
+    EXPECT_GT(loop_.tickCount(), 0u);
+}
+
+TEST_F(GameLoopTest, DoubleStartReturnsFalse) {
+    EXPECT_TRUE(loop_.start());
+    EXPECT_FALSE(loop_.start()); // Already running.
+    loop_.stop();
+}
+
+TEST_F(GameLoopTest, StopWhenNotRunningIsSafe) {
+    loop_.stop(); // No-op, should not crash.
+}
+
+TEST_F(GameLoopTest, ThreadedTickCallbackInvocation) {
+    std::atomic<int> callCount{0};
+
+    loop_.setTickCallback([&](float) {
+        callCount.fetch_add(1);
+    });
+
+    EXPECT_TRUE(loop_.start());
+    std::this_thread::sleep_for(120ms);
+    loop_.stop();
+
+    // At 20Hz, ~120ms should yield 2-3 ticks.
+    EXPECT_GE(callCount.load(), 2);
+}
+
+TEST_F(GameLoopTest, ThreadedMetricsCallbackInvocation) {
+    std::atomic<int> metricsCount{0};
+    TickMetrics lastMetrics;
+
+    loop_.setMetricsCallback([&](const TickMetrics& m) {
+        metricsCount.fetch_add(1);
+        lastMetrics = m;
+    });
+
+    EXPECT_TRUE(loop_.start());
+    std::this_thread::sleep_for(120ms);
+    loop_.stop();
+
+    EXPECT_GE(metricsCount.load(), 2);
+}
+
+TEST_F(GameLoopTest, OverrunDetection) {
+    loop_.setTickCallback([&](float) {
+        // Simulate a slow tick that exceeds the 50ms budget.
+        std::this_thread::sleep_for(60ms);
+    });
+
+    auto metrics = loop_.tick();
+    EXPECT_TRUE(metrics.overrun);
+    EXPECT_GT(metrics.budgetUtilization, 1.0f);
+}
+
+TEST_F(GameLoopTest, NormalTickIsNotOverrun) {
+    loop_.setTickCallback([&](float) {
+        // Very fast tick.
+    });
+
+    auto metrics = loop_.tick();
+    EXPECT_FALSE(metrics.overrun);
+    EXPECT_LT(metrics.budgetUtilization, 1.0f);
+}
+
+TEST_F(GameLoopTest, LastMetricsReflectsLatestTick) {
+    loop_.setTickCallback([&](float) {});
+
+    (void)loop_.tick();
+    (void)loop_.tick();
+    (void)loop_.tick();
+
+    // Manual tick doesn't update lastMetrics_ (only thread loop does),
+    // so we test via the thread loop.
+    EXPECT_TRUE(loop_.start());
+    std::this_thread::sleep_for(80ms);
+    loop_.stop();
+
+    auto metrics = loop_.lastMetrics();
+    EXPECT_GT(metrics.tickNumber, 0u);
+}
+
+TEST_F(GameLoopTest, DestructorStopsRunningLoop) {
+    auto* loop = new GameLoop(20);
+    loop->setTickCallback([](float) {});
+    EXPECT_TRUE(loop->start());
+    EXPECT_TRUE(loop->isRunning());
+    delete loop; // Should call stop() in destructor.
+}
+
+// ============================================================================
+// MapInstanceManager Tests
+// ============================================================================
+
+class MapInstanceManagerTest : public ::testing::Test {
+protected:
+    MapInstanceManager mgr_{100}; // Max 100 instances.
+};
+
+TEST_F(MapInstanceManagerTest, InitialCountIsZero) {
+    EXPECT_EQ(mgr_.instanceCount(), 0u);
+}
+
+TEST_F(MapInstanceManagerTest, CreateInstance) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_EQ(result.value(), 1u); // First instance gets ID 1.
+
+    EXPECT_EQ(mgr_.instanceCount(), 1u);
+}
+
+TEST_F(MapInstanceManagerTest, CreateMultipleInstances) {
+    auto r1 = mgr_.createInstance(1);
+    auto r2 = mgr_.createInstance(1);
+    auto r3 = mgr_.createInstance(2);
+
+    ASSERT_TRUE(r1.hasValue());
+    ASSERT_TRUE(r2.hasValue());
+    ASSERT_TRUE(r3.hasValue());
+
+    EXPECT_NE(r1.value(), r2.value());
+    EXPECT_NE(r2.value(), r3.value());
+    EXPECT_EQ(mgr_.instanceCount(), 3u);
+}
+
+TEST_F(MapInstanceManagerTest, CreateInstanceRespectMaxLimit) {
+    MapInstanceManager small(2);
+    auto r1 = small.createInstance(1);
+    auto r2 = small.createInstance(1);
+    auto r3 = small.createInstance(1);
+
+    EXPECT_TRUE(r1.hasValue());
+    EXPECT_TRUE(r2.hasValue());
+    EXPECT_TRUE(r3.hasError());
+}
+
+TEST_F(MapInstanceManagerTest, GetInstanceReturnsInfo) {
+    auto result = mgr_.createInstance(42, cgs::game::MapType::Dungeon, 50);
+    ASSERT_TRUE(result.hasValue());
+
+    auto info = mgr_.getInstance(result.value());
+    ASSERT_TRUE(info.has_value());
+    EXPECT_EQ(info->mapId, 42u);
+    EXPECT_EQ(info->type, cgs::game::MapType::Dungeon);
+    EXPECT_EQ(info->maxPlayers, 50u);
+    EXPECT_EQ(info->state, InstanceState::Active);
+    EXPECT_EQ(info->playerCount, 0u);
+}
+
+TEST_F(MapInstanceManagerTest, GetNonexistentInstanceReturnsNullopt) {
+    auto info = mgr_.getInstance(999);
+    EXPECT_FALSE(info.has_value());
+}
+
+TEST_F(MapInstanceManagerTest, DestroyEmptyInstance) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+
+    auto destroyResult = mgr_.destroyInstance(result.value());
+    EXPECT_TRUE(destroyResult.hasValue());
+    EXPECT_EQ(mgr_.instanceCount(), 0u);
+}
+
+TEST_F(MapInstanceManagerTest, DestroyNonexistentInstanceFails) {
+    auto result = mgr_.destroyInstance(999);
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST_F(MapInstanceManagerTest, DestroyInstanceWithPlayersFails) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+
+    EXPECT_TRUE(mgr_.addPlayer(result.value()));
+
+    auto destroyResult = mgr_.destroyInstance(result.value());
+    EXPECT_TRUE(destroyResult.hasError());
+}
+
+TEST_F(MapInstanceManagerTest, AddAndRemovePlayer) {
+    auto result = mgr_.createInstance(1, cgs::game::MapType::OpenWorld, 10);
+    ASSERT_TRUE(result.hasValue());
+    auto id = result.value();
+
+    EXPECT_TRUE(mgr_.addPlayer(id));
+    EXPECT_TRUE(mgr_.addPlayer(id));
+
+    auto info = mgr_.getInstance(id);
+    EXPECT_EQ(info->playerCount, 2u);
+
+    EXPECT_TRUE(mgr_.removePlayer(id));
+    info = mgr_.getInstance(id);
+    EXPECT_EQ(info->playerCount, 1u);
+}
+
+TEST_F(MapInstanceManagerTest, AddPlayerToNonexistentInstanceFails) {
+    EXPECT_FALSE(mgr_.addPlayer(999));
+}
+
+TEST_F(MapInstanceManagerTest, RemovePlayerFromEmptyInstanceFails) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+
+    EXPECT_FALSE(mgr_.removePlayer(result.value()));
+}
+
+TEST_F(MapInstanceManagerTest, AddPlayerRespectMaxPlayers) {
+    auto result = mgr_.createInstance(1, cgs::game::MapType::OpenWorld, 2);
+    ASSERT_TRUE(result.hasValue());
+    auto id = result.value();
+
+    EXPECT_TRUE(mgr_.addPlayer(id));
+    EXPECT_TRUE(mgr_.addPlayer(id));
+    EXPECT_FALSE(mgr_.addPlayer(id)); // Full.
+}
+
+TEST_F(MapInstanceManagerTest, StateTransitionActiveToDraining) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+    auto id = result.value();
+
+    EXPECT_TRUE(mgr_.setInstanceState(id, InstanceState::Draining));
+
+    auto info = mgr_.getInstance(id);
+    EXPECT_EQ(info->state, InstanceState::Draining);
+}
+
+TEST_F(MapInstanceManagerTest, StateTransitionDrainingToShuttingDown) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+    auto id = result.value();
+
+    EXPECT_TRUE(mgr_.setInstanceState(id, InstanceState::Draining));
+    EXPECT_TRUE(mgr_.setInstanceState(id, InstanceState::ShuttingDown));
+
+    auto info = mgr_.getInstance(id);
+    EXPECT_EQ(info->state, InstanceState::ShuttingDown);
+}
+
+TEST_F(MapInstanceManagerTest, InvalidStateTransitionActiveToShuttingDown) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+
+    // Cannot skip Draining.
+    EXPECT_FALSE(mgr_.setInstanceState(result.value(), InstanceState::ShuttingDown));
+}
+
+TEST_F(MapInstanceManagerTest, CannotTransitionBackToActive) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+    auto id = result.value();
+
+    EXPECT_TRUE(mgr_.setInstanceState(id, InstanceState::Draining));
+    EXPECT_FALSE(mgr_.setInstanceState(id, InstanceState::Active));
+}
+
+TEST_F(MapInstanceManagerTest, CannotAddPlayerToDrainingInstance) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+    auto id = result.value();
+
+    EXPECT_TRUE(mgr_.setInstanceState(id, InstanceState::Draining));
+    EXPECT_FALSE(mgr_.addPlayer(id));
+}
+
+TEST_F(MapInstanceManagerTest, CanRemovePlayerFromDrainingInstance) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+    auto id = result.value();
+
+    EXPECT_TRUE(mgr_.addPlayer(id));
+    EXPECT_TRUE(mgr_.setInstanceState(id, InstanceState::Draining));
+    EXPECT_TRUE(mgr_.removePlayer(id));
+}
+
+TEST_F(MapInstanceManagerTest, GetInstancesByMap) {
+    (void)mgr_.createInstance(1);
+    (void)mgr_.createInstance(1);
+    (void)mgr_.createInstance(2);
+
+    auto map1Instances = mgr_.getInstancesByMap(1);
+    EXPECT_EQ(map1Instances.size(), 2u);
+
+    auto map2Instances = mgr_.getInstancesByMap(2);
+    EXPECT_EQ(map2Instances.size(), 1u);
+
+    auto map3Instances = mgr_.getInstancesByMap(3);
+    EXPECT_TRUE(map3Instances.empty());
+}
+
+TEST_F(MapInstanceManagerTest, GetInstancesByState) {
+    auto r1 = mgr_.createInstance(1);
+    auto r2 = mgr_.createInstance(1);
+    (void)mgr_.createInstance(2);
+
+    ASSERT_TRUE(r1.hasValue());
+    ASSERT_TRUE(r2.hasValue());
+
+    EXPECT_TRUE(mgr_.setInstanceState(r1.value(), InstanceState::Draining));
+
+    auto active = mgr_.getInstancesByState(InstanceState::Active);
+    EXPECT_EQ(active.size(), 2u);
+
+    auto draining = mgr_.getInstancesByState(InstanceState::Draining);
+    EXPECT_EQ(draining.size(), 1u);
+}
+
+TEST_F(MapInstanceManagerTest, InstanceCountByState) {
+    auto r1 = mgr_.createInstance(1);
+    (void)mgr_.createInstance(1);
+
+    ASSERT_TRUE(r1.hasValue());
+    EXPECT_TRUE(mgr_.setInstanceState(r1.value(), InstanceState::Draining));
+
+    EXPECT_EQ(mgr_.instanceCount(InstanceState::Active), 1u);
+    EXPECT_EQ(mgr_.instanceCount(InstanceState::Draining), 1u);
+    EXPECT_EQ(mgr_.instanceCount(InstanceState::ShuttingDown), 0u);
+}
+
+TEST_F(MapInstanceManagerTest, FindEmptyInstances) {
+    auto r1 = mgr_.createInstance(1);
+    auto r2 = mgr_.createInstance(1);
+
+    ASSERT_TRUE(r1.hasValue());
+    ASSERT_TRUE(r2.hasValue());
+
+    EXPECT_TRUE(mgr_.addPlayer(r1.value()));
+
+    auto empty = mgr_.findEmptyInstances();
+    ASSERT_EQ(empty.size(), 1u);
+    EXPECT_EQ(empty[0], r2.value());
+}
+
+TEST_F(MapInstanceManagerTest, FindAvailableInstances) {
+    auto r1 = mgr_.createInstance(1, cgs::game::MapType::OpenWorld, 2);
+    auto r2 = mgr_.createInstance(1, cgs::game::MapType::OpenWorld, 2);
+    auto r3 = mgr_.createInstance(2, cgs::game::MapType::OpenWorld, 2);
+
+    ASSERT_TRUE(r1.hasValue());
+    ASSERT_TRUE(r2.hasValue());
+    ASSERT_TRUE(r3.hasValue());
+
+    // Fill up r1.
+    EXPECT_TRUE(mgr_.addPlayer(r1.value()));
+    EXPECT_TRUE(mgr_.addPlayer(r1.value()));
+
+    // Drain r2.
+    EXPECT_TRUE(mgr_.setInstanceState(r2.value(), InstanceState::Draining));
+
+    // Map 1: no available instances (r1 full, r2 draining).
+    auto available1 = mgr_.findAvailableInstances(1);
+    EXPECT_TRUE(available1.empty());
+
+    // Map 2: r3 is available.
+    auto available2 = mgr_.findAvailableInstances(2);
+    ASSERT_EQ(available2.size(), 1u);
+    EXPECT_EQ(available2[0], r3.value());
+}
+
+TEST_F(MapInstanceManagerTest, InstanceCreatedAtTimestamp) {
+    auto before = std::chrono::steady_clock::now();
+    auto result = mgr_.createInstance(1);
+    auto after = std::chrono::steady_clock::now();
+
+    ASSERT_TRUE(result.hasValue());
+    auto info = mgr_.getInstance(result.value());
+    ASSERT_TRUE(info.has_value());
+
+    EXPECT_GE(info->createdAt, before);
+    EXPECT_LE(info->createdAt, after);
+}
+
+TEST_F(MapInstanceManagerTest, StateTransitionOnNonexistentInstanceFails) {
+    EXPECT_FALSE(mgr_.setInstanceState(999, InstanceState::Draining));
+}
+
+TEST_F(MapInstanceManagerTest, MapTypePreserved) {
+    auto r1 = mgr_.createInstance(1, cgs::game::MapType::OpenWorld);
+    auto r2 = mgr_.createInstance(2, cgs::game::MapType::Dungeon);
+    auto r3 = mgr_.createInstance(3, cgs::game::MapType::Battleground);
+
+    ASSERT_TRUE(r1.hasValue());
+    ASSERT_TRUE(r2.hasValue());
+    ASSERT_TRUE(r3.hasValue());
+
+    EXPECT_EQ(mgr_.getInstance(r1.value())->type, cgs::game::MapType::OpenWorld);
+    EXPECT_EQ(mgr_.getInstance(r2.value())->type, cgs::game::MapType::Dungeon);
+    EXPECT_EQ(mgr_.getInstance(r3.value())->type, cgs::game::MapType::Battleground);
+}
+
+TEST_F(MapInstanceManagerTest, DestroyAfterDrainingAndEmpty) {
+    auto result = mgr_.createInstance(1);
+    ASSERT_TRUE(result.hasValue());
+    auto id = result.value();
+
+    EXPECT_TRUE(mgr_.addPlayer(id));
+    EXPECT_TRUE(mgr_.setInstanceState(id, InstanceState::Draining));
+    EXPECT_TRUE(mgr_.removePlayer(id));
+    EXPECT_TRUE(mgr_.setInstanceState(id, InstanceState::ShuttingDown));
+
+    auto destroyResult = mgr_.destroyInstance(id);
+    EXPECT_TRUE(destroyResult.hasValue());
+    EXPECT_EQ(mgr_.instanceCount(), 0u);
+}


### PR DESCRIPTION
Closes #64
Part of #24

## Summary

- Add `GameLoop` class with configurable tick rate (default 20 Hz = 50ms), dedicated thread, frame time measurement, budget utilization tracking, and overrun detection
- Add `MapInstanceManager` for map instance lifecycle management with state machine (Active → Draining → ShuttingDown), player count tracking, max player enforcement, and instance queries
- Add `GameServer` error codes at 0x0B00 range (MapInstanceNotFound, MapInstanceLimitReached, MapInstanceInvalidState, GameLoopAlreadyRunning, GameLoopNotRunning)
- 47 unit tests covering all components

## Design Decisions

- **GameLoop threading model**: The loop owns its own `std::thread` and uses `sleep_until` for precise tick timing. On overrun, it resets the target time to avoid cascading catch-up ("skip" strategy rather than "rush").
- **Manual tick() for testing**: Allows deterministic testing without needing to deal with thread timing. The thread loop path and manual path share the same `executeTick()` implementation.
- **MapInstance state machine**: Enforces strict forward-only transitions (Active → Draining → ShuttingDown) to prevent accidental re-activation of draining instances. Players can still leave a draining instance but cannot join.
- **Separation from WorldSystem**: MapInstanceManager tracks service-level metadata (player counts, states) while WorldSystem (game layer) handles spatial data. This keeps the layering clean.

## Test Plan

- [x] GameLoop: tick rate configuration, frame timing, callback invocation, start/stop lifecycle, double-start prevention, overrun detection, threaded execution, destructor safety
- [x] MapInstanceManager: create/destroy, max limits, player add/remove, state transitions, invalid transitions, queries by map/state, empty/available instance discovery, timestamp tracking
- [x] All 47 tests pass
- [x] Full regression: 1026 tests pass (0 failures)