### PR TITLE
feat(plugin): add EventBus for type-safe plugin event communication

### DIFF
--- a/include/cgs/plugin/event_bus.hpp
+++ b/include/cgs/plugin/event_bus.hpp
@@ -1,0 +1,270 @@
+#pragma once
+
+/// @file event_bus.hpp
+/// @brief Type-safe event bus for plugin-to-plugin communication.
+///
+/// Provides synchronous and deferred event publishing with priority
+/// ordering and automatic subscription management.
+///
+/// @see SRS-PLG-003
+/// @see SDS-MOD-017
+
+#include <algorithm>
+#include <any>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+
+namespace cgs::plugin {
+
+/// Unique identifier for an event subscription.
+using SubscriptionId = uint64_t;
+
+/// Type-safe event bus supporting synchronous and deferred delivery.
+///
+/// Events are dispatched to handlers registered for the concrete event
+/// type. Handlers are invoked in priority order (lower value = higher
+/// priority). Within the same priority, handlers are called in
+/// subscription order.
+///
+/// Usage:
+/// @code
+///   EventBus bus;
+///
+///   // Subscribe with priority (default = 0).
+///   auto id = bus.Subscribe<MyEvent>([](const MyEvent& e) {
+///       // handle event
+///   });
+///
+///   // Synchronous publish — handlers called immediately.
+///   bus.Publish(MyEvent{42});
+///
+///   // Deferred publish — queued for later.
+///   bus.PublishDeferred(MyEvent{99});
+///   bus.ProcessDeferred();  // Flush the queue.
+///
+///   // Unsubscribe when done.
+///   bus.Unsubscribe(id);
+/// @endcode
+class EventBus {
+public:
+    EventBus() = default;
+    ~EventBus() = default;
+
+    EventBus(const EventBus&) = delete;
+    EventBus& operator=(const EventBus&) = delete;
+
+    EventBus(EventBus&& other) noexcept {
+        std::lock_guard lock(other.mutex_);
+        handlers_ = std::move(other.handlers_);
+        subscriptionTypes_ = std::move(other.subscriptionTypes_);
+        deferredQueue_ = std::move(other.deferredQueue_);
+        nextId_ = other.nextId_;
+    }
+
+    EventBus& operator=(EventBus&& other) noexcept {
+        if (this != &other) {
+            std::scoped_lock lock(mutex_, other.mutex_);
+            handlers_ = std::move(other.handlers_);
+            subscriptionTypes_ = std::move(other.subscriptionTypes_);
+            deferredQueue_ = std::move(other.deferredQueue_);
+            nextId_ = other.nextId_;
+        }
+        return *this;
+    }
+
+    // -- Subscribe ------------------------------------------------------------
+
+    /// Subscribe a handler for events of type E.
+    ///
+    /// @tparam E  The event type to subscribe to.
+    /// @param handler   Callback invoked when an event of type E is published.
+    /// @param priority  Handler priority (lower = called first, default 0).
+    /// @return A unique subscription ID for later unsubscription.
+    template <typename E>
+    SubscriptionId Subscribe(std::function<void(const E&)> handler,
+                             int32_t priority = 0) {
+        std::lock_guard lock(mutex_);
+
+        auto id = nextId_++;
+        auto typeIdx = std::type_index(typeid(E));
+
+        HandlerEntry entry;
+        entry.id = id;
+        entry.priority = priority;
+        entry.handler = [fn = std::move(handler)](const std::any& event) {
+            fn(std::any_cast<const E&>(event));
+        };
+
+        auto& handlers = handlers_[typeIdx];
+        handlers.push_back(std::move(entry));
+        sortHandlers(handlers);
+
+        // Track type for type-erased unsubscribe.
+        subscriptionTypes_.insert_or_assign(id, typeIdx);
+
+        return id;
+    }
+
+    // -- Unsubscribe ----------------------------------------------------------
+
+    /// Remove a subscription by ID.
+    ///
+    /// Safe to call with an already-removed or invalid ID (no-op).
+    void Unsubscribe(SubscriptionId id) {
+        std::lock_guard lock(mutex_);
+        unsubscribeInternal(id);
+    }
+
+    /// Remove all subscriptions, clearing the handler table entirely.
+    void UnsubscribeAll() {
+        std::lock_guard lock(mutex_);
+        handlers_.clear();
+        subscriptionTypes_.clear();
+    }
+
+    // -- Synchronous publish --------------------------------------------------
+
+    /// Publish an event synchronously.
+    ///
+    /// All registered handlers for type E are called immediately,
+    /// in priority order, on the calling thread.
+    template <typename E>
+    void Publish(const E& event) {
+        std::vector<HandlerEntry> snapshot;
+        {
+            std::lock_guard lock(mutex_);
+            auto it = handlers_.find(std::type_index(typeid(E)));
+            if (it == handlers_.end()) {
+                return;
+            }
+            snapshot = it->second;
+        }
+
+        std::any wrapped = event;
+        for (const auto& entry : snapshot) {
+            entry.handler(wrapped);
+        }
+    }
+
+    // -- Deferred publish -----------------------------------------------------
+
+    /// Queue an event for deferred processing.
+    ///
+    /// The event is copied and stored. Call ProcessDeferred() to
+    /// dispatch all queued events (typically at frame boundaries).
+    template <typename E>
+    void PublishDeferred(E event) {
+        std::lock_guard lock(mutex_);
+        deferredQueue_.push_back([this, evt = std::move(event)]() {
+            Publish(evt);
+        });
+    }
+
+    /// Flush the deferred event queue.
+    ///
+    /// Dispatches all queued events in FIFO order. New events published
+    /// during processing are NOT included in this cycle.
+    void ProcessDeferred() {
+        std::vector<std::function<void()>> queue;
+        {
+            std::lock_guard lock(mutex_);
+            queue.swap(deferredQueue_);
+        }
+
+        for (auto& fn : queue) {
+            fn();
+        }
+    }
+
+    // -- Queries --------------------------------------------------------------
+
+    /// Get the total number of active subscriptions across all event types.
+    [[nodiscard]] std::size_t HandlerCount() const {
+        std::lock_guard lock(mutex_);
+        std::size_t count = 0;
+        for (const auto& [_, handlers] : handlers_) {
+            count += handlers.size();
+        }
+        return count;
+    }
+
+    /// Get the number of handlers for a specific event type.
+    template <typename E>
+    [[nodiscard]] std::size_t HandlerCountFor() const {
+        std::lock_guard lock(mutex_);
+        auto it = handlers_.find(std::type_index(typeid(E)));
+        if (it == handlers_.end()) {
+            return 0;
+        }
+        return it->second.size();
+    }
+
+    /// Get the number of events waiting in the deferred queue.
+    [[nodiscard]] std::size_t DeferredCount() const {
+        std::lock_guard lock(mutex_);
+        return deferredQueue_.size();
+    }
+
+private:
+    /// A type-erased handler with priority and ID.
+    struct HandlerEntry {
+        SubscriptionId id = 0;
+        int32_t priority = 0;
+        std::function<void(const std::any&)> handler;
+    };
+
+    /// Sort handlers by priority (ascending), stable to preserve
+    /// insertion order within the same priority level.
+    static void sortHandlers(std::vector<HandlerEntry>& handlers) {
+        std::stable_sort(handlers.begin(), handlers.end(),
+                         [](const HandlerEntry& a, const HandlerEntry& b) {
+                             return a.priority < b.priority;
+                         });
+    }
+
+    /// Internal unsubscribe without locking (caller must hold mutex_).
+    void unsubscribeInternal(SubscriptionId id) {
+        auto typeIt = subscriptionTypes_.find(id);
+        if (typeIt == subscriptionTypes_.end()) {
+            return;
+        }
+
+        auto handlersIt = handlers_.find(typeIt->second);
+        if (handlersIt != handlers_.end()) {
+            auto& vec = handlersIt->second;
+            vec.erase(
+                std::remove_if(vec.begin(), vec.end(),
+                               [id](const HandlerEntry& e) {
+                                   return e.id == id;
+                               }),
+                vec.end());
+
+            if (vec.empty()) {
+                handlers_.erase(handlersIt);
+            }
+        }
+
+        subscriptionTypes_.erase(typeIt);
+    }
+
+    /// Handler table: type_index → sorted handler list.
+    std::unordered_map<std::type_index, std::vector<HandlerEntry>> handlers_;
+
+    /// Reverse lookup: subscription ID → type_index.
+    std::unordered_map<SubscriptionId, std::type_index> subscriptionTypes_;
+
+    /// Queue of deferred event dispatches.
+    std::vector<std::function<void()>> deferredQueue_;
+
+    /// Next subscription ID.
+    SubscriptionId nextId_ = 1;
+
+    /// Mutex for thread safety.
+    mutable std::mutex mutex_;
+};
+
+} // namespace cgs::plugin

