### PR TITLE
feat(service): add Matchmaking Queue & ELO Calculator

### DIFF
--- a/include/cgs/foundation/error_code.hpp
+++ b/include/cgs/foundation/error_code.hpp
@@ -103,6 +103,15 @@ enum class ErrorCode : uint32_t {
     MapInstanceInvalidState = 0x0B03,
     GameLoopAlreadyRunning = 0x0B04,
     GameLoopNotRunning = 0x0B05,
+
+    // Lobby (0x0C00 - 0x0CFF)
+    LobbyError = 0x0C00,
+    QueueFull = 0x0C01,
+    AlreadyInQueue = 0x0C02,
+    NotInQueue = 0x0C03,
+    InvalidRating = 0x0C04,
+    PartyNotFound = 0x0C05,
+    PartyFull = 0x0C06,
 };
 
 /// Return the subsystem name for a given error code.
@@ -122,6 +131,7 @@ constexpr std::string_view errorSubsystem(ErrorCode code) {
         case 0x0900: return "Monitoring";
         case 0x0A00: return "Serialization";
         case 0x0B00: return "GameServer";
+        case 0x0C00: return "Lobby";
         default: return "Unknown";
     }
 }

--- a/include/cgs/service/elo_calculator.hpp
+++ b/include/cgs/service/elo_calculator.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+/// @file elo_calculator.hpp
+/// @brief ELO/MMR rating calculations for skill-based matchmaking.
+///
+/// Provides the standard Elo expected-score formula, rating updates
+/// with configurable K-factor, and match quality assessment.
+///
+/// @see SRS-SVC-004.2
+/// @see SDS-MOD-033
+
+#include <cstdint>
+#include <vector>
+
+namespace cgs::service {
+
+/// Static utility class for ELO/MMR rating calculations.
+///
+/// Uses the standard Elo formula:
+///   E(A) = 1 / (1 + 10^((R_B - R_A) / 400))
+///
+/// K-factor determines how much a single game can change a rating.
+/// Typical values: 32 (new players), 24 (established), 16 (masters).
+class EloCalculator {
+public:
+    EloCalculator() = delete;
+
+    /// Default K-factor for rating adjustments.
+    static constexpr int32_t kDefaultKFactor = 32;
+
+    /// Calculate the expected score for player A vs player B.
+    ///
+    /// @param ratingA  Player A's current rating.
+    /// @param ratingB  Player B's current rating.
+    /// @return Expected score in [0.0, 1.0].
+    [[nodiscard]] static float expectedScore(int32_t ratingA, int32_t ratingB);
+
+    /// Calculate the new rating after a game.
+    ///
+    /// @param currentRating  Player's rating before the game.
+    /// @param actualScore    Actual game result: 1.0 = win, 0.5 = draw, 0.0 = loss.
+    /// @param expectedScore  Expected score from expectedScore().
+    /// @param kFactor        Rating change sensitivity.
+    /// @return Updated rating.
+    [[nodiscard]] static int32_t newRating(
+        int32_t currentRating,
+        float actualScore,
+        float expectedScore,
+        int32_t kFactor = kDefaultKFactor);
+
+    /// Assess the quality of a potential match.
+    ///
+    /// Returns a value in [0.0, 1.0] where 1.0 means all players
+    /// have identical ratings (perfect match).  Quality decreases
+    /// as the rating spread increases.
+    ///
+    /// @param ratings  MMR values of all players in the match.
+    /// @return Quality score.
+    [[nodiscard]] static float matchQuality(const std::vector<int32_t>& ratings);
+
+    /// Check whether two ratings are within the given tolerance.
+    [[nodiscard]] static bool isWithinTolerance(
+        int32_t ratingA, int32_t ratingB, int32_t tolerance);
+
+    /// Determine an appropriate K-factor based on games played.
+    ///
+    /// New players (< 30 games) get higher K to converge faster.
+    /// Established players (30-100) get standard K.
+    /// Veterans (100+) get lower K for stability.
+    [[nodiscard]] static int32_t suggestedKFactor(uint32_t gamesPlayed);
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/lobby_types.hpp
+++ b/include/cgs/service/lobby_types.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+/// @file lobby_types.hpp
+/// @brief Core types for the Lobby Server matchmaking system.
+///
+/// Defines game modes, regions, player ratings (ELO/MMR),
+/// matchmaking tickets, match results, and queue configuration.
+///
+/// @see SRS-SVC-004
+/// @see SDS-MOD-033
+
+#include <chrono>
+#include <cstdint>
+#include <vector>
+
+namespace cgs::service {
+
+/// Available game modes for matchmaking.
+enum class GameMode : uint8_t {
+    Duel,         ///< 1v1 match.
+    Arena,        ///< Small team PvP (e.g. 3v3).
+    Battleground, ///< Large team PvP (e.g. 10v10).
+    Dungeon,      ///< PvE group content.
+    Raid          ///< Large PvE content.
+};
+
+/// Server regions for latency-based matchmaking.
+enum class Region : uint8_t {
+    Any,       ///< No preference (match with any region).
+    NAEast,    ///< North America East.
+    NAWest,    ///< North America West.
+    EU,        ///< Europe.
+    Asia,      ///< Asia.
+    Oceania    ///< Oceania.
+};
+
+/// Player skill rating for matchmaking.
+struct PlayerRating {
+    int32_t mmr = 1500;        ///< Match-Making Rating (Elo-based).
+    float uncertainty = 350.0f; ///< Rating uncertainty (higher = less confident).
+    uint32_t gamesPlayed = 0;   ///< Total ranked games played.
+};
+
+/// A player's request to join a matchmaking queue.
+struct MatchmakingTicket {
+    uint64_t playerId = 0;
+    PlayerRating rating;
+    GameMode mode = GameMode::Duel;
+    Region region = Region::Any;
+    std::chrono::steady_clock::time_point enqueuedAt;
+};
+
+/// Result of a successful match.
+struct MatchResult {
+    uint64_t matchId = 0;
+    std::vector<MatchmakingTicket> players;
+    float averageRating = 0.0f;
+    float matchQuality = 0.0f;  ///< 0.0 = worst, 1.0 = perfect.
+};
+
+/// Configuration for a matchmaking queue.
+struct QueueConfig {
+    uint32_t minPlayersPerMatch = 2;  ///< Minimum players to form a match.
+    uint32_t maxPlayersPerMatch = 2;  ///< Maximum players per match.
+
+    int32_t initialRatingTolerance = 100;  ///< Starting MMR window.
+    int32_t maxRatingTolerance = 500;      ///< Upper bound on MMR window.
+    int32_t expansionStep = 50;            ///< MMR window growth per interval.
+
+    /// How often the tolerance expands for waiting players.
+    std::chrono::seconds expansionInterval{10};
+
+    uint32_t maxQueueSize = 10000;  ///< Maximum players in the queue.
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/matchmaking_queue.hpp
+++ b/include/cgs/service/matchmaking_queue.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+/// @file matchmaking_queue.hpp
+/// @brief Skill-based matchmaking queue with rating tolerance expansion.
+///
+/// MatchmakingQueue accepts player tickets and attempts to form
+/// balanced matches based on ELO/MMR ratings.  Players who wait
+/// longer get progressively wider rating tolerance, ensuring
+/// everyone eventually finds a match.
+///
+/// @see SRS-SVC-004.1, SRS-SVC-004.2
+/// @see SDS-MOD-033
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/service/lobby_types.hpp"
+
+namespace cgs::service {
+
+/// Thread-safe matchmaking queue with rating-based matching.
+///
+/// Usage:
+/// @code
+///   MatchmakingQueue queue(config);
+///   queue.enqueue(ticket);
+///   auto match = queue.tryMatch(); // Called periodically
+///   if (match) { /* start game with match->players */ }
+/// @endcode
+class MatchmakingQueue {
+public:
+    /// Construct a queue with the given configuration.
+    explicit MatchmakingQueue(QueueConfig config);
+
+    /// Add a player to the queue.
+    ///
+    /// @return Error if the queue is full or the player is already queued.
+    [[nodiscard]] cgs::foundation::GameResult<void> enqueue(
+        MatchmakingTicket ticket);
+
+    /// Remove a player from the queue.
+    ///
+    /// @return true if the player was found and removed.
+    [[nodiscard]] bool dequeue(uint64_t playerId);
+
+    /// Attempt to form a match from currently queued players.
+    ///
+    /// Scans the queue for a group of players within rating tolerance.
+    /// Players who have waited longer get expanded tolerance windows.
+    ///
+    /// @return A MatchResult if a valid match was found, nullopt otherwise.
+    [[nodiscard]] std::optional<MatchResult> tryMatch();
+
+    /// Check if a player is currently in the queue.
+    [[nodiscard]] bool isQueued(uint64_t playerId) const;
+
+    /// Get a player's ticket.
+    [[nodiscard]] std::optional<MatchmakingTicket> getTicket(
+        uint64_t playerId) const;
+
+    /// Get the current number of players in the queue.
+    [[nodiscard]] std::size_t queueSize() const;
+
+    /// Get the queue configuration.
+    [[nodiscard]] const QueueConfig& config() const noexcept;
+
+private:
+    /// Calculate the effective rating tolerance for a ticket
+    /// based on how long it has been waiting.
+    [[nodiscard]] int32_t effectiveTolerance(
+        const MatchmakingTicket& ticket) const;
+
+    /// Generate a unique match ID.
+    [[nodiscard]] uint64_t nextMatchId();
+
+    QueueConfig config_;
+    std::vector<MatchmakingTicket> tickets_;
+    std::unordered_map<uint64_t, std::size_t> playerIndex_;
+    std::atomic<uint64_t> nextMatchId_{1};
+    mutable std::mutex mutex_;
+};
+
+} // namespace cgs::service

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -2,3 +2,4 @@
 add_subdirectory(auth)
 add_subdirectory(gateway)
 add_subdirectory(game)
+add_subdirectory(lobby)

--- a/src/services/lobby/CMakeLists.txt
+++ b/src/services/lobby/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Lobby Service - Matchmaking Queue & ELO Calculator (SDS-MOD-033)
+add_library(cgs_service_lobby
+    elo_calculator.cpp
+    matchmaking_queue.cpp
+)
+target_link_libraries(cgs_service_lobby
+    PUBLIC cgs_core
+)
+add_library(cgs::service_lobby ALIAS cgs_service_lobby)

--- a/src/services/lobby/elo_calculator.cpp
+++ b/src/services/lobby/elo_calculator.cpp
@@ -1,0 +1,66 @@
+/// @file elo_calculator.cpp
+/// @brief EloCalculator implementation.
+
+#include "cgs/service/elo_calculator.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+namespace cgs::service {
+
+float EloCalculator::expectedScore(int32_t ratingA, int32_t ratingB) {
+    float exponent =
+        static_cast<float>(ratingB - ratingA) / 400.0f;
+    return 1.0f / (1.0f + std::pow(10.0f, exponent));
+}
+
+int32_t EloCalculator::newRating(
+    int32_t currentRating,
+    float actualScore,
+    float expected,
+    int32_t kFactor) {
+    float delta =
+        static_cast<float>(kFactor) * (actualScore - expected);
+    return currentRating + static_cast<int32_t>(std::round(delta));
+}
+
+float EloCalculator::matchQuality(const std::vector<int32_t>& ratings) {
+    if (ratings.size() < 2) {
+        return 1.0f;
+    }
+
+    // Average rating.
+    double sum = std::accumulate(ratings.begin(), ratings.end(), 0.0);
+    double avg = sum / static_cast<double>(ratings.size());
+
+    // Standard deviation of ratings.
+    double sqSum = 0.0;
+    for (auto r : ratings) {
+        double diff = static_cast<double>(r) - avg;
+        sqSum += diff * diff;
+    }
+    double stddev = std::sqrt(sqSum / static_cast<double>(ratings.size()));
+
+    // Map standard deviation to quality: 0 stddev = 1.0, 400 stddev = 0.0.
+    // Using exponential decay: quality = exp(-stddev / 200).
+    float quality = std::exp(static_cast<float>(-stddev / 200.0));
+    return std::clamp(quality, 0.0f, 1.0f);
+}
+
+bool EloCalculator::isWithinTolerance(
+    int32_t ratingA, int32_t ratingB, int32_t tolerance) {
+    return std::abs(ratingA - ratingB) <= tolerance;
+}
+
+int32_t EloCalculator::suggestedKFactor(uint32_t gamesPlayed) {
+    if (gamesPlayed < 30) {
+        return 40; // Provisional: converge quickly.
+    }
+    if (gamesPlayed < 100) {
+        return 32; // Standard.
+    }
+    return 16; // Veteran: stable rating.
+}
+
+} // namespace cgs::service

--- a/src/services/lobby/matchmaking_queue.cpp
+++ b/src/services/lobby/matchmaking_queue.cpp
@@ -1,0 +1,208 @@
+/// @file matchmaking_queue.cpp
+/// @brief MatchmakingQueue implementation.
+
+#include "cgs/service/matchmaking_queue.hpp"
+
+#include <algorithm>
+#include <numeric>
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/foundation/game_error.hpp"
+#include "cgs/service/elo_calculator.hpp"
+
+namespace cgs::service {
+
+MatchmakingQueue::MatchmakingQueue(QueueConfig config)
+    : config_(std::move(config)) {}
+
+cgs::foundation::GameResult<void> MatchmakingQueue::enqueue(
+    MatchmakingTicket ticket) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (tickets_.size() >= static_cast<std::size_t>(config_.maxQueueSize)) {
+        return cgs::Result<void, cgs::foundation::GameError>::err(
+            cgs::foundation::GameError(
+                cgs::foundation::ErrorCode::QueueFull,
+                "Matchmaking queue is full"));
+    }
+
+    if (playerIndex_.count(ticket.playerId) > 0) {
+        return cgs::Result<void, cgs::foundation::GameError>::err(
+            cgs::foundation::GameError(
+                cgs::foundation::ErrorCode::AlreadyInQueue,
+                "Player is already in the matchmaking queue"));
+    }
+
+    playerIndex_[ticket.playerId] = tickets_.size();
+    tickets_.push_back(std::move(ticket));
+
+    return cgs::Result<void, cgs::foundation::GameError>::ok();
+}
+
+bool MatchmakingQueue::dequeue(uint64_t playerId) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = playerIndex_.find(playerId);
+    if (it == playerIndex_.end()) {
+        return false;
+    }
+
+    auto idx = it->second;
+    auto lastIdx = tickets_.size() - 1;
+
+    // Swap with last element for O(1) removal.
+    if (idx != lastIdx) {
+        std::swap(tickets_[idx], tickets_[lastIdx]);
+        playerIndex_[tickets_[idx].playerId] = idx;
+    }
+
+    tickets_.pop_back();
+    playerIndex_.erase(it);
+    return true;
+}
+
+std::optional<MatchResult> MatchmakingQueue::tryMatch() {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (tickets_.size() < static_cast<std::size_t>(config_.minPlayersPerMatch)) {
+        return std::nullopt;
+    }
+
+    // Try to build a match starting from each ticket as the anchor.
+    // Prioritize tickets that have waited longest (front of the vector).
+    for (std::size_t anchorIdx = 0; anchorIdx < tickets_.size(); ++anchorIdx) {
+        const auto& anchor = tickets_[anchorIdx];
+        int32_t anchorTolerance = effectiveTolerance(anchor);
+
+        // Collect compatible tickets.
+        std::vector<std::size_t> candidates;
+        candidates.push_back(anchorIdx);
+
+        for (std::size_t i = 0; i < tickets_.size(); ++i) {
+            if (i == anchorIdx) {
+                continue;
+            }
+
+            const auto& candidate = tickets_[i];
+
+            // Must share the same game mode.
+            if (candidate.mode != anchor.mode) {
+                continue;
+            }
+
+            // Region must be compatible (Any matches everything).
+            if (anchor.region != Region::Any &&
+                candidate.region != Region::Any &&
+                anchor.region != candidate.region) {
+                continue;
+            }
+
+            // Check rating tolerance from both perspectives.
+            int32_t candidateTolerance = effectiveTolerance(candidate);
+            int32_t tolerance = std::max(anchorTolerance, candidateTolerance);
+
+            if (!EloCalculator::isWithinTolerance(
+                    anchor.rating.mmr, candidate.rating.mmr, tolerance)) {
+                continue;
+            }
+
+            candidates.push_back(i);
+
+            if (candidates.size() >=
+                static_cast<std::size_t>(config_.maxPlayersPerMatch)) {
+                break;
+            }
+        }
+
+        // Check if we have enough players.
+        if (candidates.size() <
+            static_cast<std::size_t>(config_.minPlayersPerMatch)) {
+            continue;
+        }
+
+        // Build the match result.
+        MatchResult result;
+        result.matchId = nextMatchId();
+
+        std::vector<int32_t> ratings;
+        for (auto idx : candidates) {
+            result.players.push_back(tickets_[idx]);
+            ratings.push_back(tickets_[idx].rating.mmr);
+        }
+
+        float sum = 0.0f;
+        for (auto r : ratings) {
+            sum += static_cast<float>(r);
+        }
+        result.averageRating = sum / static_cast<float>(ratings.size());
+        result.matchQuality = EloCalculator::matchQuality(ratings);
+
+        // Remove matched players from the queue (reverse order to
+        // preserve indices during removal).
+        std::sort(candidates.begin(), candidates.end(), std::greater<>());
+        for (auto idx : candidates) {
+            auto lastIdx = tickets_.size() - 1;
+            auto pid = tickets_[idx].playerId;
+
+            if (idx != lastIdx) {
+                std::swap(tickets_[idx], tickets_[lastIdx]);
+                playerIndex_[tickets_[idx].playerId] = idx;
+            }
+
+            tickets_.pop_back();
+            playerIndex_.erase(pid);
+        }
+
+        return result;
+    }
+
+    return std::nullopt;
+}
+
+bool MatchmakingQueue::isQueued(uint64_t playerId) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return playerIndex_.count(playerId) > 0;
+}
+
+std::optional<MatchmakingTicket> MatchmakingQueue::getTicket(
+    uint64_t playerId) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = playerIndex_.find(playerId);
+    if (it == playerIndex_.end()) {
+        return std::nullopt;
+    }
+    return tickets_[it->second];
+}
+
+std::size_t MatchmakingQueue::queueSize() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return tickets_.size();
+}
+
+const QueueConfig& MatchmakingQueue::config() const noexcept {
+    return config_;
+}
+
+int32_t MatchmakingQueue::effectiveTolerance(
+    const MatchmakingTicket& ticket) const {
+    auto now = std::chrono::steady_clock::now();
+    auto waited = std::chrono::duration_cast<std::chrono::seconds>(
+        now - ticket.enqueuedAt);
+
+    if (config_.expansionInterval.count() <= 0) {
+        return config_.initialRatingTolerance;
+    }
+
+    auto expansions = waited.count() / config_.expansionInterval.count();
+    int32_t expanded = config_.initialRatingTolerance +
+                       static_cast<int32_t>(expansions) * config_.expansionStep;
+
+    return std::min(expanded, config_.maxRatingTolerance);
+}
+
+uint64_t MatchmakingQueue::nextMatchId() {
+    return nextMatchId_.fetch_add(1);
+}
+
+} // namespace cgs::service

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -259,6 +259,16 @@ target_link_libraries(cgs_service_game_tests PRIVATE
 )
 gtest_discover_tests(cgs_service_game_tests)
 
