### PR TITLE
feat(service): add Lobby Server with party management and matchmaking orchestration

### DIFF
--- a/include/cgs/foundation/error_code.hpp
+++ b/include/cgs/foundation/error_code.hpp
@@ -116,6 +116,12 @@ enum class ErrorCode : uint32_t {
     InvalidRating = 0x0C04,
     PartyNotFound = 0x0C05,
     PartyFull = 0x0C06,
+    PlayerAlreadyInParty = 0x0C07,
+    NotPartyLeader = 0x0C08,
+    LobbyNotStarted = 0x0C09,
+    LobbyAlreadyStarted = 0x0C0A,
+    NoServerAvailable = 0x0C0B,
+    PlayerNotInParty = 0x0C0C,
 
     // DBProxy (0x0D00 - 0x0DFF)
     DBProxyError = 0x0D00,

--- a/include/cgs/service/lobby_server.hpp
+++ b/include/cgs/service/lobby_server.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+/// @file lobby_server.hpp
+/// @brief Lobby Server orchestrating matchmaking, party management,
+///        and game server instance allocation.
+///
+/// LobbyServer unifies MatchmakingQueue, EloCalculator, and PartyManager
+/// into a single service entry point. Players can queue solo or as a
+/// party, and matches are allocated to game server instances.
+///
+/// @see SRS-SVC-004
+/// @see SDS-MOD-033
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/service/lobby_types.hpp"
+
+namespace cgs::service {
+
+/// Lobby Server orchestrating matchmaking and party management.
+///
+/// Usage:
+/// @code
+///   LobbyConfig config;
+///   LobbyServer lobby(config);
+///   lobby.start();
+///
+///   // Solo queue
+///   lobby.enqueuePlayer(playerId, rating, GameMode::Duel, Region::NAEast);
+///
+///   // Party operations
+///   auto pid = lobby.createParty(leaderId, "Leader", rating);
+///   lobby.addPartyMember(pid.value(), memberId, "Member", rating);
+///   lobby.enqueueParty(pid.value());
+///
+///   // Periodic match processing
+///   auto matches = lobby.processMatchmaking();
+///
+///   lobby.stop();
+/// @endcode
+class LobbyServer {
+public:
+    explicit LobbyServer(LobbyConfig config);
+    ~LobbyServer();
+
+    LobbyServer(const LobbyServer&) = delete;
+    LobbyServer& operator=(const LobbyServer&) = delete;
+    LobbyServer(LobbyServer&&) noexcept;
+    LobbyServer& operator=(LobbyServer&&) noexcept;
+
+    // -- Lifecycle ------------------------------------------------------------
+
+    /// Start the lobby server.
+    [[nodiscard]] cgs::foundation::GameResult<void> start();
+
+    /// Stop the lobby server.
+    void stop();
+
+    /// Check if the server is running.
+    [[nodiscard]] bool isRunning() const noexcept;
+
+    // -- Solo matchmaking -----------------------------------------------------
+
+    /// Enqueue a single player for matchmaking.
+    [[nodiscard]] cgs::foundation::GameResult<void> enqueuePlayer(
+        uint64_t playerId,
+        PlayerRating rating,
+        GameMode mode = GameMode::Duel,
+        Region region = Region::Any);
+
+    /// Remove a player from the matchmaking queue.
+    [[nodiscard]] bool dequeuePlayer(uint64_t playerId);
+
+    /// Check if a player is currently queued.
+    [[nodiscard]] bool isPlayerQueued(uint64_t playerId) const;
+
+    // -- Party management -----------------------------------------------------
+
+    /// Create a new party with the given player as leader.
+    [[nodiscard]] cgs::foundation::GameResult<PartyId> createParty(
+        uint64_t leaderId,
+        const std::string& leaderName,
+        PlayerRating leaderRating);
+
+    /// Disband a party (leader only).
+    [[nodiscard]] cgs::foundation::GameResult<void> disbandParty(
+        PartyId partyId, uint64_t requesterId);
+
+    /// Add a member to a party.
+    [[nodiscard]] cgs::foundation::GameResult<void> addPartyMember(
+        PartyId partyId,
+        uint64_t playerId,
+        const std::string& name,
+        PlayerRating rating);
+
+    /// Remove a member from a party (leave or kick).
+    [[nodiscard]] cgs::foundation::GameResult<void> removePartyMember(
+        PartyId partyId, uint64_t playerId);
+
+    /// Promote a member to party leader.
+    [[nodiscard]] cgs::foundation::GameResult<void> promotePartyLeader(
+        PartyId partyId, uint64_t requesterId, uint64_t newLeaderId);
+
+    /// Get party info.
+    [[nodiscard]] std::optional<Party> getParty(PartyId partyId) const;
+
+    /// Get the party a player belongs to.
+    [[nodiscard]] std::optional<PartyId> getPlayerParty(
+        uint64_t playerId) const;
+
+    // -- Party matchmaking ----------------------------------------------------
+
+    /// Enqueue an entire party for matchmaking.
+    ///
+    /// All party members are enqueued using the party's average rating.
+    /// The party is marked as in-queue.
+    [[nodiscard]] cgs::foundation::GameResult<void> enqueueParty(
+        PartyId partyId);
+
+    /// Remove a party from the matchmaking queue.
+    [[nodiscard]] cgs::foundation::GameResult<void> dequeueParty(
+        PartyId partyId);
+
+    // -- Match processing -----------------------------------------------------
+
+    /// Run one matchmaking cycle.
+    ///
+    /// Attempts to form as many matches as possible from the current queue.
+    /// @return The list of matches formed in this cycle.
+    [[nodiscard]] std::vector<MatchResult> processMatchmaking();
+
+    // -- ELO updates ----------------------------------------------------------
+
+    /// Update player ratings after a match result.
+    ///
+    /// @param winnerId  The winning player's ID.
+    /// @param loserId   The losing player's ID.
+    /// @param winnerRating  The winner's current rating (modified in-place).
+    /// @param loserRating   The loser's current rating (modified in-place).
+    static void updateRatings(
+        PlayerRating& winnerRating,
+        PlayerRating& loserRating);
+
+    // -- Statistics -----------------------------------------------------------
+
+    /// Get a snapshot of current lobby statistics.
+    [[nodiscard]] LobbyStats stats() const;
+
+    /// Get the configuration.
+    [[nodiscard]] const LobbyConfig& config() const noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace cgs::service

--- a/include/cgs/service/lobby_types.hpp
+++ b/include/cgs/service/lobby_types.hpp
@@ -4,13 +4,15 @@
 /// @brief Core types for the Lobby Server matchmaking system.
 ///
 /// Defines game modes, regions, player ratings (ELO/MMR),
-/// matchmaking tickets, match results, and queue configuration.
+/// matchmaking tickets, match results, queue configuration,
+/// and party management types.
 ///
 /// @see SRS-SVC-004
 /// @see SDS-MOD-033
 
 #include <chrono>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace cgs::service {
@@ -71,6 +73,47 @@ struct QueueConfig {
     std::chrono::seconds expansionInterval{10};
 
     uint32_t maxQueueSize = 10000;  ///< Maximum players in the queue.
+};
+
+// -- Party types (SRS-SVC-004.3) ---------------------------------------------
+
+/// Unique identifier for a party.
+using PartyId = uint64_t;
+
+/// A member within a party.
+struct PartyMember {
+    uint64_t playerId = 0;
+    std::string name;
+    PlayerRating rating;
+    bool isReady = false;
+};
+
+/// A party (group) of players.
+struct Party {
+    PartyId id = 0;
+    uint64_t leaderId = 0;
+    std::vector<PartyMember> members;
+    uint32_t maxSize = 5;
+    bool inQueue = false;
+    GameMode preferredMode = GameMode::Dungeon;
+};
+
+/// Configuration for the lobby server.
+struct LobbyConfig {
+    /// Queue configuration for matchmaking.
+    QueueConfig queueConfig;
+
+    /// Maximum party size.
+    uint32_t maxPartySize = 5;
+};
+
+/// Runtime statistics for the lobby server.
+struct LobbyStats {
+    std::size_t queuedPlayers = 0;
+    uint64_t matchesFormed = 0;
+    std::size_t activeParties = 0;
+    uint64_t partiesCreated = 0;
+    uint64_t partiesDisbanded = 0;
 };
 
 } // namespace cgs::service

--- a/include/cgs/service/party_manager.hpp
+++ b/include/cgs/service/party_manager.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+/// @file party_manager.hpp
+/// @brief Party (group) management for the Lobby Server.
+///
+/// PartyManager provides create, invite, join, leave, kick, promote,
+/// and disband operations for player parties. Parties can queue for
+/// matchmaking as a unit.
+///
+/// @see SRS-SVC-004.3
+/// @see SDS-MOD-033
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/service/lobby_types.hpp"
+
+namespace cgs::service {
+
+/// Thread-safe party manager.
+///
+/// Usage:
+/// @code
+///   PartyManager pm(5); // max 5 members per party
+///   auto partyId = pm.createParty(leaderId, "LeaderName", leaderRating);
+///   pm.addMember(partyId.value(), playerId, "Player", rating);
+///   pm.removeMember(partyId.value(), playerId);
+/// @endcode
+class PartyManager {
+public:
+    /// @param maxPartySize Maximum members per party (default: 5).
+    explicit PartyManager(uint32_t maxPartySize = 5);
+
+    // -- Party lifecycle ------------------------------------------------------
+
+    /// Create a new party with the given player as leader.
+    [[nodiscard]] cgs::foundation::GameResult<PartyId> createParty(
+        uint64_t leaderId,
+        const std::string& leaderName,
+        PlayerRating leaderRating);
+
+    /// Disband a party. Only the leader can do this.
+    [[nodiscard]] cgs::foundation::GameResult<void> disbandParty(
+        PartyId partyId, uint64_t requesterId);
+
+    // -- Member management ----------------------------------------------------
+
+    /// Add a member to a party.
+    [[nodiscard]] cgs::foundation::GameResult<void> addMember(
+        PartyId partyId,
+        uint64_t playerId,
+        const std::string& name,
+        PlayerRating rating);
+
+    /// Remove a member from a party (leave or kick).
+    ///
+    /// If the leader leaves, the party is automatically disbanded.
+    /// If a non-leader member is removed by the leader (kick), it succeeds.
+    /// If a member removes themselves (leave), it always succeeds.
+    [[nodiscard]] cgs::foundation::GameResult<void> removeMember(
+        PartyId partyId, uint64_t playerId);
+
+    /// Promote a member to party leader.
+    [[nodiscard]] cgs::foundation::GameResult<void> promoteLeader(
+        PartyId partyId, uint64_t requesterId, uint64_t newLeaderId);
+
+    // -- Queue integration ----------------------------------------------------
+
+    /// Mark a party as in-queue.
+    [[nodiscard]] cgs::foundation::GameResult<void> setInQueue(
+        PartyId partyId, bool inQueue);
+
+    // -- Queries --------------------------------------------------------------
+
+    /// Get party info.
+    [[nodiscard]] std::optional<Party> getParty(PartyId partyId) const;
+
+    /// Get the party a player belongs to.
+    [[nodiscard]] std::optional<PartyId> getPlayerParty(
+        uint64_t playerId) const;
+
+    /// Check if a player is in any party.
+    [[nodiscard]] bool isInParty(uint64_t playerId) const;
+
+    /// Get the number of active parties.
+    [[nodiscard]] std::size_t partyCount() const;
+
+    /// Calculate the average MMR across all party members.
+    [[nodiscard]] std::optional<int32_t> averagePartyRating(
+        PartyId partyId) const;
+
+private:
+    /// Generate a unique party ID.
+    [[nodiscard]] PartyId nextPartyId();
+
+    /// Internal: remove party and all player mappings.
+    void removePartyInternal(PartyId partyId);
+
+    uint32_t maxPartySize_;
+    std::unordered_map<PartyId, Party> parties_;
+    std::unordered_map<uint64_t, PartyId> playerParty_;
+    uint64_t nextPartyId_ = 1;
+    mutable std::mutex mutex_;
+};
+
+} // namespace cgs::service

--- a/src/services/lobby/CMakeLists.txt
+++ b/src/services/lobby/CMakeLists.txt
@@ -1,7 +1,9 @@
-# Lobby Service - Matchmaking Queue & ELO Calculator (SDS-MOD-033)
+# Lobby Service - Matchmaking, Party & Lobby Server (SDS-MOD-033)
 add_library(cgs_service_lobby
     elo_calculator.cpp
     matchmaking_queue.cpp
+    party_manager.cpp
+    lobby_server.cpp
 )
 target_link_libraries(cgs_service_lobby
     PUBLIC cgs_core

--- a/src/services/lobby/lobby_server.cpp
+++ b/src/services/lobby/lobby_server.cpp
@@ -1,0 +1,292 @@
+/// @file lobby_server.cpp
+/// @brief LobbyServer implementation orchestrating matchmaking,
+///        party management, and match processing.
+
+#include "cgs/service/lobby_server.hpp"
+
+#include <atomic>
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/foundation/game_error.hpp"
+#include "cgs/service/elo_calculator.hpp"
+#include "cgs/service/matchmaking_queue.hpp"
+#include "cgs/service/party_manager.hpp"
+
+namespace cgs::service {
+
+using cgs::foundation::ErrorCode;
+using cgs::foundation::GameError;
+using cgs::foundation::GameResult;
+
+// -- Impl ---------------------------------------------------------------------
+
+struct LobbyServer::Impl {
+    LobbyConfig config;
+
+    MatchmakingQueue queue;
+    PartyManager parties;
+
+    std::atomic<bool> running{false};
+    std::atomic<uint64_t> matchesFormed{0};
+    std::atomic<uint64_t> partiesCreated{0};
+    std::atomic<uint64_t> partiesDisbanded{0};
+
+    explicit Impl(LobbyConfig cfg)
+        : config(std::move(cfg))
+        , queue(config.queueConfig)
+        , parties(config.maxPartySize) {}
+};
+
+// -- Construction / destruction / move ----------------------------------------
+
+LobbyServer::LobbyServer(LobbyConfig config)
+    : impl_(std::make_unique<Impl>(std::move(config))) {}
+
+LobbyServer::~LobbyServer() {
+    if (impl_ && impl_->running.load()) {
+        stop();
+    }
+}
+
+LobbyServer::LobbyServer(LobbyServer&&) noexcept = default;
+LobbyServer& LobbyServer::operator=(LobbyServer&&) noexcept = default;
+
+// -- Lifecycle ----------------------------------------------------------------
+
+GameResult<void> LobbyServer::start() {
+    if (impl_->running.load()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::LobbyAlreadyStarted,
+                      "lobby server is already running"));
+    }
+
+    impl_->running.store(true);
+    return GameResult<void>::ok();
+}
+
+void LobbyServer::stop() {
+    impl_->running.store(false);
+}
+
+bool LobbyServer::isRunning() const noexcept {
+    return impl_->running.load();
+}
+
+// -- Solo matchmaking ---------------------------------------------------------
+
+GameResult<void> LobbyServer::enqueuePlayer(
+    uint64_t playerId,
+    PlayerRating rating,
+    GameMode mode,
+    Region region) {
+    if (!impl_->running.load()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::LobbyNotStarted,
+                      "lobby server is not running"));
+    }
+
+    MatchmakingTicket ticket;
+    ticket.playerId = playerId;
+    ticket.rating = rating;
+    ticket.mode = mode;
+    ticket.region = region;
+    ticket.enqueuedAt = std::chrono::steady_clock::now();
+
+    return impl_->queue.enqueue(std::move(ticket));
+}
+
+bool LobbyServer::dequeuePlayer(uint64_t playerId) {
+    return impl_->queue.dequeue(playerId);
+}
+
+bool LobbyServer::isPlayerQueued(uint64_t playerId) const {
+    return impl_->queue.isQueued(playerId);
+}
+
+// -- Party management ---------------------------------------------------------
+
+GameResult<PartyId> LobbyServer::createParty(
+    uint64_t leaderId,
+    const std::string& leaderName,
+    PlayerRating leaderRating) {
+    if (!impl_->running.load()) {
+        return GameResult<PartyId>::err(
+            GameError(ErrorCode::LobbyNotStarted,
+                      "lobby server is not running"));
+    }
+
+    auto result = impl_->parties.createParty(
+        leaderId, leaderName, leaderRating);
+
+    if (result.hasValue()) {
+        impl_->partiesCreated.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    return result;
+}
+
+GameResult<void> LobbyServer::disbandParty(
+    PartyId partyId, uint64_t requesterId) {
+    auto result = impl_->parties.disbandParty(partyId, requesterId);
+
+    if (result.hasValue()) {
+        impl_->partiesDisbanded.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    return result;
+}
+
+GameResult<void> LobbyServer::addPartyMember(
+    PartyId partyId,
+    uint64_t playerId,
+    const std::string& name,
+    PlayerRating rating) {
+    return impl_->parties.addMember(partyId, playerId, name, rating);
+}
+
+GameResult<void> LobbyServer::removePartyMember(
+    PartyId partyId, uint64_t playerId) {
+    return impl_->parties.removeMember(partyId, playerId);
+}
+
+GameResult<void> LobbyServer::promotePartyLeader(
+    PartyId partyId, uint64_t requesterId, uint64_t newLeaderId) {
+    return impl_->parties.promoteLeader(partyId, requesterId, newLeaderId);
+}
+
+std::optional<Party> LobbyServer::getParty(PartyId partyId) const {
+    return impl_->parties.getParty(partyId);
+}
+
+std::optional<PartyId> LobbyServer::getPlayerParty(
+    uint64_t playerId) const {
+    return impl_->parties.getPlayerParty(playerId);
+}
+
+// -- Party matchmaking --------------------------------------------------------
+
+GameResult<void> LobbyServer::enqueueParty(PartyId partyId) {
+    if (!impl_->running.load()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::LobbyNotStarted,
+                      "lobby server is not running"));
+    }
+
+    auto party = impl_->parties.getParty(partyId);
+    if (!party.has_value()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyNotFound,
+                      "party not found"));
+    }
+
+    // Calculate average rating for the party.
+    auto avgRating = impl_->parties.averagePartyRating(partyId);
+    if (!avgRating.has_value()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyNotFound,
+                      "party has no members"));
+    }
+
+    // Enqueue each member with the party's average rating.
+    PlayerRating partyRating;
+    partyRating.mmr = *avgRating;
+
+    for (const auto& member : party->members) {
+        MatchmakingTicket ticket;
+        ticket.playerId = member.playerId;
+        ticket.rating = partyRating;
+        ticket.mode = party->preferredMode;
+        ticket.region = Region::Any;
+        ticket.enqueuedAt = std::chrono::steady_clock::now();
+
+        auto enqueueResult = impl_->queue.enqueue(std::move(ticket));
+        if (enqueueResult.hasError()) {
+            // Rollback: remove already-enqueued members.
+            for (const auto& m : party->members) {
+                if (m.playerId == member.playerId) {
+                    break;
+                }
+                (void)impl_->queue.dequeue(m.playerId);
+            }
+            return enqueueResult;
+        }
+    }
+
+    // Mark party as in-queue.
+    (void)impl_->parties.setInQueue(partyId, true);
+
+    return GameResult<void>::ok();
+}
+
+GameResult<void> LobbyServer::dequeueParty(PartyId partyId) {
+    auto party = impl_->parties.getParty(partyId);
+    if (!party.has_value()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyNotFound,
+                      "party not found"));
+    }
+
+    for (const auto& member : party->members) {
+        (void)impl_->queue.dequeue(member.playerId);
+    }
+
+    (void)impl_->parties.setInQueue(partyId, false);
+
+    return GameResult<void>::ok();
+}
+
+// -- Match processing ---------------------------------------------------------
+
+std::vector<MatchResult> LobbyServer::processMatchmaking() {
+    std::vector<MatchResult> matches;
+
+    // Drain all possible matches from the queue.
+    while (auto match = impl_->queue.tryMatch()) {
+        impl_->matchesFormed.fetch_add(1, std::memory_order_relaxed);
+        matches.push_back(std::move(*match));
+    }
+
+    return matches;
+}
+
+// -- ELO updates --------------------------------------------------------------
+
+void LobbyServer::updateRatings(
+    PlayerRating& winnerRating,
+    PlayerRating& loserRating) {
+    float expectedWin = EloCalculator::expectedScore(
+        winnerRating.mmr, loserRating.mmr);
+    float expectedLoss = EloCalculator::expectedScore(
+        loserRating.mmr, winnerRating.mmr);
+
+    int32_t kWinner = EloCalculator::suggestedKFactor(
+        winnerRating.gamesPlayed);
+    int32_t kLoser = EloCalculator::suggestedKFactor(
+        loserRating.gamesPlayed);
+
+    winnerRating.mmr = EloCalculator::newRating(
+        winnerRating.mmr, 1.0f, expectedWin, kWinner);
+    loserRating.mmr = EloCalculator::newRating(
+        loserRating.mmr, 0.0f, expectedLoss, kLoser);
+
+    winnerRating.gamesPlayed++;
+    loserRating.gamesPlayed++;
+}
+
+// -- Statistics ---------------------------------------------------------------
+
+LobbyStats LobbyServer::stats() const {
+    LobbyStats s;
+    s.queuedPlayers = impl_->queue.queueSize();
+    s.matchesFormed = impl_->matchesFormed.load(std::memory_order_relaxed);
+    s.activeParties = impl_->parties.partyCount();
+    s.partiesCreated = impl_->partiesCreated.load(std::memory_order_relaxed);
+    s.partiesDisbanded = impl_->partiesDisbanded.load(std::memory_order_relaxed);
+    return s;
+}
+
+const LobbyConfig& LobbyServer::config() const noexcept {
+    return impl_->config;
+}
+
+} // namespace cgs::service