--- a/include/cgs/plugin/plugin_events.hpp
+++ b/include/cgs/plugin/plugin_events.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+/// @file plugin_events.hpp
+/// @brief Plugin lifecycle event types for EventBus communication.
+///
+/// These events are emitted by PluginManager at each lifecycle
+/// transition, allowing plugins to react to changes in the system.
+///
+/// @see SRS-PLG-003
+/// @see SDS-MOD-017
+
+#include <chrono>
+#include <string>
+
+#include "cgs/plugin/plugin_types.hpp"
+
+namespace cgs::plugin {
+
+/// Emitted when a plugin is successfully loaded.
+struct PluginLoadedEvent {
+    std::string pluginName;
+    Version version;
+    std::chrono::steady_clock::time_point timestamp =
+        std::chrono::steady_clock::now();
+};
+
+/// Emitted when a plugin completes initialization.
+struct PluginInitializedEvent {
+    std::string pluginName;
+    std::chrono::steady_clock::time_point timestamp =
+        std::chrono::steady_clock::now();
+};
+
+/// Emitted when a plugin is activated and ready for updates.
+struct PluginActivatedEvent {
+    std::string pluginName;
+    std::chrono::steady_clock::time_point timestamp =
+        std::chrono::steady_clock::now();
+};
+
+/// Emitted when a plugin begins shutting down.
+struct PluginShutdownEvent {
+    std::string pluginName;
+    std::chrono::steady_clock::time_point timestamp =
+        std::chrono::steady_clock::now();
+};
+
+/// Emitted when a plugin encounters an error during a lifecycle transition.
+struct PluginErrorEvent {
+    std::string pluginName;
+    std::string errorMessage;
+    std::chrono::steady_clock::time_point timestamp =
+        std::chrono::steady_clock::now();
+};
+
+} // namespace cgs::plugin