+# Unit tests - Service lobby (matchmaking queue, ELO calculator)
+add_executable(cgs_service_lobby_tests
+    unit/service/matchmaking_test.cpp
+)
+target_link_libraries(cgs_service_lobby_tests PRIVATE
+    cgs::service_lobby
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_service_lobby_tests)
+
 # Integration tests - foundation network
 add_executable(cgs_foundation_network_integration_tests
     integration/foundation/network_integration_test.cpp

--- a/tests/unit/service/matchmaking_test.cpp
+++ b/tests/unit/service/matchmaking_test.cpp
@@ -1,0 +1,451 @@
+/// @file matchmaking_test.cpp
+/// @brief Unit tests for EloCalculator and MatchmakingQueue.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#include "cgs/service/elo_calculator.hpp"
+#include "cgs/service/lobby_types.hpp"
+#include "cgs/service/matchmaking_queue.hpp"
+
+using namespace cgs::service;
+using namespace std::chrono_literals;
+
+// ============================================================================
+// EloCalculator Tests
+// ============================================================================
+
+class EloCalculatorTest : public ::testing::Test {};
+
+TEST_F(EloCalculatorTest, ExpectedScoreEqualRatings) {
+    float score = EloCalculator::expectedScore(1500, 1500);
+    EXPECT_NEAR(score, 0.5f, 0.001f);
+}
+
+TEST_F(EloCalculatorTest, ExpectedScoreHigherRatingAdvantage) {
+    float score = EloCalculator::expectedScore(1600, 1400);
+    EXPECT_GT(score, 0.5f);
+    EXPECT_LT(score, 1.0f);
+}
+
+TEST_F(EloCalculatorTest, ExpectedScoreLowerRatingDisadvantage) {
+    float score = EloCalculator::expectedScore(1400, 1600);
+    EXPECT_LT(score, 0.5f);
+    EXPECT_GT(score, 0.0f);
+}
+
+TEST_F(EloCalculatorTest, ExpectedScoreSymmetry) {
+    float scoreA = EloCalculator::expectedScore(1500, 1700);
+    float scoreB = EloCalculator::expectedScore(1700, 1500);
+    EXPECT_NEAR(scoreA + scoreB, 1.0f, 0.001f);
+}
+
+TEST_F(EloCalculatorTest, ExpectedScore400Difference) {
+    // 400 point difference → expected ~0.909 for stronger player.
+    float score = EloCalculator::expectedScore(1900, 1500);
+    EXPECT_NEAR(score, 0.909f, 0.01f);
+}
+
+TEST_F(EloCalculatorTest, NewRatingWinIncreasesRating) {
+    float expected = EloCalculator::expectedScore(1500, 1500);
+    int32_t updated = EloCalculator::newRating(1500, 1.0f, expected);
+    EXPECT_GT(updated, 1500);
+}
+
+TEST_F(EloCalculatorTest, NewRatingLossDecreasesRating) {
+    float expected = EloCalculator::expectedScore(1500, 1500);
+    int32_t updated = EloCalculator::newRating(1500, 0.0f, expected);
+    EXPECT_LT(updated, 1500);
+}
+
+TEST_F(EloCalculatorTest, NewRatingDrawAgainstEqual) {
+    float expected = EloCalculator::expectedScore(1500, 1500);
+    int32_t updated = EloCalculator::newRating(1500, 0.5f, expected);
+    EXPECT_EQ(updated, 1500);
+}
+
+TEST_F(EloCalculatorTest, NewRatingUpsetWinLargerGain) {
+    // Weaker player (1400) beats stronger (1600).
+    float expected = EloCalculator::expectedScore(1400, 1600);
+    int32_t updated = EloCalculator::newRating(1400, 1.0f, expected, 32);
+
+    // Expected win probability ~0.24, so gain = 32 * (1.0 - 0.24) ≈ 24.
+    EXPECT_GT(updated - 1400, 20);
+}
+
+TEST_F(EloCalculatorTest, NewRatingHigherKFactorLargerChange) {
+    float expected = EloCalculator::expectedScore(1500, 1500);
+    int32_t k16 = EloCalculator::newRating(1500, 1.0f, expected, 16);
+    int32_t k32 = EloCalculator::newRating(1500, 1.0f, expected, 32);
+    int32_t k40 = EloCalculator::newRating(1500, 1.0f, expected, 40);
+
+    EXPECT_LT(k16 - 1500, k32 - 1500);
+    EXPECT_LT(k32 - 1500, k40 - 1500);
+}
+
+TEST_F(EloCalculatorTest, MatchQualityPerfectMatch) {
+    float quality = EloCalculator::matchQuality({1500, 1500, 1500});
+    EXPECT_NEAR(quality, 1.0f, 0.001f);
+}
+
+TEST_F(EloCalculatorTest, MatchQualityDecreasesWithSpread) {
+    float perfect = EloCalculator::matchQuality({1500, 1500});
+    float close = EloCalculator::matchQuality({1500, 1550});
+    float wide = EloCalculator::matchQuality({1500, 1700});
+    float veryWide = EloCalculator::matchQuality({1500, 2000});
+
+    EXPECT_GT(perfect, close);
+    EXPECT_GT(close, wide);
+    EXPECT_GT(wide, veryWide);
+}
+
+TEST_F(EloCalculatorTest, MatchQualitySinglePlayer) {
+    float quality = EloCalculator::matchQuality({1500});
+    EXPECT_EQ(quality, 1.0f);
+}
+
+TEST_F(EloCalculatorTest, MatchQualityEmptyList) {
+    float quality = EloCalculator::matchQuality({});
+    EXPECT_EQ(quality, 1.0f);
+}
+
+TEST_F(EloCalculatorTest, IsWithinToleranceTrue) {
+    EXPECT_TRUE(EloCalculator::isWithinTolerance(1500, 1550, 100));
+    EXPECT_TRUE(EloCalculator::isWithinTolerance(1500, 1600, 100));
+    EXPECT_TRUE(EloCalculator::isWithinTolerance(1500, 1500, 0));
+}
+
+TEST_F(EloCalculatorTest, IsWithinToleranceFalse) {
+    EXPECT_FALSE(EloCalculator::isWithinTolerance(1500, 1601, 100));
+    EXPECT_FALSE(EloCalculator::isWithinTolerance(1500, 1400, 99));
+}
+
+TEST_F(EloCalculatorTest, SuggestedKFactorProvisional) {
+    EXPECT_EQ(EloCalculator::suggestedKFactor(0), 40);
+    EXPECT_EQ(EloCalculator::suggestedKFactor(15), 40);
+    EXPECT_EQ(EloCalculator::suggestedKFactor(29), 40);
+}
+
+TEST_F(EloCalculatorTest, SuggestedKFactorStandard) {
+    EXPECT_EQ(EloCalculator::suggestedKFactor(30), 32);
+    EXPECT_EQ(EloCalculator::suggestedKFactor(50), 32);
+    EXPECT_EQ(EloCalculator::suggestedKFactor(99), 32);
+}
+
+TEST_F(EloCalculatorTest, SuggestedKFactorVeteran) {
+    EXPECT_EQ(EloCalculator::suggestedKFactor(100), 16);
+    EXPECT_EQ(EloCalculator::suggestedKFactor(1000), 16);
+}
+
+// ============================================================================
+// LobbyTypes Tests
+// ============================================================================
+
+TEST(LobbyTypesTest, PlayerRatingDefaults) {
+    PlayerRating rating;
+    EXPECT_EQ(rating.mmr, 1500);
+    EXPECT_FLOAT_EQ(rating.uncertainty, 350.0f);
+    EXPECT_EQ(rating.gamesPlayed, 0u);
+}
+
+TEST(LobbyTypesTest, QueueConfigDefaults) {
+    QueueConfig config;
+    EXPECT_EQ(config.minPlayersPerMatch, 2u);
+    EXPECT_EQ(config.maxPlayersPerMatch, 2u);
+    EXPECT_EQ(config.initialRatingTolerance, 100);
+    EXPECT_EQ(config.maxRatingTolerance, 500);
+    EXPECT_EQ(config.expansionStep, 50);
+    EXPECT_EQ(config.expansionInterval.count(), 10);
+    EXPECT_EQ(config.maxQueueSize, 10000u);
+}
+
+// ============================================================================
+// MatchmakingQueue Tests
+// ============================================================================
+
+class MatchmakingQueueTest : public ::testing::Test {
+protected:
+    QueueConfig config_;
+    std::unique_ptr<MatchmakingQueue> queue_;
+
+    void SetUp() override {
+        config_.minPlayersPerMatch = 2;
+        config_.maxPlayersPerMatch = 2;
+        config_.initialRatingTolerance = 100;
+        config_.maxRatingTolerance = 500;
+        config_.expansionStep = 50;
+        config_.expansionInterval = 10s;
+        config_.maxQueueSize = 100;
+        queue_ = std::make_unique<MatchmakingQueue>(config_);
+    }
+
+    MatchmakingTicket makeTicket(uint64_t playerId, int32_t mmr,
+                                 GameMode mode = GameMode::Duel,
+                                 Region region = Region::Any) {
+        MatchmakingTicket ticket;
+        ticket.playerId = playerId;
+        ticket.rating.mmr = mmr;
+        ticket.mode = mode;
+        ticket.region = region;
+        ticket.enqueuedAt = std::chrono::steady_clock::now();
+        return ticket;
+    }
+};
+
+TEST_F(MatchmakingQueueTest, InitialQueueIsEmpty) {
+    EXPECT_EQ(queue_->queueSize(), 0u);
+}
+
+TEST_F(MatchmakingQueueTest, EnqueuePlayer) {
+    auto result = queue_->enqueue(makeTicket(1, 1500));
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_EQ(queue_->queueSize(), 1u);
+}
+
+TEST_F(MatchmakingQueueTest, EnqueueMultiplePlayers) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    (void)queue_->enqueue(makeTicket(2, 1550));
+    (void)queue_->enqueue(makeTicket(3, 1600));
+    EXPECT_EQ(queue_->queueSize(), 3u);
+}
+
+TEST_F(MatchmakingQueueTest, EnqueueDuplicatePlayerFails) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    auto result = queue_->enqueue(makeTicket(1, 1600));
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(queue_->queueSize(), 1u);
+}
+
+TEST_F(MatchmakingQueueTest, EnqueueFullQueueFails) {
+    QueueConfig small;
+    small.maxQueueSize = 2;
+    MatchmakingQueue smallQueue(small);
+
+    (void)smallQueue.enqueue(makeTicket(1, 1500));
+    (void)smallQueue.enqueue(makeTicket(2, 1500));
+    auto result = smallQueue.enqueue(makeTicket(3, 1500));
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST_F(MatchmakingQueueTest, DequeuePlayer) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    EXPECT_TRUE(queue_->dequeue(1));
+    EXPECT_EQ(queue_->queueSize(), 0u);
+}
+
+TEST_F(MatchmakingQueueTest, DequeueNonexistentPlayerReturnsFalse) {
+    EXPECT_FALSE(queue_->dequeue(999));
+}
+
+TEST_F(MatchmakingQueueTest, IsQueued) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    EXPECT_TRUE(queue_->isQueued(1));
+    EXPECT_FALSE(queue_->isQueued(2));
+}
+
+TEST_F(MatchmakingQueueTest, GetTicket) {
+    (void)queue_->enqueue(makeTicket(42, 1750));
+    auto ticket = queue_->getTicket(42);
+
+    ASSERT_TRUE(ticket.has_value());
+    EXPECT_EQ(ticket->playerId, 42u);
+    EXPECT_EQ(ticket->rating.mmr, 1750);
+}
+
+TEST_F(MatchmakingQueueTest, GetTicketNonexistent) {
+    auto ticket = queue_->getTicket(999);
+    EXPECT_FALSE(ticket.has_value());
+}
+
+TEST_F(MatchmakingQueueTest, TryMatchNotEnoughPlayers) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    auto match = queue_->tryMatch();
+    EXPECT_FALSE(match.has_value());
+}
+
+TEST_F(MatchmakingQueueTest, TryMatchEmptyQueue) {
+    auto match = queue_->tryMatch();
+    EXPECT_FALSE(match.has_value());
+}
+
+TEST_F(MatchmakingQueueTest, TryMatchTwoCloseRatings) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    (void)queue_->enqueue(makeTicket(2, 1550));
+
+    auto match = queue_->tryMatch();
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->players.size(), 2u);
+    EXPECT_GT(match->matchId, 0u);
+    EXPECT_NEAR(match->averageRating, 1525.0f, 0.1f);
+    EXPECT_GT(match->matchQuality, 0.5f);
+}
+
+TEST_F(MatchmakingQueueTest, MatchRemovesPlayersFromQueue) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    (void)queue_->enqueue(makeTicket(2, 1550));
+
+    auto match = queue_->tryMatch();
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(queue_->queueSize(), 0u);
+    EXPECT_FALSE(queue_->isQueued(1));
+    EXPECT_FALSE(queue_->isQueued(2));
+}
+
+TEST_F(MatchmakingQueueTest, TryMatchRatingsTooFarApart) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    (void)queue_->enqueue(makeTicket(2, 1700)); // 200 apart > 100 tolerance.
+
+    auto match = queue_->tryMatch();
+    EXPECT_FALSE(match.has_value());
+    EXPECT_EQ(queue_->queueSize(), 2u);
+}
+
+TEST_F(MatchmakingQueueTest, TryMatchDifferentGameModes) {
+    (void)queue_->enqueue(makeTicket(1, 1500, GameMode::Duel));
+    (void)queue_->enqueue(makeTicket(2, 1510, GameMode::Arena));
+
+    auto match = queue_->tryMatch();
+    EXPECT_FALSE(match.has_value());
+}
+
+TEST_F(MatchmakingQueueTest, TryMatchDifferentRegions) {
+    (void)queue_->enqueue(makeTicket(1, 1500, GameMode::Duel, Region::EU));
+    (void)queue_->enqueue(makeTicket(2, 1510, GameMode::Duel, Region::Asia));
+
+    auto match = queue_->tryMatch();
+    EXPECT_FALSE(match.has_value());
+}
+
+TEST_F(MatchmakingQueueTest, TryMatchAnyRegionMatchesAll) {
+    (void)queue_->enqueue(makeTicket(1, 1500, GameMode::Duel, Region::Any));
+    (void)queue_->enqueue(makeTicket(2, 1510, GameMode::Duel, Region::EU));
+
+    auto match = queue_->tryMatch();
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->players.size(), 2u);
+}
+
+TEST_F(MatchmakingQueueTest, TryMatchSameRegion) {
+    (void)queue_->enqueue(makeTicket(1, 1500, GameMode::Duel, Region::EU));
+    (void)queue_->enqueue(makeTicket(2, 1510, GameMode::Duel, Region::EU));
+
+    auto match = queue_->tryMatch();
+    ASSERT_TRUE(match.has_value());
+}
+
+TEST_F(MatchmakingQueueTest, MatchIdsAreUnique) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    (void)queue_->enqueue(makeTicket(2, 1510));
+    auto m1 = queue_->tryMatch();
+
+    (void)queue_->enqueue(makeTicket(3, 1500));
+    (void)queue_->enqueue(makeTicket(4, 1510));
+    auto m2 = queue_->tryMatch();
+
+    ASSERT_TRUE(m1.has_value());
+    ASSERT_TRUE(m2.has_value());
+    EXPECT_NE(m1->matchId, m2->matchId);
+}
+
+TEST_F(MatchmakingQueueTest, MultiPlayerMatch) {
+    QueueConfig arena;
+    arena.minPlayersPerMatch = 3;
+    arena.maxPlayersPerMatch = 3;
+    arena.initialRatingTolerance = 200;
+    MatchmakingQueue arenaQueue(arena);
+
+    (void)arenaQueue.enqueue(makeTicket(1, 1500));
+    (void)arenaQueue.enqueue(makeTicket(2, 1520));
+
+    // Not enough for 3-player match.
+    auto match = arenaQueue.tryMatch();
+    EXPECT_FALSE(match.has_value());
+
+    (void)arenaQueue.enqueue(makeTicket(3, 1540));
+
+    match = arenaQueue.tryMatch();
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->players.size(), 3u);
+}
+
+TEST_F(MatchmakingQueueTest, MaxPlayersPerMatchRespected) {
+    QueueConfig twoMax;
+    twoMax.minPlayersPerMatch = 2;
+    twoMax.maxPlayersPerMatch = 2;
+    twoMax.initialRatingTolerance = 200;
+    MatchmakingQueue twoQueue(twoMax);
+
+    (void)twoQueue.enqueue(makeTicket(1, 1500));
+    (void)twoQueue.enqueue(makeTicket(2, 1510));
+    (void)twoQueue.enqueue(makeTicket(3, 1520));
+
+    auto match = twoQueue.tryMatch();
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->players.size(), 2u);
+    EXPECT_EQ(twoQueue.queueSize(), 1u);
+}
+
+TEST_F(MatchmakingQueueTest, ConfigAccessor) {
+    EXPECT_EQ(queue_->config().minPlayersPerMatch, 2u);
+    EXPECT_EQ(queue_->config().maxPlayersPerMatch, 2u);
+    EXPECT_EQ(queue_->config().initialRatingTolerance, 100);
+}
+
+TEST_F(MatchmakingQueueTest, DequeueAfterEnqueueMultiple) {
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    (void)queue_->enqueue(makeTicket(2, 1550));
+    (void)queue_->enqueue(makeTicket(3, 1600));
+
+    EXPECT_TRUE(queue_->dequeue(2));
+    EXPECT_EQ(queue_->queueSize(), 2u);
+    EXPECT_FALSE(queue_->isQueued(2));
+    EXPECT_TRUE(queue_->isQueued(1));
+    EXPECT_TRUE(queue_->isQueued(3));
+}
+
+TEST_F(MatchmakingQueueTest, MatchSelectsBestQualityGroup) {
+    // Enqueue players: 1500, 1510, 1700.
+    // With tolerance 100, only 1500+1510 should match.
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    (void)queue_->enqueue(makeTicket(2, 1510));
+    (void)queue_->enqueue(makeTicket(3, 1700));
+
+    auto match = queue_->tryMatch();
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->players.size(), 2u);
+
+    // Check that matched players are 1500 and 1510.
+    bool has1 = false, has2 = false;
+    for (const auto& p : match->players) {
+        if (p.playerId == 1) has1 = true;
+        if (p.playerId == 2) has2 = true;
+    }
+    EXPECT_TRUE(has1);
+    EXPECT_TRUE(has2);
+
+    // Player 3 should still be in queue.
+    EXPECT_EQ(queue_->queueSize(), 1u);
+    EXPECT_TRUE(queue_->isQueued(3));
+}
+
+TEST_F(MatchmakingQueueTest, ConsecutiveMatchesFromLargerPool) {
+    // Enqueue 4 close-rated players.
+    (void)queue_->enqueue(makeTicket(1, 1500));
+    (void)queue_->enqueue(makeTicket(2, 1510));
+    (void)queue_->enqueue(makeTicket(3, 1520));
+    (void)queue_->enqueue(makeTicket(4, 1530));
+
+    auto m1 = queue_->tryMatch();
+    ASSERT_TRUE(m1.has_value());
+    EXPECT_EQ(m1->players.size(), 2u);
+    EXPECT_EQ(queue_->queueSize(), 2u);
+
+    auto m2 = queue_->tryMatch();
+    ASSERT_TRUE(m2.has_value());
+    EXPECT_EQ(m2->players.size(), 2u);
+    EXPECT_EQ(queue_->queueSize(), 0u);
+}