--- a/src/services/lobby/party_manager.cpp
+++ b/src/services/lobby/party_manager.cpp
@@ -1,0 +1,282 @@
+/// @file party_manager.cpp
+/// @brief PartyManager implementation for party lifecycle and member management.
+
+#include "cgs/service/party_manager.hpp"
+
+#include <algorithm>
+#include <numeric>
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/foundation/game_error.hpp"
+
+namespace cgs::service {
+
+using cgs::foundation::ErrorCode;
+using cgs::foundation::GameError;
+using cgs::foundation::GameResult;
+
+PartyManager::PartyManager(uint32_t maxPartySize)
+    : maxPartySize_(maxPartySize) {}
+
+// -- Party lifecycle ----------------------------------------------------------
+
+GameResult<PartyId> PartyManager::createParty(
+    uint64_t leaderId,
+    const std::string& leaderName,
+    PlayerRating leaderRating) {
+    std::lock_guard lock(mutex_);
+
+    if (playerParty_.contains(leaderId)) {
+        return GameResult<PartyId>::err(
+            GameError(ErrorCode::PlayerAlreadyInParty,
+                      "player is already in a party"));
+    }
+
+    auto partyId = nextPartyId();
+
+    Party party;
+    party.id = partyId;
+    party.leaderId = leaderId;
+    party.maxSize = maxPartySize_;
+
+    PartyMember leader;
+    leader.playerId = leaderId;
+    leader.name = leaderName;
+    leader.rating = leaderRating;
+    leader.isReady = true;
+    party.members.push_back(std::move(leader));
+
+    parties_.emplace(partyId, std::move(party));
+    playerParty_.emplace(leaderId, partyId);
+
+    return GameResult<PartyId>::ok(partyId);
+}
+
+GameResult<void> PartyManager::disbandParty(
+    PartyId partyId, uint64_t requesterId) {
+    std::lock_guard lock(mutex_);
+
+    auto it = parties_.find(partyId);
+    if (it == parties_.end()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyNotFound,
+                      "party not found"));
+    }
+
+    if (it->second.leaderId != requesterId) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::NotPartyLeader,
+                      "only the party leader can disband the party"));
+    }
+
+    removePartyInternal(partyId);
+    return GameResult<void>::ok();
+}
+
+// -- Member management --------------------------------------------------------
+
+GameResult<void> PartyManager::addMember(
+    PartyId partyId,
+    uint64_t playerId,
+    const std::string& name,
+    PlayerRating rating) {
+    std::lock_guard lock(mutex_);
+
+    if (playerParty_.contains(playerId)) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PlayerAlreadyInParty,
+                      "player is already in a party"));
+    }
+
+    auto it = parties_.find(partyId);
+    if (it == parties_.end()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyNotFound,
+                      "party not found"));
+    }
+
+    auto& party = it->second;
+
+    if (party.members.size() >= static_cast<std::size_t>(party.maxSize)) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyFull,
+                      "party is full"));
+    }
+
+    PartyMember member;
+    member.playerId = playerId;
+    member.name = name;
+    member.rating = rating;
+    party.members.push_back(std::move(member));
+
+    playerParty_.emplace(playerId, partyId);
+
+    return GameResult<void>::ok();
+}
+
+GameResult<void> PartyManager::removeMember(
+    PartyId partyId, uint64_t playerId) {
+    std::lock_guard lock(mutex_);
+
+    auto partyIt = parties_.find(partyId);
+    if (partyIt == parties_.end()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyNotFound,
+                      "party not found"));
+    }
+
+    auto& party = partyIt->second;
+
+    // Find the member.
+    auto memberIt = std::find_if(
+        party.members.begin(), party.members.end(),
+        [playerId](const PartyMember& m) { return m.playerId == playerId; });
+
+    if (memberIt == party.members.end()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PlayerNotInParty,
+                      "player is not in the party"));
+    }
+
+    // If the leader leaves, disband the entire party.
+    if (playerId == party.leaderId) {
+        removePartyInternal(partyId);
+        return GameResult<void>::ok();
+    }
+
+    // Remove non-leader member.
+    party.members.erase(memberIt);
+    playerParty_.erase(playerId);
+
+    return GameResult<void>::ok();
+}
+
+GameResult<void> PartyManager::promoteLeader(
+    PartyId partyId, uint64_t requesterId, uint64_t newLeaderId) {
+    std::lock_guard lock(mutex_);
+
+    auto it = parties_.find(partyId);
+    if (it == parties_.end()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyNotFound,
+                      "party not found"));
+    }
+
+    auto& party = it->second;
+
+    if (party.leaderId != requesterId) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::NotPartyLeader,
+                      "only the party leader can promote"));
+    }
+
+    // Verify new leader is in the party.
+    auto memberIt = std::find_if(
+        party.members.begin(), party.members.end(),
+        [newLeaderId](const PartyMember& m) {
+            return m.playerId == newLeaderId;
+        });
+
+    if (memberIt == party.members.end()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PlayerNotInParty,
+                      "target player is not in the party"));
+    }
+
+    party.leaderId = newLeaderId;
+
+    return GameResult<void>::ok();
+}
+
+// -- Queue integration --------------------------------------------------------
+
+GameResult<void> PartyManager::setInQueue(PartyId partyId, bool inQueue) {
+    std::lock_guard lock(mutex_);
+
+    auto it = parties_.find(partyId);
+    if (it == parties_.end()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PartyNotFound,
+                      "party not found"));
+    }
+
+    it->second.inQueue = inQueue;
+    return GameResult<void>::ok();
+}
+
+// -- Queries ------------------------------------------------------------------
+
+std::optional<Party> PartyManager::getParty(PartyId partyId) const {
+    std::lock_guard lock(mutex_);
+
+    auto it = parties_.find(partyId);
+    if (it == parties_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::optional<PartyId> PartyManager::getPlayerParty(
+    uint64_t playerId) const {
+    std::lock_guard lock(mutex_);
+
+    auto it = playerParty_.find(playerId);
+    if (it == playerParty_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+bool PartyManager::isInParty(uint64_t playerId) const {
+    std::lock_guard lock(mutex_);
+    return playerParty_.contains(playerId);
+}
+
+std::size_t PartyManager::partyCount() const {
+    std::lock_guard lock(mutex_);
+    return parties_.size();
+}
+
+std::optional<int32_t> PartyManager::averagePartyRating(
+    PartyId partyId) const {
+    std::lock_guard lock(mutex_);
+
+    auto it = parties_.find(partyId);
+    if (it == parties_.end()) {
+        return std::nullopt;
+    }
+
+    const auto& members = it->second.members;
+    if (members.empty()) {
+        return std::nullopt;
+    }
+
+    int64_t sum = 0;
+    for (const auto& m : members) {
+        sum += static_cast<int64_t>(m.rating.mmr);
+    }
+
+    return static_cast<int32_t>(sum / static_cast<int64_t>(members.size()));
+}
+
+// -- Private helpers ----------------------------------------------------------
+
+PartyId PartyManager::nextPartyId() {
+    return nextPartyId_++;
+}
+
+void PartyManager::removePartyInternal(PartyId partyId) {
+    auto it = parties_.find(partyId);
+    if (it == parties_.end()) {
+        return;
+    }
+
+    // Remove all player→party mappings.
+    for (const auto& member : it->second.members) {
+        playerParty_.erase(member.playerId);
+    }
+
+    parties_.erase(it);
+}
+
+} // namespace cgs::service

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -313,6 +313,38 @@ target_link_libraries(cgs_service_lobby_tests PRIVATE
 )
 gtest_discover_tests(cgs_service_lobby_tests)
 
+# Unit tests - Service party manager (party lifecycle, member management)
+add_executable(cgs_service_party_manager_tests
+    unit/service/party_manager_test.cpp
+)
+target_link_libraries(cgs_service_party_manager_tests PRIVATE
+    cgs::service_lobby
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_service_party_manager_tests)
+
+# Unit tests - Service lobby server (orchestration, party queuing, ELO)
+add_executable(cgs_service_lobby_server_tests
+    unit/service/lobby_server_test.cpp
+)
+target_link_libraries(cgs_service_lobby_server_tests PRIVATE
+    cgs::service_lobby
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_service_lobby_server_tests)
+
+# Integration tests - Service lobby (matchmaking flow, party queuing, benchmark)
+add_executable(cgs_service_lobby_integration_tests
+    integration/service/lobby_integration_test.cpp
+)
+target_link_libraries(cgs_service_lobby_integration_tests PRIVATE
+    cgs::service_lobby
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_service_lobby_integration_tests
+    PROPERTIES LABELS "integration"
+)
+
 # Unit tests - Service dbproxy (query cache, connection pool, dbproxy server)
 add_executable(cgs_service_dbproxy_tests
     unit/service/dbproxy_test.cpp

--- a/tests/integration/service/lobby_integration_test.cpp
+++ b/tests/integration/service/lobby_integration_test.cpp
@@ -1,0 +1,159 @@
+/// @file lobby_integration_test.cpp
+/// @brief Integration tests for LobbyServer: full matchmaking flow,
+///        party queuing, and throughput benchmark.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "cgs/service/lobby_server.hpp"
+#include "cgs/service/lobby_types.hpp"
+
+using namespace cgs::service;
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+class LobbyIntegrationTest : public ::testing::Test {
+protected:
+    LobbyConfig config_;
+    std::unique_ptr<LobbyServer> lobby_;
+
+    void SetUp() override {
+        config_.queueConfig.minPlayersPerMatch = 2;
+        config_.queueConfig.maxPlayersPerMatch = 2;
+        config_.queueConfig.initialRatingTolerance = 100;
+        config_.queueConfig.maxQueueSize = 10000;
+        config_.maxPartySize = 5;
+
+        lobby_ = std::make_unique<LobbyServer>(config_);
+        (void)lobby_->start();
+    }
+
+    PlayerRating makeRating(int32_t mmr) {
+        PlayerRating r;
+        r.mmr = mmr;
+        return r;
+    }
+};
+
+TEST_F(LobbyIntegrationTest, FullSoloMatchmakingFlow) {
+    // 20 players enqueue with close ratings.
+    for (uint64_t i = 1; i <= 20; ++i) {
+        auto mmr = static_cast<int32_t>(1500 + i * 5);
+        auto result = lobby_->enqueuePlayer(i, makeRating(mmr));
+        ASSERT_TRUE(result.hasValue()) << "Failed to enqueue player " << i;
+    }
+
+    auto s1 = lobby_->stats();
+    EXPECT_EQ(s1.queuedPlayers, 20u);
+
+    auto matches = lobby_->processMatchmaking();
+
+    // All 20 players should form 10 matches.
+    EXPECT_EQ(matches.size(), 10u);
+
+    auto s2 = lobby_->stats();
+    EXPECT_EQ(s2.queuedPlayers, 0u);
+    EXPECT_EQ(s2.matchesFormed, 10u);
+
+    // Each match should have 2 players.
+    for (const auto& match : matches) {
+        EXPECT_EQ(match.players.size(), 2u);
+        EXPECT_GT(match.matchQuality, 0.0f);
+        EXPECT_GT(match.matchId, 0u);
+    }
+}
+
+TEST_F(LobbyIntegrationTest, PartyQueueAndMatch) {
+    // Create two parties of 1 player each and queue them.
+    auto p1 = lobby_->createParty(1, "Alice", makeRating(1500));
+    auto p2 = lobby_->createParty(2, "Bob", makeRating(1520));
+    ASSERT_TRUE(p1.hasValue());
+    ASSERT_TRUE(p2.hasValue());
+
+    (void)lobby_->enqueueParty(p1.value());
+    (void)lobby_->enqueueParty(p2.value());
+
+    auto matches = lobby_->processMatchmaking();
+    EXPECT_EQ(matches.size(), 1u);
+
+    // Verify party members were matched.
+    bool hasAlice = false, hasBob = false;
+    for (const auto& player : matches[0].players) {
+        if (player.playerId == 1) hasAlice = true;
+        if (player.playerId == 2) hasBob = true;
+    }
+    EXPECT_TRUE(hasAlice);
+    EXPECT_TRUE(hasBob);
+
+    auto s = lobby_->stats();
+    EXPECT_EQ(s.matchesFormed, 1u);
+    EXPECT_EQ(s.partiesCreated, 2u);
+}
+
+TEST_F(LobbyIntegrationTest, PartyWithMultipleMembersQueue) {
+    // Create a 3-member party.
+    auto partyId = lobby_->createParty(10, "Leader", makeRating(1500));
+    (void)lobby_->addPartyMember(partyId.value(), 11, "M1", makeRating(1520));
+    (void)lobby_->addPartyMember(partyId.value(), 12, "M2", makeRating(1480));
+
+    auto result = lobby_->enqueueParty(partyId.value());
+    EXPECT_TRUE(result.hasValue());
+
+    // All 3 members should be queued.
+    EXPECT_TRUE(lobby_->isPlayerQueued(10));
+    EXPECT_TRUE(lobby_->isPlayerQueued(11));
+    EXPECT_TRUE(lobby_->isPlayerQueued(12));
+
+    // Dequeue party removes all members.
+    (void)lobby_->dequeueParty(partyId.value());
+    EXPECT_FALSE(lobby_->isPlayerQueued(10));
+    EXPECT_FALSE(lobby_->isPlayerQueued(11));
+    EXPECT_FALSE(lobby_->isPlayerQueued(12));
+}
+
+TEST_F(LobbyIntegrationTest, EloRatingConvergence) {
+    // Simulate 10 games between two players of equal skill.
+    PlayerRating p1;
+    p1.mmr = 1500;
+    p1.gamesPlayed = 0;
+
+    PlayerRating p2;
+    p2.mmr = 1500;
+    p2.gamesPlayed = 0;
+
+    // Alternate winners to simulate equal skill.
+    for (int i = 0; i < 10; ++i) {
+        if (i % 2 == 0) {
+            LobbyServer::updateRatings(p1, p2);
+        } else {
+            LobbyServer::updateRatings(p2, p1);
+        }
+    }
+
+    // After alternating wins, ratings should stay close to initial.
+    EXPECT_NEAR(p1.mmr, 1500, 50);
+    EXPECT_NEAR(p2.mmr, 1500, 50);
+    EXPECT_EQ(p1.gamesPlayed, 10u);
+    EXPECT_EQ(p2.gamesPlayed, 10u);
+}
+
+TEST_F(LobbyIntegrationTest, MatchmakingThroughputBenchmark) {
+    // Enqueue 1000 players and process all matches.
+    for (uint64_t i = 1; i <= 1000; ++i) {
+        auto mmr = static_cast<int32_t>(1400 + static_cast<int32_t>(i % 200));
+        (void)lobby_->enqueuePlayer(i, makeRating(mmr));
+    }
+
+    EXPECT_EQ(lobby_->stats().queuedPlayers, 1000u);
+
+    auto matches = lobby_->processMatchmaking();
+
+    // Should form a significant number of matches.
+    EXPECT_GE(matches.size(), 400u);
+
+    auto s = lobby_->stats();
+    EXPECT_GE(s.matchesFormed, 400u);
+}

--- a/tests/unit/service/lobby_server_test.cpp
+++ b/tests/unit/service/lobby_server_test.cpp
@@ -1,0 +1,298 @@
+/// @file lobby_server_test.cpp
+/// @brief Unit tests for LobbyServer (orchestration, party queuing, ELO).
+
+#include <gtest/gtest.h>
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/service/lobby_server.hpp"
+#include "cgs/service/lobby_types.hpp"
+
+using namespace cgs::service;
+using cgs::foundation::ErrorCode;
+
+// ============================================================================
+// LobbyServer Tests
+// ============================================================================
+
+class LobbyServerTest : public ::testing::Test {
+protected:
+    LobbyConfig config_;
+    std::unique_ptr<LobbyServer> lobby_;
+
+    void SetUp() override {
+        config_.queueConfig.minPlayersPerMatch = 2;
+        config_.queueConfig.maxPlayersPerMatch = 2;
+        config_.queueConfig.initialRatingTolerance = 100;
+        config_.queueConfig.maxQueueSize = 100;
+        config_.maxPartySize = 5;
+
+        lobby_ = std::make_unique<LobbyServer>(config_);
+        (void)lobby_->start();
+    }
+
+    PlayerRating makeRating(int32_t mmr, uint32_t gamesPlayed = 50) {
+        PlayerRating r;
+        r.mmr = mmr;
+        r.gamesPlayed = gamesPlayed;
+        return r;
+    }
+};
+
+// -- Lifecycle ----------------------------------------------------------------
+
+TEST_F(LobbyServerTest, StartSucceeds) {
+    LobbyServer lobby(config_);
+    auto result = lobby.start();
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_TRUE(lobby.isRunning());
+}
+
+TEST_F(LobbyServerTest, DoubleStartFails) {
+    auto result = lobby_->start();
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::LobbyAlreadyStarted);
+}
+
+TEST_F(LobbyServerTest, StopAndRestart) {
+    lobby_->stop();
+    EXPECT_FALSE(lobby_->isRunning());
+
+    auto result = lobby_->start();
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_TRUE(lobby_->isRunning());
+}
+
+// -- Solo matchmaking ---------------------------------------------------------
+
+TEST_F(LobbyServerTest, EnqueuePlayerSucceeds) {
+    auto result = lobby_->enqueuePlayer(1, makeRating(1500));
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_TRUE(lobby_->isPlayerQueued(1));
+}
+
+TEST_F(LobbyServerTest, EnqueuePlayerNotStartedFails) {
+    LobbyServer lobby(config_);
+    auto result = lobby.enqueuePlayer(1, makeRating(1500));
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::LobbyNotStarted);
+}
+
+TEST_F(LobbyServerTest, EnqueueDuplicatePlayerFails) {
+    (void)lobby_->enqueuePlayer(1, makeRating(1500));
+    auto result = lobby_->enqueuePlayer(1, makeRating(1500));
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST_F(LobbyServerTest, DequeuePlayerSucceeds) {
+    (void)lobby_->enqueuePlayer(1, makeRating(1500));
+    EXPECT_TRUE(lobby_->dequeuePlayer(1));
+    EXPECT_FALSE(lobby_->isPlayerQueued(1));
+}
+
+TEST_F(LobbyServerTest, DequeueNonexistentReturnsFalse) {
+    EXPECT_FALSE(lobby_->dequeuePlayer(999));
+}
+
+// -- Party management via LobbyServer ----------------------------------------
+
+TEST_F(LobbyServerTest, CreatePartySucceeds) {
+    auto result = lobby_->createParty(1, "Alice", makeRating(1500));
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_GT(result.value(), 0u);
+}
+
+TEST_F(LobbyServerTest, CreatePartyNotStartedFails) {
+    LobbyServer lobby(config_);
+    auto result = lobby.createParty(1, "Alice", makeRating(1500));
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::LobbyNotStarted);
+}
+
+TEST_F(LobbyServerTest, AddAndRemovePartyMember) {
+    auto partyId = lobby_->createParty(1, "Alice", makeRating(1500));
+    auto result = lobby_->addPartyMember(
+        partyId.value(), 2, "Bob", makeRating(1600));
+    EXPECT_TRUE(result.hasValue());
+
+    auto party = lobby_->getParty(partyId.value());
+    ASSERT_TRUE(party.has_value());
+    EXPECT_EQ(party->members.size(), 2u);
+
+    result = lobby_->removePartyMember(partyId.value(), 2);
+    EXPECT_TRUE(result.hasValue());
+
+    party = lobby_->getParty(partyId.value());
+    EXPECT_EQ(party->members.size(), 1u);
+}
+
+TEST_F(LobbyServerTest, DisbandPartySucceeds) {
+    auto partyId = lobby_->createParty(1, "Alice", makeRating(1500));
+    auto result = lobby_->disbandParty(partyId.value(), 1);
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_FALSE(lobby_->getParty(partyId.value()).has_value());
+}
+
+TEST_F(LobbyServerTest, PromotePartyLeader) {
+    auto partyId = lobby_->createParty(1, "Alice", makeRating(1500));
+    (void)lobby_->addPartyMember(partyId.value(), 2, "Bob", makeRating(1500));
+
+    auto result = lobby_->promotePartyLeader(partyId.value(), 1, 2);
+    EXPECT_TRUE(result.hasValue());
+
+    auto party = lobby_->getParty(partyId.value());
+    EXPECT_EQ(party->leaderId, 2u);
+}
+
+TEST_F(LobbyServerTest, GetPlayerParty) {
+    auto partyId = lobby_->createParty(1, "Alice", makeRating(1500));
+    auto result = lobby_->getPlayerParty(1);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, partyId.value());
+}
+
+// -- Party matchmaking --------------------------------------------------------
+
+TEST_F(LobbyServerTest, EnqueuePartySucceeds) {
+    auto partyId = lobby_->createParty(1, "Alice", makeRating(1500));
+    (void)lobby_->addPartyMember(partyId.value(), 2, "Bob", makeRating(1600));
+
+    auto result = lobby_->enqueueParty(partyId.value());
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_TRUE(lobby_->isPlayerQueued(1));
+    EXPECT_TRUE(lobby_->isPlayerQueued(2));
+}
+
+TEST_F(LobbyServerTest, EnqueuePartyNotStartedFails) {
+    LobbyServer lobby(config_);
+    auto result = lobby.enqueueParty(999);
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST_F(LobbyServerTest, EnqueuePartyNotFoundFails) {
+    auto result = lobby_->enqueueParty(999);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PartyNotFound);
+}
+
+TEST_F(LobbyServerTest, DequeuePartySucceeds) {
+    auto partyId = lobby_->createParty(1, "Alice", makeRating(1500));
+    (void)lobby_->addPartyMember(partyId.value(), 2, "Bob", makeRating(1600));
+    (void)lobby_->enqueueParty(partyId.value());
+
+    auto result = lobby_->dequeueParty(partyId.value());
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_FALSE(lobby_->isPlayerQueued(1));
+    EXPECT_FALSE(lobby_->isPlayerQueued(2));
+}
+
+TEST_F(LobbyServerTest, DequeuePartyNotFoundFails) {
+    auto result = lobby_->dequeueParty(999);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PartyNotFound);
+}
+
+// -- Match processing ---------------------------------------------------------
+
+TEST_F(LobbyServerTest, ProcessMatchmakingFormsMatch) {
+    (void)lobby_->enqueuePlayer(1, makeRating(1500));
+    (void)lobby_->enqueuePlayer(2, makeRating(1550));
+
+    auto matches = lobby_->processMatchmaking();
+    EXPECT_EQ(matches.size(), 1u);
+    EXPECT_EQ(matches[0].players.size(), 2u);
+}
+
+TEST_F(LobbyServerTest, ProcessMatchmakingNoMatchPossible) {
+    (void)lobby_->enqueuePlayer(1, makeRating(1500));
+    auto matches = lobby_->processMatchmaking();
+    EXPECT_TRUE(matches.empty());
+}
+
+TEST_F(LobbyServerTest, ProcessMatchmakingMultipleMatches) {
+    (void)lobby_->enqueuePlayer(1, makeRating(1500));
+    (void)lobby_->enqueuePlayer(2, makeRating(1510));
+    (void)lobby_->enqueuePlayer(3, makeRating(1600));
+    (void)lobby_->enqueuePlayer(4, makeRating(1610));
+
+    auto matches = lobby_->processMatchmaking();
+    EXPECT_EQ(matches.size(), 2u);
+}
+
+// -- ELO updates --------------------------------------------------------------
+
+TEST_F(LobbyServerTest, UpdateRatingsWinnerGains) {
+    PlayerRating winner = makeRating(1500);
+    PlayerRating loser = makeRating(1500);
+
+    LobbyServer::updateRatings(winner, loser);
+
+    EXPECT_GT(winner.mmr, 1500);
+    EXPECT_LT(loser.mmr, 1500);
+    EXPECT_EQ(winner.gamesPlayed, 51u);
+    EXPECT_EQ(loser.gamesPlayed, 51u);
+}
+
+TEST_F(LobbyServerTest, UpdateRatingsUpsetLargerSwing) {
+    PlayerRating underdog = makeRating(1400);
+    PlayerRating favorite = makeRating(1600);
+
+    LobbyServer::updateRatings(underdog, favorite);
+
+    int32_t underdogGain = underdog.mmr - 1400;
+    EXPECT_GT(underdogGain, 16); // Upset win yields larger gain.
+}
+
+TEST_F(LobbyServerTest, UpdateRatingsConservation) {
+    PlayerRating winner = makeRating(1500, 50);
+    PlayerRating loser = makeRating(1500, 50);
+
+    LobbyServer::updateRatings(winner, loser);
+
+    // Same K-factor → total rating change is zero-sum.
+    EXPECT_EQ(winner.mmr + loser.mmr, 3000);
+}
+
+// -- Statistics ---------------------------------------------------------------
+
+TEST_F(LobbyServerTest, StatsInitiallyZero) {
+    auto s = lobby_->stats();
+    EXPECT_EQ(s.queuedPlayers, 0u);
+    EXPECT_EQ(s.matchesFormed, 0u);
+    EXPECT_EQ(s.activeParties, 0u);
+    EXPECT_EQ(s.partiesCreated, 0u);
+    EXPECT_EQ(s.partiesDisbanded, 0u);
+}
+
+TEST_F(LobbyServerTest, StatsTracksQueuesAndMatches) {
+    (void)lobby_->enqueuePlayer(1, makeRating(1500));
+    (void)lobby_->enqueuePlayer(2, makeRating(1510));
+
+    auto s1 = lobby_->stats();
+    EXPECT_EQ(s1.queuedPlayers, 2u);
+
+    (void)lobby_->processMatchmaking();
+
+    auto s2 = lobby_->stats();
+    EXPECT_EQ(s2.queuedPlayers, 0u);
+    EXPECT_EQ(s2.matchesFormed, 1u);
+}
+
+TEST_F(LobbyServerTest, StatsTracksParties) {
+    auto p1 = lobby_->createParty(1, "Alice", makeRating(1500));
+    (void)lobby_->createParty(2, "Bob", makeRating(1500));
+
+    auto s1 = lobby_->stats();
+    EXPECT_EQ(s1.activeParties, 2u);
+    EXPECT_EQ(s1.partiesCreated, 2u);
+
+    (void)lobby_->disbandParty(p1.value(), 1);
+
+    auto s2 = lobby_->stats();
+    EXPECT_EQ(s2.activeParties, 1u);
+    EXPECT_EQ(s2.partiesDisbanded, 1u);
+}
+
+TEST_F(LobbyServerTest, ConfigAccessor) {
+    EXPECT_EQ(lobby_->config().maxPartySize, 5u);
+    EXPECT_EQ(lobby_->config().queueConfig.minPlayersPerMatch, 2u);
+}

