### PR TITLE
feat(plugin): add hot reload support for development builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(CGS_BUILD_TESTS "Build unit and integration tests" ON)
 option(CGS_BUILD_BENCHMARKS "Build performance benchmarks" OFF)
 option(CGS_ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
+option(CGS_HOT_RELOAD "Enable plugin hot reload (development only)" OFF)
 
 # Compiler warning flags
 add_library(cgs_warnings INTERFACE)

--- a/include/cgs/foundation/error_code.hpp
+++ b/include/cgs/foundation/error_code.hpp
@@ -53,6 +53,10 @@ enum class ErrorCode : uint32_t {
     PluginInvalidState = 0x0404,
     PluginVersionMismatch = 0x0405,
     PluginInitFailed = 0x0406,
+    HotReloadFailed = 0x0407,
+    HotReloadDisabled = 0x0408,
+    StateSerializationFailed = 0x0409,
+    StateDeserializationFailed = 0x040A,
 
     // Auth (0x0500 - 0x05FF)
     AuthenticationFailed = 0x0500,

--- a/include/cgs/plugin/file_watcher.hpp
+++ b/include/cgs/plugin/file_watcher.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+/// @file file_watcher.hpp
+/// @brief Polling-based file change detector for plugin hot reload.
+///
+/// Monitors plugin shared library files (.so/.dll/.dylib) for
+/// modifications by comparing filesystem timestamps.
+///
+/// @see SRS-PLG-005.1
+/// @see SDS-MOD-023
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace cgs::plugin {
+
+/// Callback invoked when a watched file is modified.
+/// @param path  The path of the modified file.
+using FileChangeCallback = std::function<void(const std::filesystem::path& path)>;
+
+/// Polling-based file change detector.
+///
+/// Watches shared library files by periodically checking their
+/// last-write timestamps.  Changes within a configurable debounce
+/// window are coalesced into a single callback invocation.
+///
+/// Usage:
+/// @code
+///   FileWatcher watcher;
+///   watcher.SetCallback([](const std::filesystem::path& p) {
+///       std::cout << "Modified: " << p << "\n";
+///   });
+///   watcher.Watch("/path/to/plugin.so");
+///   watcher.Poll();  // Call periodically.
+/// @endcode
+class FileWatcher {
+public:
+    FileWatcher();
+    ~FileWatcher() = default;
+
+    FileWatcher(const FileWatcher&) = delete;
+    FileWatcher& operator=(const FileWatcher&) = delete;
+    FileWatcher(FileWatcher&&) = delete;
+    FileWatcher& operator=(FileWatcher&&) = delete;
+
+    /// Set the callback invoked when a file modification is detected.
+    void SetCallback(FileChangeCallback callback);
+
+    /// Start watching a file for modifications.
+    ///
+    /// Records the current last-write time as baseline.
+    /// @return true if the file exists and watching started.
+    bool Watch(const std::filesystem::path& path);
+
+    /// Stop watching a specific file.
+    void Unwatch(const std::filesystem::path& path);
+
+    /// Stop watching all files and clear state.
+    void UnwatchAll();
+
+    /// Poll all watched files for modifications.
+    ///
+    /// Compares current timestamps against stored baselines.
+    /// If a change is detected and the debounce window has elapsed,
+    /// the callback is invoked.
+    void Poll();
+
+    /// Set the debounce duration in milliseconds.
+    ///
+    /// File changes within this window after the last detected change
+    /// are coalesced into a single callback.
+    void SetDebounceMs(uint32_t ms);
+
+    /// Return the number of watched files.
+    [[nodiscard]] std::size_t WatchCount() const;
+
+    /// Check whether a specific path is being watched.
+    [[nodiscard]] bool IsWatching(const std::filesystem::path& path) const;
+
+private:
+    struct WatchEntry {
+        std::filesystem::file_time_type lastWriteTime;
+        std::chrono::steady_clock::time_point lastChangeDetected;
+        bool pendingCallback = false;
+    };
+
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, WatchEntry> entries_;
+    FileChangeCallback callback_;
+    std::chrono::milliseconds debounceMs_{200};
+};
+
+} // namespace cgs::plugin

--- a/include/cgs/plugin/hot_reload_manager.hpp
+++ b/include/cgs/plugin/hot_reload_manager.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+/// @file hot_reload_manager.hpp
+/// @brief HotReloadManager: orchestrates safe plugin reload during development.
+///
+/// Guarded by CGS_HOT_RELOAD — compiled out entirely in production builds.
+///
+/// @see SRS-PLG-005
+/// @see SDS-MOD-023
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/plugin/file_watcher.hpp"
+#include "cgs/plugin/hot_reloadable.hpp"
+
+namespace cgs::plugin {
+
+class PluginManager;
+
+/// Manages plugin hot reload during development.
+///
+/// Orchestrates the safe reload cycle:
+///   1. Detect file change (via FileWatcher)
+///   2. Capture state (if IHotReloadable)
+///   3. Shutdown → Unload
+///   4. Load → Init → Activate (new binary)
+///   5. Restore state (if version matches)
+///
+/// This entire class is a no-op shell when CGS_HOT_RELOAD is not defined,
+/// ensuring zero overhead in production builds.
+class HotReloadManager {
+public:
+    explicit HotReloadManager(PluginManager& pluginManager);
+    ~HotReloadManager();
+
+    HotReloadManager(const HotReloadManager&) = delete;
+    HotReloadManager& operator=(const HotReloadManager&) = delete;
+    HotReloadManager(HotReloadManager&&) = delete;
+    HotReloadManager& operator=(HotReloadManager&&) = delete;
+
+    /// Whether hot reload is available in this build.
+    [[nodiscard]] static constexpr bool IsAvailable() noexcept {
+#ifdef CGS_HOT_RELOAD
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    /// Start monitoring a plugin shared library for changes.
+    ///
+    /// Associates a plugin name with its library file path so that
+    /// file changes trigger a reload of that specific plugin.
+    ///
+    /// @param pluginName  The registered plugin name.
+    /// @param libraryPath Path to the .so/.dll/.dylib file.
+    /// @return Error if hot reload is disabled or file not found.
+    [[nodiscard]] cgs::foundation::GameResult<void>
+    WatchPlugin(const std::string& pluginName,
+                const std::filesystem::path& libraryPath);
+
+    /// Stop monitoring a plugin.
+    void UnwatchPlugin(const std::string& pluginName);
+
+    /// Poll for file changes and trigger reloads as needed.
+    ///
+    /// Call this periodically (e.g., once per frame in development).
+    void Poll();
+
+    /// Manually trigger a hot reload for a specific plugin.
+    ///
+    /// @param pluginName The plugin to reload.
+    /// @return Error if the plugin is not found, not dynamic, or reload fails.
+    [[nodiscard]] cgs::foundation::GameResult<void>
+    ReloadPlugin(const std::string& pluginName);
+
+    /// Set debounce duration for file change detection.
+    void SetDebounceMs(uint32_t ms);
+
+    /// Return the number of plugins being watched.
+    [[nodiscard]] std::size_t WatchedPluginCount() const;
+
+    /// Return the number of successful reloads performed.
+    [[nodiscard]] uint64_t ReloadCount() const noexcept;
+
+    /// Retrieve the most recent state snapshot for a plugin (if any).
+    [[nodiscard]] const PluginStateSnapshot*
+    GetSnapshot(const std::string& pluginName) const;
+
+private:
+#ifdef CGS_HOT_RELOAD
+    /// Perform the full reload cycle for a single plugin.
+    [[nodiscard]] cgs::foundation::GameResult<void>
+    doReload(const std::string& pluginName,
+             const std::filesystem::path& libraryPath);
+
+    /// Capture state from an IHotReloadable plugin.
+    [[nodiscard]] cgs::foundation::GameResult<PluginStateSnapshot>
+    captureState(const std::string& pluginName);
+
+    /// Restore state to an IHotReloadable plugin.
+    [[nodiscard]] cgs::foundation::GameResult<void>
+    restoreState(const std::string& pluginName,
+                 const PluginStateSnapshot& snapshot);
+
+    PluginManager& pluginManager_;
+    FileWatcher fileWatcher_;
+
+    /// Plugin name → library path mapping.
+    std::unordered_map<std::string, std::filesystem::path> watchedPlugins_;
+
+    /// Plugin name → most recent state snapshot.
+    std::unordered_map<std::string, PluginStateSnapshot> snapshots_;
+
+    uint64_t reloadCount_ = 0;
+#else
+    // Reference kept for API compatibility even when hot reload is disabled.
+    [[maybe_unused]] PluginManager& pluginManager_;
+#endif
+};
+
+} // namespace cgs::plugin

--- a/include/cgs/plugin/hot_reloadable.hpp
+++ b/include/cgs/plugin/hot_reloadable.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+/// @file hot_reloadable.hpp
+/// @brief Optional interface for plugins that support state preservation
+///        across hot reloads.
+///
+/// @see SRS-PLG-005.3
+/// @see SDS-MOD-023
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "cgs/foundation/game_result.hpp"
+#include "cgs/plugin/plugin_types.hpp"
+
+namespace cgs::plugin {
+
+/// Snapshot of a plugin's serialized state for reload preservation.
+struct PluginStateSnapshot {
+    std::string pluginName;
+    Version pluginVersion;
+    uint32_t stateVersion = 0;
+    std::vector<uint8_t> data;
+    std::chrono::steady_clock::time_point capturedAt;
+};
+
+/// Optional interface for plugins that wish to preserve state
+/// across hot reloads.
+///
+/// Plugins may optionally implement this interface to support
+/// state serialization/deserialization during reload cycles.
+/// Plugins that do not implement this interface will simply be
+/// reloaded without state restoration.
+///
+/// Usage:
+/// @code
+///   class MyPlugin : public IPlugin, public IHotReloadable {
+///   public:
+///       GameResult<std::vector<uint8_t>> SerializeState() override {
+///           // Serialize important state to bytes.
+///           return GameResult<std::vector<uint8_t>>::ok({...});
+///       }
+///
+///       GameResult<void> DeserializeState(
+///           const uint8_t* data, std::size_t size) override {
+///           // Restore state from bytes.
+///           return GameResult<void>::ok();
+///       }
+///
+///       uint32_t GetStateVersion() const override { return 1; }
+///   };
+/// @endcode
+class IHotReloadable {
+public:
+    virtual ~IHotReloadable() = default;
+
+    /// Serialize the plugin's current state into a byte buffer.
+    ///
+    /// Called before the plugin is unloaded during a hot reload cycle.
+    [[nodiscard]] virtual cgs::foundation::GameResult<std::vector<uint8_t>>
+    SerializeState() = 0;
+
+    /// Restore the plugin's state from a previously serialized buffer.
+    ///
+    /// Called after the plugin is reloaded and initialized.
+    /// @param data  Pointer to the serialized state bytes.
+    /// @param size  Number of bytes in the buffer.
+    [[nodiscard]] virtual cgs::foundation::GameResult<void>
+    DeserializeState(const uint8_t* data, std::size_t size) = 0;
+
+    /// Return a version number for the serialized state format.
+    ///
+    /// If the version returned by a reloaded plugin differs from
+    /// the stored snapshot, state restoration will be skipped.
+    [[nodiscard]] virtual uint32_t GetStateVersion() const = 0;
+};
+
+} // namespace cgs::plugin

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -1,7 +1,9 @@
-# Plugin System (SDS-MOD-020, SDS-MOD-021, SDS-MOD-018)
+# Plugin System (SDS-MOD-020, SDS-MOD-021, SDS-MOD-018, SDS-MOD-023)
 add_library(cgs_plugin
     plugin_manager.cpp
     version_constraint.cpp
+    file_watcher.cpp
+    hot_reload_manager.cpp
 )
 target_link_libraries(cgs_plugin
     PUBLIC cgs_core
@@ -9,5 +11,12 @@ target_link_libraries(cgs_plugin
 # dlopen/dlclose on Unix; LoadLibrary/FreeLibrary on Windows.
 if(UNIX)
     target_link_libraries(cgs_plugin PRIVATE ${CMAKE_DL_LIBS})
+endif()
+# Hot reload support (development only).
+if(CGS_HOT_RELOAD)
+    target_compile_definitions(cgs_plugin PUBLIC CGS_HOT_RELOAD)
+    message(STATUS "Plugin hot reload: ENABLED (development)")
+else()
+    message(STATUS "Plugin hot reload: DISABLED (production)")
 endif()
 add_library(cgs::plugin ALIAS cgs_plugin)

--- a/src/plugins/file_watcher.cpp
+++ b/src/plugins/file_watcher.cpp
@@ -1,0 +1,100 @@
+/// @file file_watcher.cpp
+/// @brief Polling-based file change detection implementation.
+///
+/// @see SDS-MOD-023
+
+#include "cgs/plugin/file_watcher.hpp"
+
+#include <utility>
+
+namespace fs = std::filesystem;
+
+namespace cgs::plugin {
+
+FileWatcher::FileWatcher() = default;
+
+void FileWatcher::SetCallback(FileChangeCallback callback) {
+    std::lock_guard lock(mutex_);
+    callback_ = std::move(callback);
+}
+
+bool FileWatcher::Watch(const fs::path& path) {
+    std::error_code ec;
+    auto writeTime = fs::last_write_time(path, ec);
+    if (ec) {
+        return false;
+    }
+
+    std::lock_guard lock(mutex_);
+    auto key = path.string();
+    entries_[key] = WatchEntry{
+        writeTime,
+        std::chrono::steady_clock::time_point{},
+        false};
+    return true;
+}
+
+void FileWatcher::Unwatch(const fs::path& path) {
+    std::lock_guard lock(mutex_);
+    entries_.erase(path.string());
+}
+
+void FileWatcher::UnwatchAll() {
+    std::lock_guard lock(mutex_);
+    entries_.clear();
+}
+
+void FileWatcher::Poll() {
+    // Collect changes under the lock, invoke callbacks outside.
+    std::vector<fs::path> changed;
+    auto now = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard lock(mutex_);
+        for (auto& [pathStr, entry] : entries_) {
+            std::error_code ec;
+            auto currentTime = fs::last_write_time(fs::path(pathStr), ec);
+            if (ec) {
+                continue;
+            }
+
+            if (currentTime != entry.lastWriteTime) {
+                entry.lastWriteTime = currentTime;
+                entry.lastChangeDetected = now;
+                entry.pendingCallback = true;
+            }
+
+            if (entry.pendingCallback) {
+                auto elapsed = now - entry.lastChangeDetected;
+                if (elapsed >= debounceMs_) {
+                    entry.pendingCallback = false;
+                    changed.emplace_back(pathStr);
+                }
+            }
+        }
+    }
+
+    // Invoke callbacks outside the lock to prevent deadlock.
+    for (const auto& path : changed) {
+        if (callback_) {
+            callback_(path);
+        }
+    }
+}
+
+void FileWatcher::SetDebounceMs(uint32_t ms) {
+    std::lock_guard lock(mutex_);
+    debounceMs_ = std::chrono::milliseconds(ms);
+}
+
+std::size_t FileWatcher::WatchCount() const {
+    std::lock_guard lock(mutex_);
+    return entries_.size();
+}
+
+bool FileWatcher::IsWatching(const fs::path& path) const {
+    std::lock_guard lock(mutex_);
+    return entries_.count(path.string()) > 0;
+}
+
+} // namespace cgs::plugin

--- a/src/plugins/hot_reload_manager.cpp
+++ b/src/plugins/hot_reload_manager.cpp
@@ -1,0 +1,266 @@
+/// @file hot_reload_manager.cpp
+/// @brief HotReloadManager implementation: safe reload cycle with state preservation.
+///
+/// @see SDS-MOD-023
+
+#include "cgs/plugin/hot_reload_manager.hpp"
+
+#include "cgs/foundation/error_code.hpp"
+#include "cgs/plugin/plugin_events.hpp"
+#include "cgs/plugin/plugin_manager.hpp"
+
+using cgs::foundation::ErrorCode;
+using cgs::foundation::GameError;
+using cgs::foundation::GameResult;
+
+namespace cgs::plugin {
+
+// ── Construction / destruction ──────────────────────────────────────────
+
+HotReloadManager::HotReloadManager(PluginManager& pluginManager)
+    : pluginManager_(pluginManager) {
+#ifdef CGS_HOT_RELOAD
+    fileWatcher_.SetCallback([this](const std::filesystem::path& path) {
+        // Find which plugin corresponds to this file.
+        for (const auto& [name, watchedPath] : watchedPlugins_) {
+            if (std::filesystem::equivalent(path, watchedPath)) {
+                (void)doReload(name, watchedPath);
+                break;
+            }
+        }
+    });
+#endif
+}
+
+HotReloadManager::~HotReloadManager() = default;
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+GameResult<void> HotReloadManager::WatchPlugin(
+    const std::string& pluginName,
+    const std::filesystem::path& libraryPath) {
+#ifdef CGS_HOT_RELOAD
+    if (!std::filesystem::exists(libraryPath)) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PluginLoadFailed,
+                      "Library file not found: " + libraryPath.string()));
+    }
+
+    if (!fileWatcher_.Watch(libraryPath)) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::HotReloadFailed,
+                      "Failed to watch: " + libraryPath.string()));
+    }
+
+    watchedPlugins_[pluginName] = libraryPath;
+    return GameResult<void>::ok();
+#else
+    (void)pluginName;
+    (void)libraryPath;
+    return GameResult<void>::err(
+        GameError(ErrorCode::HotReloadDisabled,
+                  "Hot reload is not available in this build"));
+#endif
+}
+
+void HotReloadManager::UnwatchPlugin(const std::string& pluginName) {
+#ifdef CGS_HOT_RELOAD
+    auto it = watchedPlugins_.find(pluginName);
+    if (it != watchedPlugins_.end()) {
+        fileWatcher_.Unwatch(it->second);
+        watchedPlugins_.erase(it);
+    }
+#else
+    (void)pluginName;
+#endif
+}
+
+void HotReloadManager::Poll() {
+#ifdef CGS_HOT_RELOAD
+    fileWatcher_.Poll();
+#endif
+}
+
+GameResult<void> HotReloadManager::ReloadPlugin(
+    const std::string& pluginName) {
+#ifdef CGS_HOT_RELOAD
+    auto it = watchedPlugins_.find(pluginName);
+    if (it == watchedPlugins_.end()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PluginNotFound,
+                      "Plugin not watched: " + pluginName));
+    }
+    return doReload(pluginName, it->second);
+#else
+    (void)pluginName;
+    return GameResult<void>::err(
+        GameError(ErrorCode::HotReloadDisabled,
+                  "Hot reload is not available in this build"));
+#endif
+}
+
+void HotReloadManager::SetDebounceMs(uint32_t ms) {
+#ifdef CGS_HOT_RELOAD
+    fileWatcher_.SetDebounceMs(ms);
+#else
+    (void)ms;
+#endif
+}
+
+std::size_t HotReloadManager::WatchedPluginCount() const {
+#ifdef CGS_HOT_RELOAD
+    return watchedPlugins_.size();
+#else
+    return 0;
+#endif
+}
+
+uint64_t HotReloadManager::ReloadCount() const noexcept {
+#ifdef CGS_HOT_RELOAD
+    return reloadCount_;
+#else
+    return 0;
+#endif
+}
+
+const PluginStateSnapshot* HotReloadManager::GetSnapshot(
+    const std::string& pluginName) const {
+#ifdef CGS_HOT_RELOAD
+    auto it = snapshots_.find(pluginName);
+    if (it == snapshots_.end()) {
+        return nullptr;
+    }
+    return &it->second;
+#else
+    (void)pluginName;
+    return nullptr;
+#endif
+}
+
+// ── Internal reload implementation ──────────────────────────────────────
+
+#ifdef CGS_HOT_RELOAD
+
+GameResult<void> HotReloadManager::doReload(
+    const std::string& pluginName,
+    const std::filesystem::path& libraryPath) {
+
+    // 1. Capture state (if the plugin supports IHotReloadable).
+    auto stateResult = captureState(pluginName);
+    bool hasState = stateResult.hasValue();
+    if (hasState) {
+        snapshots_.insert_or_assign(pluginName, std::move(stateResult).value());
+    }
+
+    // 2. Shutdown the plugin (Active/Initialized → Loaded).
+    auto stateCheck = pluginManager_.GetPluginState(pluginName);
+    if (stateCheck.hasValue()) {
+        auto state = stateCheck.value();
+        if (state == PluginState::Active ||
+            state == PluginState::Initialized) {
+            auto shutResult = pluginManager_.ShutdownPlugin(pluginName);
+            if (shutResult.hasError()) {
+                return shutResult;
+            }
+        }
+    }
+
+    // 3. Unload the old binary.
+    auto unloadResult = pluginManager_.UnloadPlugin(pluginName);
+    if (unloadResult.hasError()) {
+        return unloadResult;
+    }
+
+    // 4. Load the new binary.
+    auto loadResult = pluginManager_.LoadPlugin(libraryPath);
+    if (loadResult.hasError()) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::HotReloadFailed,
+                      "Failed to reload plugin '" + pluginName +
+                          "': " + loadResult.error().message()));
+    }
+
+    // 5. Initialize the reloaded plugin.
+    auto initResult = pluginManager_.InitPlugin(pluginName);
+    if (initResult.hasError()) {
+        return initResult;
+    }
+
+    // 6. Activate the reloaded plugin.
+    auto activateResult = pluginManager_.ActivatePlugin(pluginName);
+    if (activateResult.hasError()) {
+        return activateResult;
+    }
+
+    // 7. Restore state (if captured and version matches).
+    if (hasState) {
+        auto restoreResult = restoreState(
+            pluginName, snapshots_.at(pluginName));
+        // State restoration failure is non-fatal; the plugin runs fresh.
+        (void)restoreResult;
+    }
+
+    ++reloadCount_;
+    return GameResult<void>::ok();
+}
+
+GameResult<PluginStateSnapshot> HotReloadManager::captureState(
+    const std::string& pluginName) {
+    auto* plugin = pluginManager_.GetPlugin(pluginName);
+    if (plugin == nullptr) {
+        return GameResult<PluginStateSnapshot>::err(
+            GameError(ErrorCode::PluginNotFound,
+                      "Plugin not found: " + pluginName));
+    }
+
+    auto* reloadable = dynamic_cast<IHotReloadable*>(plugin);
+    if (reloadable == nullptr) {
+        return GameResult<PluginStateSnapshot>::err(
+            GameError(ErrorCode::StateSerializationFailed,
+                      "Plugin does not support IHotReloadable: " + pluginName));
+    }
+
+    auto serResult = reloadable->SerializeState();
+    if (serResult.hasError()) {
+        return GameResult<PluginStateSnapshot>::err(serResult.error());
+    }
+
+    PluginStateSnapshot snapshot;
+    snapshot.pluginName = pluginName;
+    snapshot.pluginVersion = plugin->GetInfo().version;
+    snapshot.stateVersion = reloadable->GetStateVersion();
+    snapshot.data = std::move(serResult).value();
+    snapshot.capturedAt = std::chrono::steady_clock::now();
+
+    return GameResult<PluginStateSnapshot>::ok(std::move(snapshot));
+}
+
+GameResult<void> HotReloadManager::restoreState(
+    const std::string& pluginName,
+    const PluginStateSnapshot& snapshot) {
+    auto* plugin = pluginManager_.GetPlugin(pluginName);
+    if (plugin == nullptr) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::PluginNotFound,
+                      "Plugin not found after reload: " + pluginName));
+    }
+
+    auto* reloadable = dynamic_cast<IHotReloadable*>(plugin);
+    if (reloadable == nullptr) {
+        return GameResult<void>::err(
+            GameError(ErrorCode::StateDeserializationFailed,
+                      "Reloaded plugin lost IHotReloadable: " + pluginName));
+    }
+
+    // Version mismatch: skip restoration silently.
+    if (reloadable->GetStateVersion() != snapshot.stateVersion) {
+        return GameResult<void>::ok();
+    }
+
+    return reloadable->DeserializeState(
+        snapshot.data.data(), snapshot.data.size());
+}
+
+#endif // CGS_HOT_RELOAD
+
+} // namespace cgs::plugin

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,6 +163,16 @@ target_link_libraries(cgs_plugin_event_bus_tests PRIVATE
 )
 gtest_discover_tests(cgs_plugin_event_bus_tests)
 