### PR DESCRIPTION
Closes #66
Part of #25

## Summary

- Add `EloCalculator` with standard Elo expected-score formula, configurable K-factor rating updates, match quality assessment (exponential decay based on rating spread), and suggested K-factor tiers (provisional 40 / standard 32 / veteran 16)
- Add `MatchmakingQueue` with skill-based matching, configurable initial/max rating tolerance, automatic tolerance expansion over wait time, game mode and region filtering, and O(1) player removal via swap-and-pop
- Add `lobby_types.hpp` with `GameMode`, `Region`, `PlayerRating`, `MatchmakingTicket`, `MatchResult`, and `QueueConfig` types
- Add Lobby error codes at 0x0C00 range (`QueueFull`, `AlreadyInQueue`, `NotInQueue`, `InvalidRating`, `PartyNotFound`, `PartyFull`)
- 47 unit tests covering all components

## Design Decisions

- **Elo formula**: Standard `E(A) = 1 / (1 + 10^((R_B - R_A) / 400))` with configurable K-factor. K-factor adapts based on games played to allow provisional players to converge quickly while keeping veteran ratings stable.
- **Match quality**: Uses exponential decay `exp(-stddev/200)` of rating standard deviation. This maps perfectly equal ratings to 1.0 and degrades gracefully with increasing spread.
- **Tolerance expansion**: Players who wait longer get progressively wider rating windows (`initial + expansions * step`, capped at max). This ensures everyone eventually finds a match while prioritizing quality for fresh entries.
- **Bidirectional tolerance**: Uses `max(anchorTolerance, candidateTolerance)` so a long-waiting player can match with someone who just joined, even if the new player's own tolerance is narrow.
- **O(1) dequeue**: Swap-and-pop removal from the ticket vector with index tracking via hashmap, avoiding O(n) shifts.

## Test Plan

- [x] EloCalculator: expected score symmetry, win/loss/draw updates, K-factor scaling, match quality ordering, tolerance checks
- [x] LobbyTypes: default values for PlayerRating and QueueConfig
- [x] MatchmakingQueue: enqueue/dequeue, duplicate prevention, queue limits, rating-based matching, mode/region filtering, Any-region compatibility, multi-player matches, consecutive matches, pool management
- [x] All 47 tests pass
- [x] Full regression: 1073 tests pass (0 failures)