--- a/include/cgs/plugin/plugin_manager.hpp
+++ b/include/cgs/plugin/plugin_manager.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "cgs/foundation/game_result.hpp"
+#include "cgs/plugin/event_bus.hpp"
 #include "cgs/plugin/iplugin.hpp"
 #include "cgs/plugin/plugin_types.hpp"
 #include "cgs/plugin/version_constraint.hpp"
@@ -127,6 +128,9 @@ public:
     /// Return the number of loaded plugins.
     [[nodiscard]] std::size_t PluginCount() const noexcept;
 
+    /// Access the event bus owned by this manager.
+    [[nodiscard]] EventBus& GetEventBus() noexcept;
+
     // ── Dependency validation ──────────────────────────────────────────
 
     /// Describes a single dependency issue found during validation.
@@ -192,6 +196,9 @@ private:
 
     /// Plugin context shared with all plugins.
     PluginContext context_;
+
+    /// Event bus for inter-plugin communication and lifecycle events.
+    EventBus eventBus_;
 };
 
 } // namespace cgs::plugin

--- a/include/cgs/plugin/plugin_types.hpp
+++ b/include/cgs/plugin/plugin_types.hpp
@@ -13,6 +13,10 @@
 #include "cgs/foundation/service_locator.hpp"
 
 namespace cgs::plugin {
+class EventBus;
+} // namespace cgs::plugin
+
+namespace cgs::plugin {
 
 /// Plugin API version.  Plugins built against a different major version
 /// are considered incompatible and will be rejected during loading.
@@ -44,9 +48,11 @@ struct PluginInfo {
 /// Runtime context passed to plugins during their Load phase.
 ///
 /// Provides access to foundation services (logger, config, etc.)
-/// via the ServiceLocator.
+/// via the ServiceLocator, and to the shared EventBus for
+/// inter-plugin communication.
 struct PluginContext {
     cgs::foundation::ServiceLocator* services = nullptr;
+    EventBus* eventBus = nullptr;
 };
 
 /// Plugin lifecycle states.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,16 @@ target_link_libraries(cgs_plugin_dependency_tests PRIVATE
 )
 gtest_discover_tests(cgs_plugin_dependency_tests)
 
+# Unit tests - Plugin event bus (pub/sub, priority, deferred, lifecycle events)
+add_executable(cgs_plugin_event_bus_tests
+    unit/plugin/event_bus_test.cpp
+)
+target_link_libraries(cgs_plugin_event_bus_tests PRIVATE
+    cgs::plugin
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_plugin_event_bus_tests)
+
 # Unit tests - Game object system
 add_executable(cgs_game_object_system_tests
     unit/game/object_system_test.cpp

--- a/tests/unit/plugin/event_bus_test.cpp
+++ b/tests/unit/plugin/event_bus_test.cpp
@@ -1,0 +1,512 @@
+/// @file event_bus_test.cpp
+/// @brief Unit tests for EventBus (pub/sub, priority, deferred, unsubscribe)
+///        and integration tests for plugin lifecycle events.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "cgs/plugin/event_bus.hpp"
+#include "cgs/plugin/iplugin.hpp"
+#include "cgs/plugin/plugin_events.hpp"
+#include "cgs/plugin/plugin_export.hpp"
+#include "cgs/plugin/plugin_manager.hpp"
+
+using namespace cgs::plugin;
+
+// ============================================================================
+// Test event types
+// ============================================================================
+
+struct IntEvent {
+    int value = 0;
+};
+
+struct StringEvent {
+    std::string message;
+};
+
+struct PriorityEvent {
+    int id = 0;
+};
+
+// ============================================================================
+// EventBus Core Tests
+// ============================================================================
+
+class EventBusTest : public ::testing::Test {
+protected:
+    EventBus bus_;
+};
+
+TEST_F(EventBusTest, SubscribeAndPublish) {
+    int received = 0;
+    bus_.Subscribe<IntEvent>([&](const IntEvent& e) {
+        received = e.value;
+    });
+
+    bus_.Publish(IntEvent{42});
+    EXPECT_EQ(received, 42);
+}
+
+TEST_F(EventBusTest, MultipleHandlersCalledInOrder) {
+    std::vector<int> order;
+
+    bus_.Subscribe<IntEvent>([&](const IntEvent&) { order.push_back(1); });
+    bus_.Subscribe<IntEvent>([&](const IntEvent&) { order.push_back(2); });
+    bus_.Subscribe<IntEvent>([&](const IntEvent&) { order.push_back(3); });
+
+    bus_.Publish(IntEvent{0});
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[0], 1);
+    EXPECT_EQ(order[1], 2);
+    EXPECT_EQ(order[2], 3);
+}
+
+TEST_F(EventBusTest, DifferentEventTypesIndependent) {
+    int intReceived = 0;
+    std::string strReceived;
+
+    bus_.Subscribe<IntEvent>([&](const IntEvent& e) {
+        intReceived = e.value;
+    });
+    bus_.Subscribe<StringEvent>([&](const StringEvent& e) {
+        strReceived = e.message;
+    });
+
+    bus_.Publish(IntEvent{7});
+    EXPECT_EQ(intReceived, 7);
+    EXPECT_TRUE(strReceived.empty());
+
+    bus_.Publish(StringEvent{"hello"});
+    EXPECT_EQ(strReceived, "hello");
+    EXPECT_EQ(intReceived, 7);
+}
+
+TEST_F(EventBusTest, PublishWithNoHandlersIsNoOp) {
+    // Should not crash or throw.
+    bus_.Publish(IntEvent{99});
+}
+
+TEST_F(EventBusTest, HandlerCountTracking) {
+    EXPECT_EQ(bus_.HandlerCount(), 0u);
+    EXPECT_EQ(bus_.HandlerCountFor<IntEvent>(), 0u);
+
+    bus_.Subscribe<IntEvent>([](const IntEvent&) {});
+    bus_.Subscribe<IntEvent>([](const IntEvent&) {});
+    bus_.Subscribe<StringEvent>([](const StringEvent&) {});
+
+    EXPECT_EQ(bus_.HandlerCount(), 3u);
+    EXPECT_EQ(bus_.HandlerCountFor<IntEvent>(), 2u);
+    EXPECT_EQ(bus_.HandlerCountFor<StringEvent>(), 1u);
+}
+
+// ============================================================================
+// Unsubscribe Tests
+// ============================================================================
+
+TEST_F(EventBusTest, UnsubscribeRemovesHandler) {
+    int callCount = 0;
+    auto id = bus_.Subscribe<IntEvent>([&](const IntEvent&) {
+        callCount++;
+    });
+
+    bus_.Publish(IntEvent{1});
+    EXPECT_EQ(callCount, 1);
+
+    bus_.Unsubscribe(id);
+
+    bus_.Publish(IntEvent{2});
+    EXPECT_EQ(callCount, 1); // Not called again.
+    EXPECT_EQ(bus_.HandlerCountFor<IntEvent>(), 0u);
+}
+
+TEST_F(EventBusTest, UnsubscribeInvalidIdIsNoOp) {
+    bus_.Unsubscribe(99999); // Should not crash.
+}
+
+TEST_F(EventBusTest, UnsubscribeOneOfMany) {
+    std::vector<int> calls;
+
+    bus_.Subscribe<IntEvent>([&](const IntEvent&) { calls.push_back(1); });
+    auto id2 = bus_.Subscribe<IntEvent>([&](const IntEvent&) { calls.push_back(2); });
+    bus_.Subscribe<IntEvent>([&](const IntEvent&) { calls.push_back(3); });
+
+    bus_.Unsubscribe(id2);
+
+    bus_.Publish(IntEvent{0});
+    ASSERT_EQ(calls.size(), 2u);
+    EXPECT_EQ(calls[0], 1);
+    EXPECT_EQ(calls[1], 3);
+}
+
+TEST_F(EventBusTest, UnsubscribeAll) {
+    bus_.Subscribe<IntEvent>([](const IntEvent&) {});
+    bus_.Subscribe<StringEvent>([](const StringEvent&) {});
+
+    EXPECT_EQ(bus_.HandlerCount(), 2u);
+
+    bus_.UnsubscribeAll();
+
+    EXPECT_EQ(bus_.HandlerCount(), 0u);
+}
+
+TEST_F(EventBusTest, DoubleUnsubscribeIsNoOp) {
+    auto id = bus_.Subscribe<IntEvent>([](const IntEvent&) {});
+    bus_.Unsubscribe(id);
+    bus_.Unsubscribe(id); // Should not crash.
+    EXPECT_EQ(bus_.HandlerCount(), 0u);
+}
+
+// ============================================================================
+// Priority Tests
+// ============================================================================
+
+TEST_F(EventBusTest, HandlersCalledInPriorityOrder) {
+    std::vector<int> order;
+
+    // Subscribe out of priority order.
+    bus_.Subscribe<PriorityEvent>(
+        [&](const PriorityEvent&) { order.push_back(3); }, 10);
+    bus_.Subscribe<PriorityEvent>(
+        [&](const PriorityEvent&) { order.push_back(1); }, -5);
+    bus_.Subscribe<PriorityEvent>(
+        [&](const PriorityEvent&) { order.push_back(2); }, 0);
+
+    bus_.Publish(PriorityEvent{0});
+
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[0], 1); // priority -5 (highest)
+    EXPECT_EQ(order[1], 2); // priority 0
+    EXPECT_EQ(order[2], 3); // priority 10 (lowest)
+}
+
+TEST_F(EventBusTest, SamePriorityPreservesInsertionOrder) {
+    std::vector<int> order;
+
+    bus_.Subscribe<IntEvent>(
+        [&](const IntEvent&) { order.push_back(1); }, 0);
+    bus_.Subscribe<IntEvent>(
+        [&](const IntEvent&) { order.push_back(2); }, 0);
+    bus_.Subscribe<IntEvent>(
+        [&](const IntEvent&) { order.push_back(3); }, 0);
+
+    bus_.Publish(IntEvent{0});
+
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[0], 1);
+    EXPECT_EQ(order[1], 2);
+    EXPECT_EQ(order[2], 3);
+}
+
+// ============================================================================
+// Deferred Publishing Tests
+// ============================================================================
+
+TEST_F(EventBusTest, DeferredNotCalledImmediately) {
+    int received = 0;
+    bus_.Subscribe<IntEvent>([&](const IntEvent& e) {
+        received = e.value;
+    });
+
+    bus_.PublishDeferred(IntEvent{42});
+    EXPECT_EQ(received, 0); // Not yet dispatched.
+    EXPECT_EQ(bus_.DeferredCount(), 1u);
+}
+
+TEST_F(EventBusTest, ProcessDeferredFlushesQueue) {
+    int received = 0;
+    bus_.Subscribe<IntEvent>([&](const IntEvent& e) {
+        received = e.value;
+    });
+
+    bus_.PublishDeferred(IntEvent{42});
+    bus_.ProcessDeferred();
+
+    EXPECT_EQ(received, 42);
+    EXPECT_EQ(bus_.DeferredCount(), 0u);
+}
+
+TEST_F(EventBusTest, MultipleDeferredProcessedInFIFO) {
+    std::vector<int> order;
+    bus_.Subscribe<IntEvent>([&](const IntEvent& e) {
+        order.push_back(e.value);
+    });
+
+    bus_.PublishDeferred(IntEvent{1});
+    bus_.PublishDeferred(IntEvent{2});
+    bus_.PublishDeferred(IntEvent{3});
+
+    bus_.ProcessDeferred();
+
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[0], 1);
+    EXPECT_EQ(order[1], 2);
+    EXPECT_EQ(order[2], 3);
+}
+
+TEST_F(EventBusTest, ProcessDeferredOnEmptyQueueIsNoOp) {
+    bus_.ProcessDeferred(); // Should not crash.
+    EXPECT_EQ(bus_.DeferredCount(), 0u);
+}
+
+TEST_F(EventBusTest, DeferredEventsFromProcessingNotIncluded) {
+    std::vector<int> order;
+
+    bus_.Subscribe<IntEvent>([&](const IntEvent& e) {
+        order.push_back(e.value);
+        if (e.value == 1) {
+            // Publish another deferred event during processing.
+            bus_.PublishDeferred(IntEvent{99});
+        }
+    });
+
+    bus_.PublishDeferred(IntEvent{1});
+    bus_.ProcessDeferred();
+
+    // Only event 1 should have been processed.
+    ASSERT_EQ(order.size(), 1u);
+    EXPECT_EQ(order[0], 1);
+
+    // Event 99 should be in the next cycle.
+    EXPECT_EQ(bus_.DeferredCount(), 1u);
+
+    bus_.ProcessDeferred();
+    ASSERT_EQ(order.size(), 2u);
+    EXPECT_EQ(order[1], 99);
+}
+
+TEST_F(EventBusTest, MixedSyncAndDeferred) {
+    std::vector<int> order;
+    bus_.Subscribe<IntEvent>([&](const IntEvent& e) {
+        order.push_back(e.value);
+    });
+
+    bus_.Publish(IntEvent{1});        // Immediate.
+    bus_.PublishDeferred(IntEvent{2}); // Deferred.
+    bus_.Publish(IntEvent{3});        // Immediate.
+
+    ASSERT_EQ(order.size(), 2u);
+    EXPECT_EQ(order[0], 1);
+    EXPECT_EQ(order[1], 3);
+
+    bus_.ProcessDeferred();
+
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[2], 2);
+}
+
+// ============================================================================
+// Subscription IDs
+// ============================================================================
+
+TEST_F(EventBusTest, SubscriptionIdsAreUnique) {
+    auto id1 = bus_.Subscribe<IntEvent>([](const IntEvent&) {});
+    auto id2 = bus_.Subscribe<IntEvent>([](const IntEvent&) {});
+    auto id3 = bus_.Subscribe<StringEvent>([](const StringEvent&) {});
+
+    EXPECT_NE(id1, id2);
+    EXPECT_NE(id2, id3);
+    EXPECT_NE(id1, id3);
+}
+
+// ============================================================================
+// Handler subscribes/unsubscribes during Publish (re-entrancy)
+// ============================================================================
+
+TEST_F(EventBusTest, SubscribeDuringPublishDoesNotAffectCurrentDispatch) {
+    std::vector<int> order;
+
+    bus_.Subscribe<IntEvent>([&](const IntEvent&) {
+        order.push_back(1);
+        // Subscribe a new handler during dispatch.
+        bus_.Subscribe<IntEvent>([&](const IntEvent&) {
+            order.push_back(99);
+        });
+    });
+
+    bus_.Publish(IntEvent{0});
+
+    // Only the original handler should have been called.
+    ASSERT_EQ(order.size(), 1u);
+    EXPECT_EQ(order[0], 1);
+
+    // New handler should be called on next publish.
+    order.clear();
+    bus_.Publish(IntEvent{0});
+    EXPECT_EQ(order.size(), 2u);
+}
+
+// ============================================================================
+// Plugin Lifecycle Events via PluginManager
+// ============================================================================
+
+namespace {
+
+/// Test plugin that records lifecycle calls for event testing.
+class EventTestPlugin : public IPlugin {
+public:
+    explicit EventTestPlugin(std::string name = "EventTestPlugin")
+        : info_{std::move(name), "Test plugin for events",
+                {1, 0, 0}, {}, kPluginApiVersion} {}
+
+    const PluginInfo& GetInfo() const override { return info_; }
+
+    bool OnLoad(PluginContext& ctx) override {
+        context_ = &ctx;
+        return true;
+    }
+    bool OnInit() override { return true; }
+    void OnUpdate(float) override {}
+    void OnShutdown() override {}
+    void OnUnload() override {}
+
+    PluginContext* context_ = nullptr;
+
+private:
+    PluginInfo info_;
+};
+
+} // anonymous namespace
+
+class PluginEventTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Save global static registry and inject our test plugin factory.
+        auto& registry = StaticPluginRegistry();
+        savedRegistry_ = std::move(registry);
+        registry.clear();
+        registry.push_back(
+            {"EventTestPlugin",
+             []() -> std::unique_ptr<IPlugin> {
+                 return std::make_unique<EventTestPlugin>();
+             }});
+    }
+
+    void TearDown() override {
+        // Restore the original static registry.
+        StaticPluginRegistry() = std::move(savedRegistry_);
+    }
+
+    PluginManager manager_;
+
+private:
+    std::vector<StaticPluginEntry> savedRegistry_;
+};
+
+TEST_F(PluginEventTest, ContextHasEventBus) {
+    EXPECT_NE(manager_.GetContext().eventBus, nullptr);
+}
+
+TEST_F(PluginEventTest, GetEventBusReturnsSameInstance) {
+    EXPECT_EQ(&manager_.GetEventBus(),
+              manager_.GetContext().eventBus);
+}
+
+TEST_F(PluginEventTest, PluginLoadedEventEmitted) {
+    std::string loadedName;
+    manager_.GetEventBus().Subscribe<PluginLoadedEvent>(
+        [&](const PluginLoadedEvent& e) {
+            loadedName = e.pluginName;
+        });
+
+    (void)manager_.RegisterStaticPlugins();
+
+    EXPECT_EQ(loadedName, "EventTestPlugin");
+}
+
+TEST_F(PluginEventTest, PluginInitializedEventEmitted) {
+    std::string initName;
+    manager_.GetEventBus().Subscribe<PluginInitializedEvent>(
+        [&](const PluginInitializedEvent& e) {
+            initName = e.pluginName;
+        });
+
+    (void)manager_.RegisterStaticPlugins();
+    (void)manager_.InitializeAll();
+
+    EXPECT_FALSE(initName.empty());
+}
+
+TEST_F(PluginEventTest, PluginActivatedEventEmitted) {
+    std::string activatedName;
+    manager_.GetEventBus().Subscribe<PluginActivatedEvent>(
+        [&](const PluginActivatedEvent& e) {
+            activatedName = e.pluginName;
+        });
+
+    (void)manager_.RegisterStaticPlugins();
+    (void)manager_.InitializeAll();
+    (void)manager_.ActivateAll();
+
+    EXPECT_FALSE(activatedName.empty());
+}
+
+TEST_F(PluginEventTest, PluginShutdownEventEmitted) {
+    std::string shutdownName;
+    manager_.GetEventBus().Subscribe<PluginShutdownEvent>(
+        [&](const PluginShutdownEvent& e) {
+            shutdownName = e.pluginName;
+        });
+
+    (void)manager_.RegisterStaticPlugins();
+    (void)manager_.InitializeAll();
+    (void)manager_.ActivateAll();
+    manager_.ShutdownAll();
+
+    EXPECT_FALSE(shutdownName.empty());
+}
+
+TEST_F(PluginEventTest, PluginReceivesEventBusViaContext) {
+    (void)manager_.RegisterStaticPlugins();
+
+    auto names = manager_.GetAllPluginNames();
+    ASSERT_FALSE(names.empty());
+
+    auto* plugin = dynamic_cast<EventTestPlugin*>(
+        manager_.GetPlugin(names[0]));
+    ASSERT_NE(plugin, nullptr);
+    ASSERT_NE(plugin->context_, nullptr);
+    EXPECT_NE(plugin->context_->eventBus, nullptr);
+}
+
+TEST_F(PluginEventTest, LifecycleEventOrdering) {
+    std::vector<std::string> events;
+
+    auto& bus = manager_.GetEventBus();
+    bus.Subscribe<PluginLoadedEvent>(
+        [&](const PluginLoadedEvent&) { events.push_back("loaded"); });
+    bus.Subscribe<PluginInitializedEvent>(
+        [&](const PluginInitializedEvent&) { events.push_back("initialized"); });
+    bus.Subscribe<PluginActivatedEvent>(
+        [&](const PluginActivatedEvent&) { events.push_back("activated"); });
+    bus.Subscribe<PluginShutdownEvent>(
+        [&](const PluginShutdownEvent&) { events.push_back("shutdown"); });
+
+    (void)manager_.RegisterStaticPlugins();
+    (void)manager_.InitializeAll();
+    (void)manager_.ActivateAll();
+    manager_.ShutdownAll();
+
+    ASSERT_GE(events.size(), 4u);
+    EXPECT_EQ(events[0], "loaded");
+    EXPECT_EQ(events[1], "initialized");
+    EXPECT_EQ(events[2], "activated");
+    EXPECT_EQ(events[3], "shutdown");
+}
+
+TEST_F(PluginEventTest, DeferredEventsInUpdateCycle) {
+    auto& bus = manager_.GetEventBus();
+
+    int received = 0;
+    bus.Subscribe<IntEvent>([&](const IntEvent& e) {
+        received = e.value;
+    });
+
+    bus.PublishDeferred(IntEvent{777});
+    EXPECT_EQ(received, 0);
+
+    bus.ProcessDeferred();
+    EXPECT_EQ(received, 777);
+}


### PR DESCRIPTION
## Summary
- Add thread-safe `EventBus` class with type-safe subscribe/publish via `std::any` and `std::type_index`
- Support priority-ordered handlers, deferred event queuing, and snapshot dispatch for re-entrancy safety
- Define 5 lifecycle event types (`PluginLoadedEvent`, `PluginInitializedEvent`, `PluginActivatedEvent`, `PluginShutdownEvent`, `PluginErrorEvent`)
- Integrate `EventBus` into `PluginContext` for plugin-to-plugin communication
- Emit lifecycle events from `PluginManager` during all state transitions (load, init, activate, shutdown)
- Custom move semantics for `EventBus` to handle non-movable `std::mutex` member

## Test Plan
- [x] 20 EventBus core tests (subscribe/publish, unsubscribe, priority, deferred, re-entrancy)
- [x] 9 PluginManager lifecycle event tests (event emission, ordering, context integration)
- [x] Existing plugin tests pass (38 plugin_tests + 44 dependency_tests)
- [x] All 111 tests pass with zero warnings under `-Werror -Wconversion -Wpedantic`

Closes #27