+# Unit tests - Plugin hot reload (file watcher, hot reload manager, state preservation)
+add_executable(cgs_plugin_hot_reload_tests
+    unit/plugin/hot_reload_test.cpp
+)
+target_link_libraries(cgs_plugin_hot_reload_tests PRIVATE
+    cgs::plugin
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_plugin_hot_reload_tests)
+
 # Unit tests - Game object system
 add_executable(cgs_game_object_system_tests
     unit/game/object_system_test.cpp

--- a/tests/unit/plugin/hot_reload_test.cpp
+++ b/tests/unit/plugin/hot_reload_test.cpp
@@ -1,0 +1,390 @@
+/// @file hot_reload_test.cpp
+/// @brief Unit tests for FileWatcher, HotReloadManager, and IHotReloadable.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "cgs/plugin/file_watcher.hpp"
+#include "cgs/plugin/hot_reload_manager.hpp"
+#include "cgs/plugin/hot_reloadable.hpp"
+#include "cgs/plugin/iplugin.hpp"
+#include "cgs/plugin/plugin_manager.hpp"
+
+using namespace cgs::plugin;
+namespace fs = std::filesystem;
+
+// ============================================================================
+// Helper: Create a temporary file for testing
+// ============================================================================
+
+namespace {
+
+class TempFile {
+public:
+    explicit TempFile(const std::string& name) {
+        path_ = fs::temp_directory_path() / ("cgs_test_" + name);
+        std::ofstream ofs(path_);
+        ofs << "test content";
+        ofs.close();
+    }
+
+    ~TempFile() {
+        std::error_code ec;
+        fs::remove(path_, ec);
+    }
+
+    TempFile(const TempFile&) = delete;
+    TempFile& operator=(const TempFile&) = delete;
+
+    [[nodiscard]] const fs::path& Path() const { return path_; }
+
+    void Touch() {
+        // Write new content to update modification time.
+        std::ofstream ofs(path_, std::ios::app);
+        ofs << ".";
+        ofs.close();
+    }
+
+private:
+    fs::path path_;
+};
+
+} // anonymous namespace
+
+// ============================================================================
+// FileWatcher Tests
+// ============================================================================
+
+class FileWatcherTest : public ::testing::Test {
+protected:
+    FileWatcher watcher_;
+};
+
+TEST_F(FileWatcherTest, InitialStateIsEmpty) {
+    EXPECT_EQ(watcher_.WatchCount(), 0u);
+}
+
+TEST_F(FileWatcherTest, WatchExistingFile) {
+    TempFile tmp("watch_test.txt");
+    EXPECT_TRUE(watcher_.Watch(tmp.Path()));
+    EXPECT_EQ(watcher_.WatchCount(), 1u);
+    EXPECT_TRUE(watcher_.IsWatching(tmp.Path()));
+}
+
+TEST_F(FileWatcherTest, WatchNonExistentFileReturnsFalse) {
+    EXPECT_FALSE(watcher_.Watch("/nonexistent/path/to/file.so"));
+    EXPECT_EQ(watcher_.WatchCount(), 0u);
+}
+
+TEST_F(FileWatcherTest, UnwatchRemovesFile) {
+    TempFile tmp("unwatch_test.txt");
+    watcher_.Watch(tmp.Path());
+    EXPECT_EQ(watcher_.WatchCount(), 1u);
+
+    watcher_.Unwatch(tmp.Path());
+    EXPECT_EQ(watcher_.WatchCount(), 0u);
+    EXPECT_FALSE(watcher_.IsWatching(tmp.Path()));
+}
+
+TEST_F(FileWatcherTest, UnwatchAllClearsEverything) {
+    TempFile tmp1("unwatch_all_1.txt");
+    TempFile tmp2("unwatch_all_2.txt");
+    watcher_.Watch(tmp1.Path());
+    watcher_.Watch(tmp2.Path());
+    EXPECT_EQ(watcher_.WatchCount(), 2u);
+
+    watcher_.UnwatchAll();
+    EXPECT_EQ(watcher_.WatchCount(), 0u);
+}
+
+TEST_F(FileWatcherTest, PollWithNoChangesNoCallback) {
+    TempFile tmp("no_change.txt");
+    int callCount = 0;
+    watcher_.SetCallback([&](const fs::path&) { callCount++; });
+    watcher_.Watch(tmp.Path());
+
+    watcher_.Poll();
+    EXPECT_EQ(callCount, 0);
+}
+
+TEST_F(FileWatcherTest, PollDetectsFileModification) {
+    TempFile tmp("detect_change.txt");
+    watcher_.SetDebounceMs(0); // Disable debounce for test.
+
+    fs::path changedPath;
+    watcher_.SetCallback([&](const fs::path& p) { changedPath = p; });
+    watcher_.Watch(tmp.Path());
+
+    // Wait briefly to ensure filesystem timestamp resolution.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    tmp.Touch();
+
+    watcher_.Poll();
+    EXPECT_EQ(changedPath, tmp.Path());
+}
+
+TEST_F(FileWatcherTest, DebounceCoalescesChanges) {
+    TempFile tmp("debounce_test.txt");
+    watcher_.SetDebounceMs(100);
+
+    int callCount = 0;
+    watcher_.SetCallback([&](const fs::path&) { callCount++; });
+    watcher_.Watch(tmp.Path());
+
+    // Modify the file.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    tmp.Touch();
+
+    // Poll immediately — debounce hasn't elapsed yet.
+    watcher_.Poll();
+    EXPECT_EQ(callCount, 0);
+
+    // Wait for debounce to elapse.
+    std::this_thread::sleep_for(std::chrono::milliseconds(120));
+    watcher_.Poll();
+    EXPECT_EQ(callCount, 1);
+}
+
+TEST_F(FileWatcherTest, MultiplePollsAfterChangeCallOnce) {
+    TempFile tmp("multi_poll.txt");
+    watcher_.SetDebounceMs(0);
+
+    int callCount = 0;
+    watcher_.SetCallback([&](const fs::path&) { callCount++; });
+    watcher_.Watch(tmp.Path());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    tmp.Touch();
+
+    watcher_.Poll();
+    EXPECT_EQ(callCount, 1);
+
+    // Second poll without further changes — no callback.
+    watcher_.Poll();
+    EXPECT_EQ(callCount, 1);
+}
+
+TEST_F(FileWatcherTest, WatchMultipleFiles) {
+    TempFile tmp1("multi_1.txt");
+    TempFile tmp2("multi_2.txt");
+    watcher_.SetDebounceMs(0);
+
+    std::vector<std::string> changed;
+    watcher_.SetCallback([&](const fs::path& p) {
+        changed.push_back(p.filename().string());
+    });
+    watcher_.Watch(tmp1.Path());
+    watcher_.Watch(tmp2.Path());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    tmp1.Touch();
+    tmp2.Touch();
+
+    watcher_.Poll();
+    EXPECT_EQ(changed.size(), 2u);
+}
+
+// ============================================================================
+// IHotReloadable Tests
+// ============================================================================
+
+namespace {
+
+/// Test plugin that implements IHotReloadable.
+class ReloadablePlugin : public IPlugin, public IHotReloadable {
+public:
+    explicit ReloadablePlugin(std::string name = "ReloadablePlugin")
+        : info_{std::move(name), "Test reloadable plugin",
+                {1, 0, 0}, {}, kPluginApiVersion} {}
+
+    const PluginInfo& GetInfo() const override { return info_; }
+    bool OnLoad(PluginContext&) override { return true; }
+    bool OnInit() override { return true; }
+    void OnUpdate(float) override {}
+    void OnShutdown() override {}
+    void OnUnload() override {}
+
+    // IHotReloadable
+    cgs::foundation::GameResult<std::vector<uint8_t>>
+    SerializeState() override {
+        std::vector<uint8_t> data(sizeof(counter_));
+        std::memcpy(data.data(), &counter_, sizeof(counter_));
+        return cgs::foundation::GameResult<std::vector<uint8_t>>::ok(
+            std::move(data));
+    }
+
+    cgs::foundation::GameResult<void>
+    DeserializeState(const uint8_t* data, std::size_t size) override {
+        if (size != sizeof(counter_)) {
+            return cgs::foundation::GameResult<void>::err(
+                cgs::foundation::GameError(
+                    cgs::foundation::ErrorCode::StateDeserializationFailed,
+                    "Invalid state size"));
+        }
+        std::memcpy(&counter_, data, sizeof(counter_));
+        return cgs::foundation::GameResult<void>::ok();
+    }
+
+    uint32_t GetStateVersion() const override { return stateVersion_; }
+
+    int counter_ = 0;
+    uint32_t stateVersion_ = 1;
+
+private:
+    PluginInfo info_;
+};
+
+/// Test plugin that does NOT implement IHotReloadable.
+class NonReloadablePlugin : public IPlugin {
+public:
+    const PluginInfo& GetInfo() const override { return info_; }
+    bool OnLoad(PluginContext&) override { return true; }
+    bool OnInit() override { return true; }
+    void OnUpdate(float) override {}
+    void OnShutdown() override {}
+    void OnUnload() override {}
+
+private:
+    PluginInfo info_{"NonReloadable", "Non-reloadable test plugin",
+                     {1, 0, 0}, {}, kPluginApiVersion};
+};
+
+} // anonymous namespace
+
+TEST(HotReloadableTest, SerializeAndDeserializeRoundTrip) {
+    ReloadablePlugin plugin;
+    plugin.counter_ = 42;
+
+    auto serResult = plugin.SerializeState();
+    ASSERT_TRUE(serResult.hasValue());
+    auto data = std::move(serResult).value();
+    EXPECT_EQ(data.size(), sizeof(int));
+
+    ReloadablePlugin plugin2;
+    EXPECT_EQ(plugin2.counter_, 0);
+
+    auto desResult = plugin2.DeserializeState(data.data(), data.size());
+    ASSERT_TRUE(desResult.hasValue());
+    EXPECT_EQ(plugin2.counter_, 42);
+}
+
+TEST(HotReloadableTest, DeserializeInvalidSizeFails) {
+    ReloadablePlugin plugin;
+    std::vector<uint8_t> badData = {0x01};
+
+    auto result = plugin.DeserializeState(badData.data(), badData.size());
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST(HotReloadableTest, DynamicCastDetectsReloadable) {
+    ReloadablePlugin reloadable;
+    NonReloadablePlugin nonReloadable;
+
+    IPlugin* p1 = &reloadable;
+    IPlugin* p2 = &nonReloadable;
+
+    EXPECT_NE(dynamic_cast<IHotReloadable*>(p1), nullptr);
+    EXPECT_EQ(dynamic_cast<IHotReloadable*>(p2), nullptr);
+}
+
+// ============================================================================
+// HotReloadManager Tests
+// ============================================================================
+
+class HotReloadManagerTest : public ::testing::Test {
+protected:
+    PluginManager pluginManager_;
+    HotReloadManager hotReloadManager_{pluginManager_};
+};
+
+TEST_F(HotReloadManagerTest, IsAvailableMatchesBuildFlag) {
+#ifdef CGS_HOT_RELOAD
+    EXPECT_TRUE(HotReloadManager::IsAvailable());
+#else
+    EXPECT_FALSE(HotReloadManager::IsAvailable());
+#endif
+}
+
+TEST_F(HotReloadManagerTest, InitialState) {
+    EXPECT_EQ(hotReloadManager_.WatchedPluginCount(), 0u);
+    EXPECT_EQ(hotReloadManager_.ReloadCount(), 0u);
+    EXPECT_EQ(hotReloadManager_.GetSnapshot("any"), nullptr);
+}
+
+TEST_F(HotReloadManagerTest, WatchPluginBehavior) {
+    TempFile tmp("watch_plugin.so");
+
+    auto result = hotReloadManager_.WatchPlugin("TestPlugin", tmp.Path());
+
+#ifdef CGS_HOT_RELOAD
+    ASSERT_TRUE(result.hasValue()) << result.error().message();
+    EXPECT_EQ(hotReloadManager_.WatchedPluginCount(), 1u);
+#else
+    // When hot reload is disabled, WatchPlugin returns an error.
+    EXPECT_TRUE(result.hasError());
+    EXPECT_EQ(hotReloadManager_.WatchedPluginCount(), 0u);
+#endif
+}
+
+TEST_F(HotReloadManagerTest, WatchPluginNonExistentFileFails) {
+    auto result = hotReloadManager_.WatchPlugin(
+        "TestPlugin", "/nonexistent/plugin.so");
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST_F(HotReloadManagerTest, UnwatchPluginRemovesWatch) {
+    TempFile tmp("unwatch_plugin.so");
+    (void)hotReloadManager_.WatchPlugin("TestPlugin", tmp.Path());
+
+    hotReloadManager_.UnwatchPlugin("TestPlugin");
+    EXPECT_EQ(hotReloadManager_.WatchedPluginCount(), 0u);
+}
+
+TEST_F(HotReloadManagerTest, PollWithNoChangesIsNoOp) {
+    // Should not crash even with no watched plugins.
+    hotReloadManager_.Poll();
+    EXPECT_EQ(hotReloadManager_.ReloadCount(), 0u);
+}
+
+TEST_F(HotReloadManagerTest, ReloadPluginNotWatchedFails) {
+    auto result = hotReloadManager_.ReloadPlugin("NonExistent");
+    EXPECT_TRUE(result.hasError());
+}
+
+TEST_F(HotReloadManagerTest, SetDebounceMsDoesNotCrash) {
+    hotReloadManager_.SetDebounceMs(500);
+    // Just verify it doesn't crash.
+}
+
+// ============================================================================
+// PluginStateSnapshot Tests
+// ============================================================================
+
+TEST(PluginStateSnapshotTest, DefaultConstruction) {
+    PluginStateSnapshot snapshot;
+    EXPECT_TRUE(snapshot.pluginName.empty());
+    EXPECT_EQ(snapshot.stateVersion, 0u);
+    EXPECT_TRUE(snapshot.data.empty());
+}
+
+TEST(PluginStateSnapshotTest, PopulatedSnapshot) {
+    PluginStateSnapshot snapshot;
+    snapshot.pluginName = "TestPlugin";
+    snapshot.pluginVersion = {1, 2, 3};
+    snapshot.stateVersion = 1;
+    snapshot.data = {0xDE, 0xAD, 0xBE, 0xEF};
+    snapshot.capturedAt = std::chrono::steady_clock::now();
+
+    EXPECT_EQ(snapshot.pluginName, "TestPlugin");
+    EXPECT_EQ(snapshot.pluginVersion.major, 1);
+    EXPECT_EQ(snapshot.pluginVersion.minor, 2);
+    EXPECT_EQ(snapshot.pluginVersion.patch, 3);
+    EXPECT_EQ(snapshot.stateVersion, 1u);
+    EXPECT_EQ(snapshot.data.size(), 4u);
+}


### PR DESCRIPTION
## Summary
- Add `FileWatcher` class with polling-based file timestamp monitoring and configurable debounce
- Add `HotReloadManager` orchestrating safe reload cycle: capture state, shutdown, unload, load new binary, init, activate, restore state
- Add `IHotReloadable` opt-in interface for plugins that want state preservation across reloads
- Add `PluginStateSnapshot` for versioned state capture with timestamp tracking
- Add `CGS_HOT_RELOAD` CMake option (OFF by default) — zero runtime overhead in production
- Add 4 new error codes: `HotReloadFailed`, `HotReloadDisabled`, `StateSerializationFailed`, `StateDeserializationFailed`

## Architecture
```
FileWatcher  -->  HotReloadManager  -->  PluginManager
(poll timestamps)  (orchestrate cycle)     (lifecycle calls)
                        |
                   IHotReloadable
                   (opt-in state preservation)
```

## Test Plan
- [x] 10 FileWatcher tests (watch/unwatch, polling, debounce, multiple files)
- [x] 3 IHotReloadable tests (serialize/deserialize round-trip, dynamic_cast detection)
- [x] 8 HotReloadManager tests (disabled-mode behavior, watch/unwatch, poll, reload)
- [x] 2 PluginStateSnapshot tests (default construction, populated snapshot)
- [x] All 134 plugin system tests pass (38 + 44 + 29 + 23)
- [x] Build succeeds with `-Werror -Wconversion -Wpedantic`

Closes #28