--- a/tests/unit/service/party_manager_test.cpp
+++ b/tests/unit/service/party_manager_test.cpp
@@ -1,0 +1,314 @@
+/// @file party_manager_test.cpp
+/// @brief Unit tests for PartyManager (party lifecycle, member management).
+
+#include <gtest/gtest.h>
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/service/lobby_types.hpp"
+#include "cgs/service/party_manager.hpp"
+
+using namespace cgs::service;
+using cgs::foundation::ErrorCode;
+
+// ============================================================================
+// PartyManager Tests
+// ============================================================================
+
+class PartyManagerTest : public ::testing::Test {
+protected:
+    PartyManager pm_{5};
+
+    PlayerRating makeRating(int32_t mmr) {
+        PlayerRating r;
+        r.mmr = mmr;
+        return r;
+    }
+};
+
+// -- Party lifecycle ----------------------------------------------------------
+
+TEST_F(PartyManagerTest, CreatePartySucceeds) {
+    auto result = pm_.createParty(1, "Alice", makeRating(1500));
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_GT(result.value(), 0u);
+    EXPECT_EQ(pm_.partyCount(), 1u);
+}
+
+TEST_F(PartyManagerTest, CreatePartyPlayerAlreadyInParty) {
+    (void)pm_.createParty(1, "Alice", makeRating(1500));
+    auto result = pm_.createParty(1, "Alice", makeRating(1500));
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PlayerAlreadyInParty);
+}
+
+TEST_F(PartyManagerTest, CreatePartyLeaderIsMember) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    ASSERT_TRUE(partyId.hasValue());
+
+    auto party = pm_.getParty(partyId.value());
+    ASSERT_TRUE(party.has_value());
+    EXPECT_EQ(party->leaderId, 1u);
+    EXPECT_EQ(party->members.size(), 1u);
+    EXPECT_EQ(party->members[0].playerId, 1u);
+    EXPECT_EQ(party->members[0].name, "Alice");
+}
+
+TEST_F(PartyManagerTest, DisbandPartySucceeds) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    auto result = pm_.disbandParty(partyId.value(), 1);
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_EQ(pm_.partyCount(), 0u);
+    EXPECT_FALSE(pm_.isInParty(1));
+}
+
+TEST_F(PartyManagerTest, DisbandPartyNotLeaderFails) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+
+    auto result = pm_.disbandParty(partyId.value(), 2);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::NotPartyLeader);
+}
+
+TEST_F(PartyManagerTest, DisbandPartyNotFoundFails) {
+    auto result = pm_.disbandParty(999, 1);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PartyNotFound);
+}
+
+TEST_F(PartyManagerTest, DisbandClearsAllMemberMappings) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 3, "Charlie", makeRating(1500));
+
+    (void)pm_.disbandParty(partyId.value(), 1);
+
+    EXPECT_FALSE(pm_.isInParty(1));
+    EXPECT_FALSE(pm_.isInParty(2));
+    EXPECT_FALSE(pm_.isInParty(3));
+}
+
+// -- Member management --------------------------------------------------------
+
+TEST_F(PartyManagerTest, AddMemberSucceeds) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    auto result = pm_.addMember(partyId.value(), 2, "Bob", makeRating(1600));
+
+    EXPECT_TRUE(result.hasValue());
+
+    auto party = pm_.getParty(partyId.value());
+    ASSERT_TRUE(party.has_value());
+    EXPECT_EQ(party->members.size(), 2u);
+}
+
+TEST_F(PartyManagerTest, AddMemberPartyNotFound) {
+    auto result = pm_.addMember(999, 2, "Bob", makeRating(1500));
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PartyNotFound);
+}
+
+TEST_F(PartyManagerTest, AddMemberAlreadyInParty) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    auto result = pm_.addMember(partyId.value(), 1, "Alice", makeRating(1500));
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PlayerAlreadyInParty);
+}
+
+TEST_F(PartyManagerTest, AddMemberAlreadyInDifferentParty) {
+    auto p1 = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.createParty(2, "Bob", makeRating(1500));
+
+    auto result = pm_.addMember(p1.value(), 2, "Bob", makeRating(1500));
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PlayerAlreadyInParty);
+}
+
+TEST_F(PartyManagerTest, AddMemberPartyFull) {
+    PartyManager pm(2);
+    auto partyId = pm.createParty(1, "Alice", makeRating(1500));
+    (void)pm.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+
+    auto result = pm.addMember(partyId.value(), 3, "Charlie", makeRating(1500));
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PartyFull);
+}
+
+TEST_F(PartyManagerTest, RemoveMemberNonLeader) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+
+    auto result = pm_.removeMember(partyId.value(), 2);
+    EXPECT_TRUE(result.hasValue());
+
+    auto party = pm_.getParty(partyId.value());
+    ASSERT_TRUE(party.has_value());
+    EXPECT_EQ(party->members.size(), 1u);
+    EXPECT_FALSE(pm_.isInParty(2));
+}
+
+TEST_F(PartyManagerTest, RemoveLeaderDisbandsParty) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+
+    auto result = pm_.removeMember(partyId.value(), 1);
+    EXPECT_TRUE(result.hasValue());
+    EXPECT_EQ(pm_.partyCount(), 0u);
+    EXPECT_FALSE(pm_.isInParty(1));
+    EXPECT_FALSE(pm_.isInParty(2));
+}
+
+TEST_F(PartyManagerTest, RemoveMemberNotInParty) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    auto result = pm_.removeMember(partyId.value(), 99);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PlayerNotInParty);
+}
+
+TEST_F(PartyManagerTest, RemoveMemberPartyNotFound) {
+    auto result = pm_.removeMember(999, 1);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PartyNotFound);
+}
+
+// -- Promote leader -----------------------------------------------------------
+
+TEST_F(PartyManagerTest, PromoteLeaderSucceeds) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+
+    auto result = pm_.promoteLeader(partyId.value(), 1, 2);
+    EXPECT_TRUE(result.hasValue());
+
+    auto party = pm_.getParty(partyId.value());
+    ASSERT_TRUE(party.has_value());
+    EXPECT_EQ(party->leaderId, 2u);
+}
+
+TEST_F(PartyManagerTest, PromoteLeaderNotCurrentLeader) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+
+    auto result = pm_.promoteLeader(partyId.value(), 2, 1);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::NotPartyLeader);
+}
+
+TEST_F(PartyManagerTest, PromoteLeaderTargetNotInParty) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    auto result = pm_.promoteLeader(partyId.value(), 1, 99);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PlayerNotInParty);
+}
+
+TEST_F(PartyManagerTest, PromoteLeaderPartyNotFound) {
+    auto result = pm_.promoteLeader(999, 1, 2);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PartyNotFound);
+}
+
+// -- Queue integration --------------------------------------------------------
+
+TEST_F(PartyManagerTest, SetInQueueSucceeds) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    auto result = pm_.setInQueue(partyId.value(), true);
+    EXPECT_TRUE(result.hasValue());
+
+    auto party = pm_.getParty(partyId.value());
+    ASSERT_TRUE(party.has_value());
+    EXPECT_TRUE(party->inQueue);
+}
+
+TEST_F(PartyManagerTest, SetInQueuePartyNotFound) {
+    auto result = pm_.setInQueue(999, true);
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(result.error().code(), ErrorCode::PartyNotFound);
+}
+
+// -- Queries ------------------------------------------------------------------
+
+TEST_F(PartyManagerTest, GetPlayerParty) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+
+    auto p1 = pm_.getPlayerParty(1);
+    auto p2 = pm_.getPlayerParty(2);
+    ASSERT_TRUE(p1.has_value());
+    ASSERT_TRUE(p2.has_value());
+    EXPECT_EQ(*p1, partyId.value());
+    EXPECT_EQ(*p2, partyId.value());
+}
+
+TEST_F(PartyManagerTest, GetPlayerPartyNotInAny) {
+    auto result = pm_.getPlayerParty(999);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(PartyManagerTest, IsInPartyCheck) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    EXPECT_TRUE(pm_.isInParty(1));
+    EXPECT_FALSE(pm_.isInParty(2));
+
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1500));
+    EXPECT_TRUE(pm_.isInParty(2));
+}
+
+TEST_F(PartyManagerTest, AveragePartyRating) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.addMember(partyId.value(), 2, "Bob", makeRating(1600));
+    (void)pm_.addMember(partyId.value(), 3, "Charlie", makeRating(1700));
+
+    auto avg = pm_.averagePartyRating(partyId.value());
+    ASSERT_TRUE(avg.has_value());
+    EXPECT_EQ(*avg, 1600); // (1500 + 1600 + 1700) / 3
+}
+
+TEST_F(PartyManagerTest, AveragePartyRatingSingleMember) {
+    auto partyId = pm_.createParty(1, "Alice", makeRating(1500));
+    auto avg = pm_.averagePartyRating(partyId.value());
+    ASSERT_TRUE(avg.has_value());
+    EXPECT_EQ(*avg, 1500);
+}
+
+TEST_F(PartyManagerTest, AveragePartyRatingNotFound) {
+    auto avg = pm_.averagePartyRating(999);
+    EXPECT_FALSE(avg.has_value());
+}
+
+TEST_F(PartyManagerTest, UniquePartyIds) {
+    auto p1 = pm_.createParty(1, "Alice", makeRating(1500));
+    (void)pm_.disbandParty(p1.value(), 1);
+    auto p2 = pm_.createParty(1, "Alice", makeRating(1500));
+
+    ASSERT_TRUE(p1.hasValue());
+    ASSERT_TRUE(p2.hasValue());
+    EXPECT_NE(p1.value(), p2.value());
+}
+
+TEST_F(PartyManagerTest, MultiplePartiesCoexist) {
+    auto p1 = pm_.createParty(1, "Alice", makeRating(1500));
+    auto p2 = pm_.createParty(2, "Bob", makeRating(1600));
+
+    EXPECT_EQ(pm_.partyCount(), 2u);
+
+    auto party1 = pm_.getParty(p1.value());
+    auto party2 = pm_.getParty(p2.value());
+    ASSERT_TRUE(party1.has_value());
+    ASSERT_TRUE(party2.has_value());
+    EXPECT_EQ(party1->leaderId, 1u);
+    EXPECT_EQ(party2->leaderId, 2u);
+}
+
+TEST_F(PartyManagerTest, FillPartyToMaxSize) {
+    PartyManager pm(3);
+    auto partyId = pm.createParty(1, "P1", makeRating(1500));
+
+    auto r2 = pm.addMember(partyId.value(), 2, "P2", makeRating(1500));
+    EXPECT_TRUE(r2.hasValue());
+
+    auto r3 = pm.addMember(partyId.value(), 3, "P3", makeRating(1500));
+    EXPECT_TRUE(r3.hasValue());
+
+    auto r4 = pm.addMember(partyId.value(), 4, "P4", makeRating(1500));
+    EXPECT_TRUE(r4.hasError());
+    EXPECT_EQ(r4.error().code(), ErrorCode::PartyFull);
+}


### PR DESCRIPTION
## Summary

- Add **PartyManager** for thread-safe party lifecycle: create, disband, add/remove members, promote leader, queue integration
- Add **LobbyServer** orchestrating MatchmakingQueue, PartyManager, and EloCalculator into a unified facade
- Support solo and party matchmaking with automatic average MMR calculation for parties
- Extend `lobby_types.hpp` with Party, LobbyConfig, and LobbyStats types
- Add 6 new Lobby error codes (PlayerAlreadyInParty, NotPartyLeader, LobbyNotStarted, LobbyAlreadyStarted, NoServerAvailable, PlayerNotInParty)
- Update lobby CMakeLists to include new source files

## Test Plan

- [x] 31 PartyManager unit tests (lifecycle, member management, promote, queue, queries)
- [x] 29 LobbyServer unit tests (lifecycle, solo queue, party management, match processing, ELO, stats)
- [x] 5 integration tests (full solo flow with 20 players, party queue and match, multi-member party queue, ELO convergence, 1000-player throughput benchmark)
- [x] 47 existing matchmaking/ELO tests still pass (regression)
- [x] Build passes with -Werror -Wconversion -Wsign-conversion

Closes #25