### PR TITLE
perf(benchmark): add ECS, world tick, and plugin load benchmarks

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -434,3 +434,40 @@ target_link_libraries(cgs_foundation_network_throughput_tests PRIVATE
 gtest_discover_tests(cgs_foundation_network_throughput_tests
     PROPERTIES LABELS "benchmark"
 )
+
+# Benchmark tests - ECS component storage throughput (SRS-NFR-003)
+add_executable(cgs_ecs_component_storage_benchmark_tests
+    benchmark/ecs/component_storage_benchmark_test.cpp
+)
+target_link_libraries(cgs_ecs_component_storage_benchmark_tests PRIVATE
+    cgs::ecs_entity_manager
+    cgs::game_object_system
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_ecs_component_storage_benchmark_tests
+    PROPERTIES LABELS "benchmark"
+)
+
+# Benchmark tests - ECS system scheduler and world tick (SRS-NFR-002)
+add_executable(cgs_ecs_system_scheduler_benchmark_tests
+    benchmark/ecs/system_scheduler_benchmark_test.cpp
+)
+target_link_libraries(cgs_ecs_system_scheduler_benchmark_tests PRIVATE
+    cgs::plugin_mmorpg
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_ecs_system_scheduler_benchmark_tests
+    PROPERTIES LABELS "benchmark"
+)
+
+# Benchmark tests - plugin load time (SRS-NFR-006)
+add_executable(cgs_plugin_load_benchmark_tests
+    benchmark/plugin/plugin_load_benchmark_test.cpp
+)
+target_link_libraries(cgs_plugin_load_benchmark_tests PRIVATE
+    cgs::plugin_mmorpg
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_plugin_load_benchmark_tests
+    PROPERTIES LABELS "benchmark"
+)

--- a/tests/benchmark/ecs/component_storage_benchmark_test.cpp
+++ b/tests/benchmark/ecs/component_storage_benchmark_test.cpp
@@ -1,0 +1,400 @@
+/// @file component_storage_benchmark_test.cpp
+/// @brief Performance benchmark for ComponentStorage<T> sparse-set operations.
+///
+/// Measures Add, Get, iteration, and Remove throughput for 10K+ entities.
+/// The sparse-set is the foundation of all ECS data access; its performance
+/// directly determines entity update latency (SRS-NFR-003: 10K entities ≤5ms).
+///
+/// Acceptance criterion: 10K entity component iteration ≤5ms.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "cgs/ecs/component_storage.hpp"
+#include "cgs/ecs/entity.hpp"
+#include "cgs/ecs/entity_manager.hpp"
+#include "cgs/game/components.hpp"
+
+using namespace cgs::ecs;
+using namespace cgs::game;
+
+namespace {
+
+// Benchmark parameters
+constexpr int kEntityCount = 10000;
+constexpr int kIterations = 100;
+constexpr double kMaxIterationMs = 5.0; // SRS-NFR-003: ≤5ms for 10K entities
+
+} // anonymous namespace
+
+// ===========================================================================
+// Benchmark Fixture
+// ===========================================================================
+
+class ComponentStorageBenchmark : public ::testing::Test {
+protected:
+    void SetUp() override {
+        entities_.reserve(static_cast<std::size_t>(kEntityCount));
+        for (int i = 0; i < kEntityCount; ++i) {
+            entities_.push_back(manager_.Create());
+        }
+    }
+
+    EntityManager manager_;
+    std::vector<Entity> entities_;
+};
+
+// ===========================================================================
+// Add Throughput
+// ===========================================================================
+
+TEST_F(ComponentStorageBenchmark, AddThroughput) {
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        ComponentStorage<Transform> storage;
+
+        auto start = std::chrono::high_resolution_clock::now();
+
+        for (int i = 0; i < kEntityCount; ++i) {
+            storage.Add(entities_[static_cast<std::size_t>(i)],
+                        Transform{{static_cast<float>(i), 0.0f, 0.0f}, {}, {}});
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double minMs = latencies.front();
+    double maxMs = latencies.back();
+    double medianMs = latencies[latencies.size() / 2];
+    double avgMs =
+        std::accumulate(latencies.begin(), latencies.end(), 0.0) /
+        static_cast<double>(latencies.size());
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+
+    double opsPerSec = static_cast<double>(kEntityCount) / (medianMs / 1000.0);
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  ComponentStorage Add Benchmark                  |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Entities:      " << std::setw(10) << kEntityCount
+              << "                    |\n"
+              << "|  Iterations:    " << std::setw(10) << kIterations
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Min:           " << std::setw(10) << std::fixed
+              << std::setprecision(4) << minMs << " ms               |\n"
+              << "|  Avg:           " << std::setw(10) << avgMs
+              << " ms               |\n"
+              << "|  Median:        " << std::setw(10) << medianMs
+              << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "|  Max:           " << std::setw(10) << maxMs
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Throughput:    " << std::setw(10) << std::setprecision(0)
+              << opsPerSec << " adds/sec           |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_LE(medianMs, kMaxIterationMs)
+        << "Median add time " << medianMs << " ms exceeds " << kMaxIterationMs
+        << " ms for " << kEntityCount << " entities";
+}
+
+// ===========================================================================
+// Iteration Throughput (SRS-NFR-003 Critical Path)
+// ===========================================================================
+
+TEST_F(ComponentStorageBenchmark, IterationThroughput10K) {
+    ComponentStorage<Transform> transforms;
+    ComponentStorage<Movement> movements;
+
+    for (int i = 0; i < kEntityCount; ++i) {
+        auto e = entities_[static_cast<std::size_t>(i)];
+        transforms.Add(e, Transform{{static_cast<float>(i), 0.0f, 0.0f}, {}, {}});
+        Movement mov;
+        mov.speed = 5.0f;
+        mov.baseSpeed = 5.0f;
+        mov.direction = {1.0f, 0.0f, 0.0f};
+        movements.Add(e, std::move(mov));
+    }
+
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        auto start = std::chrono::high_resolution_clock::now();
+
+        // Simulate ObjectUpdateSystem: iterate all transforms and apply movement
+        for (std::size_t i = 0; i < transforms.Size(); ++i) {
+            auto entityId = transforms.EntityAt(i);
+            Entity entity(entityId, 0); // version unused for Has() check via id
+            // Direct dense array access for cache-friendly iteration
+            auto& transform = *(transforms.begin() + static_cast<std::ptrdiff_t>(i));
+            auto& movement = *(movements.begin() + static_cast<std::ptrdiff_t>(i));
+
+            float dt = 0.016f; // 60 FPS delta
+            transform.position.x += movement.direction.x * movement.speed * dt;
+            transform.position.y += movement.direction.y * movement.speed * dt;
+            transform.position.z += movement.direction.z * movement.speed * dt;
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double minMs = latencies.front();
+    double maxMs = latencies.back();
+    double medianMs = latencies[latencies.size() / 2];
+    double avgMs =
+        std::accumulate(latencies.begin(), latencies.end(), 0.0) /
+        static_cast<double>(latencies.size());
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  ComponentStorage Iteration Benchmark            |\n"
+              << "|  (SRS-NFR-003: 10K entity update ≤5ms)          |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Entities:      " << std::setw(10) << kEntityCount
+              << "                    |\n"
+              << "|  Iterations:    " << std::setw(10) << kIterations
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Min:           " << std::setw(10) << std::fixed
+              << std::setprecision(4) << minMs << " ms               |\n"
+              << "|  Avg:           " << std::setw(10) << avgMs
+              << " ms               |\n"
+              << "|  Median:        " << std::setw(10) << medianMs
+              << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "|  Max:           " << std::setw(10) << maxMs
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Requirement:   " << std::setw(10) << std::setprecision(1)
+              << kMaxIterationMs << " ms (SRS-NFR-003)  |\n"
+              << "|  Status:        " << std::setw(10)
+              << (p99Ms <= kMaxIterationMs ? "PASS" : "FAIL")
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_LE(p99Ms, kMaxIterationMs)
+        << "p99 iteration time " << p99Ms << " ms exceeds the "
+        << kMaxIterationMs << " ms requirement (SRS-NFR-003) for "
+        << kEntityCount << " entities";
+}
+
+// ===========================================================================
+// Random Access (Get) Throughput
+// ===========================================================================
+
+TEST_F(ComponentStorageBenchmark, RandomAccessThroughput) {
+    ComponentStorage<Stats> stats;
+
+    for (int i = 0; i < kEntityCount; ++i) {
+        Stats s;
+        s.health = 100;
+        s.maxHealth = 100;
+        s.mana = 50;
+        s.maxMana = 50;
+        stats.Add(entities_[static_cast<std::size_t>(i)], std::move(s));
+    }
+
+    // Create a shuffled access order to test random access pattern
+    std::vector<std::size_t> accessOrder(static_cast<std::size_t>(kEntityCount));
+    std::iota(accessOrder.begin(), accessOrder.end(), 0);
+    // Deterministic shuffle using simple index swapping
+    for (std::size_t i = accessOrder.size() - 1; i > 0; --i) {
+        std::size_t j = (i * 2654435761ULL) % (i + 1);
+        std::swap(accessOrder[i], accessOrder[j]);
+    }
+
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        auto start = std::chrono::high_resolution_clock::now();
+
+        for (int i = 0; i < kEntityCount; ++i) {
+            auto idx = accessOrder[static_cast<std::size_t>(i)];
+            auto& s = stats.Get(entities_[idx]);
+            s.SetHealth(s.health - 1);
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double medianMs = latencies[latencies.size() / 2];
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  ComponentStorage Random Access Benchmark        |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Entities:      " << std::setw(10) << kEntityCount
+              << "                    |\n"
+              << "|  Median:        " << std::setw(10) << std::fixed
+              << std::setprecision(4) << medianMs << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_LE(p99Ms, kMaxIterationMs)
+        << "p99 random access time " << p99Ms << " ms exceeds " << kMaxIterationMs
+        << " ms for " << kEntityCount << " entities";
+}
+
+// ===========================================================================
+// Remove Throughput
+// ===========================================================================
+
+TEST_F(ComponentStorageBenchmark, RemoveThroughput) {
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        ComponentStorage<Transform> storage;
+        for (int i = 0; i < kEntityCount; ++i) {
+            storage.Add(entities_[static_cast<std::size_t>(i)],
+                        Transform{{static_cast<float>(i), 0.0f, 0.0f}, {}, {}});
+        }
+
+        auto start = std::chrono::high_resolution_clock::now();
+
+        // Remove in reverse order (worst case for swap-with-last strategy)
+        for (int i = kEntityCount - 1; i >= 0; --i) {
+            storage.Remove(entities_[static_cast<std::size_t>(i)]);
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double medianMs = latencies[latencies.size() / 2];
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  ComponentStorage Remove Benchmark               |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Entities:      " << std::setw(10) << kEntityCount
+              << "                    |\n"
+              << "|  Median:        " << std::setw(10) << std::fixed
+              << std::setprecision(4) << medianMs << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_LE(p99Ms, kMaxIterationMs)
+        << "p99 remove time " << p99Ms << " ms exceeds " << kMaxIterationMs
+        << " ms for " << kEntityCount << " entities";
+}
+
+// ===========================================================================
+// Entity Create/Destroy Lifecycle Throughput
+// ===========================================================================
+
+TEST_F(ComponentStorageBenchmark, EntityLifecycleThroughput) {
+    ComponentStorage<Transform> transforms;
+    ComponentStorage<Stats> stats;
+    manager_.RegisterStorage(&transforms);
+    manager_.RegisterStorage(&stats);
+
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        std::vector<Entity> created;
+        created.reserve(static_cast<std::size_t>(kEntityCount));
+
+        auto start = std::chrono::high_resolution_clock::now();
+
+        // Create entities with components
+        for (int i = 0; i < kEntityCount; ++i) {
+            auto e = manager_.Create();
+            transforms.Add(e, Transform{{static_cast<float>(i), 0.0f, 0.0f}, {}, {}});
+            Stats s;
+            s.health = 100;
+            s.maxHealth = 100;
+            stats.Add(e, std::move(s));
+            created.push_back(e);
+        }
+
+        // Destroy all (triggers component cleanup)
+        for (auto e : created) {
+            manager_.Destroy(e);
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double medianMs = latencies[latencies.size() / 2];
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+    double opsPerSec =
+        static_cast<double>(kEntityCount * 2) / (medianMs / 1000.0);
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Entity Lifecycle Benchmark                      |\n"
+              << "|  (Create + 2 Components + Destroy)               |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Entities:      " << std::setw(10) << kEntityCount
+              << "                    |\n"
+              << "|  Median:        " << std::setw(10) << std::fixed
+              << std::setprecision(4) << medianMs << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "|  Throughput:    " << std::setw(10) << std::setprecision(0)
+              << opsPerSec << " lifecycle/sec      |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+}

--- a/tests/benchmark/ecs/system_scheduler_benchmark_test.cpp
+++ b/tests/benchmark/ecs/system_scheduler_benchmark_test.cpp
@@ -1,0 +1,327 @@
+/// @file system_scheduler_benchmark_test.cpp
+/// @brief Performance benchmark for SystemScheduler and full world tick.
+///
+/// Measures staged system execution with 6 game systems operating on 10K
+/// entities.  This directly validates the SRS-NFR-002 requirement: world
+/// tick latency ≤50ms (20 Hz server tick rate).
+///
+/// The benchmark uses MMORPGPlugin as the integration point since it owns
+/// all ECS infrastructure and registers all 6 game systems.
+///
+/// Acceptance criteria:
+///   - SRS-NFR-002: Full world tick ≤50ms
+///   - SRS-NFR-003: 10K entity update within a single tick ≤5ms
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "cgs/game/ai_system.hpp"
+#include "cgs/game/combat_system.hpp"
+#include "cgs/game/inventory_system.hpp"
+#include "cgs/game/object_system.hpp"
+#include "cgs/game/quest_system.hpp"
+#include "cgs/game/world_system.hpp"
+#include "cgs/plugin/mmorpg_plugin.hpp"
+
+using namespace cgs::plugin;
+
+namespace {
+
+// Benchmark parameters
+constexpr int kPlayerCount = 1000;
+constexpr int kCreatureCount = 9000;
+constexpr int kTotalEntities = kPlayerCount + kCreatureCount;
+constexpr int kTickIterations = 200;
+constexpr int kWarmupTicks = 20;
+constexpr float kDeltaTime = 0.05f; // 20 Hz tick (50ms budget)
+constexpr double kMaxWorldTickMs = 50.0; // SRS-NFR-002
+
+} // anonymous namespace
+
+// ===========================================================================
+// Benchmark Fixture
+// ===========================================================================
+
+class SystemSchedulerBenchmark : public ::testing::Test {
+protected:
+    void SetUp() override {
+        PluginContext ctx;
+        ASSERT_TRUE(plugin_.OnLoad(ctx));
+        ASSERT_TRUE(plugin_.OnInit());
+
+        // Create a world map
+        mapEntity_ = plugin_.CreateMapInstance(1, cgs::game::MapType::OpenWorld);
+
+        // Spawn players and creatures to reach 10K entities
+        for (int i = 0; i < kPlayerCount; ++i) {
+            cgs::game::Vector3 pos{static_cast<float>(i % 100),
+                                    0.0f,
+                                    static_cast<float>(i / 100)};
+            auto cls = static_cast<CharacterClass>(
+                static_cast<std::size_t>(i) % kCharacterClassCount);
+            (void)plugin_.CreateCharacter(
+                "Player" + std::to_string(i), cls, pos, mapEntity_);
+        }
+
+        for (int i = 0; i < kCreatureCount; ++i) {
+            cgs::game::Vector3 pos{static_cast<float>(i % 200),
+                                    0.0f,
+                                    static_cast<float>(i / 200)};
+            (void)plugin_.SpawnCreature(
+                static_cast<uint32_t>(i + 1),
+                "Creature" + std::to_string(i),
+                pos, mapEntity_);
+        }
+    }
+
+    void TearDown() override {
+        plugin_.OnShutdown();
+        plugin_.OnUnload();
+    }
+
+    MMORPGPlugin plugin_;
+    cgs::ecs::Entity mapEntity_;
+};
+
+// ===========================================================================
+// Full World Tick Latency (SRS-NFR-002)
+// ===========================================================================
+
+TEST_F(SystemSchedulerBenchmark, WorldTickLatency) {
+    // Warmup: let caches, branch predictors, and allocators stabilize
+    for (int i = 0; i < kWarmupTicks; ++i) {
+        plugin_.OnUpdate(kDeltaTime);
+    }
+
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kTickIterations));
+
+    for (int iter = 0; iter < kTickIterations; ++iter) {
+        auto start = std::chrono::high_resolution_clock::now();
+        plugin_.OnUpdate(kDeltaTime);
+        auto end = std::chrono::high_resolution_clock::now();
+
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double minMs = latencies.front();
+    double maxMs = latencies.back();
+    double medianMs = latencies[latencies.size() / 2];
+    double avgMs =
+        std::accumulate(latencies.begin(), latencies.end(), 0.0) /
+        static_cast<double>(latencies.size());
+    double p95Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.95)];
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+
+    double tickRate = 1000.0 / medianMs;
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  World Tick Benchmark (SRS-NFR-002)              |\n"
+              << "|  6 Systems × " << std::setw(5) << kTotalEntities
+              << " Entities                    |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Players:       " << std::setw(10) << kPlayerCount
+              << "                    |\n"
+              << "|  Creatures:     " << std::setw(10) << kCreatureCount
+              << "                    |\n"
+              << "|  Tick Count:    " << std::setw(10) << kTickIterations
+              << "                    |\n"
+              << "|  Delta Time:    " << std::setw(10) << std::fixed
+              << std::setprecision(3) << kDeltaTime << " sec              |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Min Latency:   " << std::setw(10) << std::setprecision(4)
+              << minMs << " ms               |\n"
+              << "|  Avg Latency:   " << std::setw(10) << avgMs
+              << " ms               |\n"
+              << "|  Median:        " << std::setw(10) << medianMs
+              << " ms               |\n"
+              << "|  p95 Latency:   " << std::setw(10) << p95Ms
+              << " ms               |\n"
+              << "|  p99 Latency:   " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "|  Max Latency:   " << std::setw(10) << maxMs
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Tick Rate:     " << std::setw(10) << std::setprecision(1)
+              << tickRate << " Hz                |\n"
+              << "|  Requirement:   " << std::setw(10) << kMaxWorldTickMs
+              << " ms (≥20 Hz)       |\n"
+              << "|  Status:        " << std::setw(10)
+              << (p99Ms <= kMaxWorldTickMs ? "PASS" : "FAIL")
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_LE(p99Ms, kMaxWorldTickMs)
+        << "p99 world tick latency " << p99Ms
+        << " ms exceeds the " << kMaxWorldTickMs
+        << " ms requirement (SRS-NFR-002) with " << kTotalEntities
+        << " entities";
+}
+
+// ===========================================================================
+// Scheduler Build Time
+// ===========================================================================
+
+TEST_F(SystemSchedulerBenchmark, SchedulerBuildTime) {
+    // Measure how long it takes to build the execution plan
+    constexpr int kBuildIterations = 1000;
+
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kBuildIterations));
+
+    for (int iter = 0; iter < kBuildIterations; ++iter) {
+        // Create a fresh scheduler and register systems
+        cgs::ecs::SystemScheduler scheduler;
+        cgs::ecs::ComponentStorage<cgs::game::Transform> transforms;
+        cgs::ecs::ComponentStorage<cgs::game::Movement> movements;
+        cgs::ecs::ComponentStorage<cgs::game::MapMembership> mapMemberships;
+        cgs::ecs::ComponentStorage<cgs::game::MapInstance> mapInstances;
+        cgs::ecs::ComponentStorage<cgs::game::VisibilityRange> visibilityRanges;
+        cgs::ecs::ComponentStorage<cgs::game::Zone> zones;
+        cgs::ecs::ComponentStorage<cgs::game::SpellCast> spellCasts;
+        cgs::ecs::ComponentStorage<cgs::game::AuraHolder> auraHolders;
+        cgs::ecs::ComponentStorage<cgs::game::DamageEvent> damageEvents;
+        cgs::ecs::ComponentStorage<cgs::game::Stats> stats;
+        cgs::ecs::ComponentStorage<cgs::game::ThreatList> threatLists;
+        cgs::ecs::ComponentStorage<cgs::game::AIBrain> aiBrains;
+        cgs::ecs::ComponentStorage<cgs::game::QuestLog> questLogs;
+        cgs::ecs::ComponentStorage<cgs::game::QuestEvent> questEvents;
+        cgs::ecs::ComponentStorage<cgs::game::Inventory> inventories;
+        cgs::ecs::ComponentStorage<cgs::game::Equipment> equipment;
+        cgs::ecs::ComponentStorage<cgs::game::DurabilityEvent> durabilityEvents;
+
+        scheduler.Register<cgs::game::WorldSystem>(
+            transforms, mapMemberships, mapInstances,
+            visibilityRanges, zones);
+        scheduler.Register<cgs::game::ObjectUpdateSystem>(
+            transforms, movements);
+        scheduler.Register<cgs::game::CombatSystem>(
+            spellCasts, auraHolders, damageEvents, stats, threatLists);
+        scheduler.Register<cgs::game::AISystem>(
+            aiBrains, transforms, movements, stats, threatLists);
+        scheduler.Register<cgs::game::QuestSystem>(
+            questLogs, questEvents);
+        scheduler.Register<cgs::game::InventorySystem>(
+            inventories, equipment, durabilityEvents);
+
+        auto start = std::chrono::high_resolution_clock::now();
+        bool ok = scheduler.Build();
+        auto end = std::chrono::high_resolution_clock::now();
+
+        ASSERT_TRUE(ok);
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double medianMs = latencies[latencies.size() / 2];
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+    double avgMs =
+        std::accumulate(latencies.begin(), latencies.end(), 0.0) /
+        static_cast<double>(latencies.size());
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Scheduler Build Benchmark                       |\n"
+              << "|  (6 Systems, Topological Sort)                   |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Iterations:    " << std::setw(10) << kBuildIterations
+              << "                    |\n"
+              << "|  Avg:           " << std::setw(10) << std::fixed
+              << std::setprecision(4) << avgMs << " ms               |\n"
+              << "|  Median:        " << std::setw(10) << medianMs
+              << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+}
+
+// ===========================================================================
+// Sustained Tick Rate Stability
+// ===========================================================================
+
+TEST_F(SystemSchedulerBenchmark, SustainedTickRateStability) {
+    // Run 1000 ticks and check that no tick exceeds the budget
+    constexpr int kSustainedTicks = 1000;
+    constexpr int kSustainedWarmup = 50;
+
+    // Warmup
+    for (int i = 0; i < kSustainedWarmup; ++i) {
+        plugin_.OnUpdate(kDeltaTime);
+    }
+
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kSustainedTicks));
+    int overBudget = 0;
+
+    for (int iter = 0; iter < kSustainedTicks; ++iter) {
+        auto start = std::chrono::high_resolution_clock::now();
+        plugin_.OnUpdate(kDeltaTime);
+        auto end = std::chrono::high_resolution_clock::now();
+
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+
+        if (ms > kMaxWorldTickMs) {
+            ++overBudget;
+        }
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double medianMs = latencies[latencies.size() / 2];
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+    double maxMs = latencies.back();
+    double overBudgetPct =
+        static_cast<double>(overBudget) /
+        static_cast<double>(kSustainedTicks) * 100.0;
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Sustained Tick Rate Stability                   |\n"
+              << "|  (1000 Consecutive Ticks)                        |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Total Ticks:   " << std::setw(10) << kSustainedTicks
+              << "                    |\n"
+              << "|  Median:        " << std::setw(10) << std::fixed
+              << std::setprecision(4) << medianMs << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "|  Max:           " << std::setw(10) << maxMs
+              << " ms               |\n"
+              << "|  Over Budget:   " << std::setw(10) << std::setprecision(1)
+              << overBudgetPct << " %                 |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    // Allow up to 1% of ticks to be over budget (jitter tolerance)
+    EXPECT_LE(overBudgetPct, 1.0)
+        << overBudget << " out of " << kSustainedTicks
+        << " ticks exceeded the " << kMaxWorldTickMs << " ms budget";
+}

--- a/tests/benchmark/plugin/plugin_load_benchmark_test.cpp
+++ b/tests/benchmark/plugin/plugin_load_benchmark_test.cpp
@@ -1,0 +1,261 @@
+/// @file plugin_load_benchmark_test.cpp
+/// @brief Performance benchmark for plugin load and initialization time.
+///
+/// Measures the MMORPG plugin's full startup sequence:
+///   OnLoad  — context binding + component storage registration (18 storages)
+///   OnInit  — system registration (6 systems) + scheduler build
+///
+/// The combined time must meet SRS-NFR-006: plugin load ≤100ms.
+///
+/// Acceptance criterion: OnLoad + OnInit ≤100ms.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "cgs/plugin/mmorpg_plugin.hpp"
+
+using namespace cgs::plugin;
+
+namespace {
+
+// Benchmark parameters
+constexpr int kIterations = 500;
+constexpr int kWarmup = 10;
+constexpr double kMaxLoadTimeMs = 100.0; // SRS-NFR-006
+
+} // anonymous namespace
+
+// ===========================================================================
+// Plugin Load Benchmark
+// ===========================================================================
+
+class PluginLoadBenchmark : public ::testing::Test {};
+
+// ===========================================================================
+// Full Plugin Startup (OnLoad + OnInit)
+// ===========================================================================
+
+TEST_F(PluginLoadBenchmark, FullStartupTime) {
+    // Warmup: prime allocators and caches
+    for (int i = 0; i < kWarmup; ++i) {
+        MMORPGPlugin plugin;
+        PluginContext ctx;
+        (void)plugin.OnLoad(ctx);
+        (void)plugin.OnInit();
+        plugin.OnShutdown();
+        plugin.OnUnload();
+    }
+
+    std::vector<double> totalLatencies;
+    std::vector<double> loadLatencies;
+    std::vector<double> initLatencies;
+    totalLatencies.reserve(static_cast<std::size_t>(kIterations));
+    loadLatencies.reserve(static_cast<std::size_t>(kIterations));
+    initLatencies.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        MMORPGPlugin plugin;
+        PluginContext ctx;
+
+        // Measure OnLoad (context binding + 18 storage registrations)
+        auto loadStart = std::chrono::high_resolution_clock::now();
+        bool loadOk = plugin.OnLoad(ctx);
+        auto loadEnd = std::chrono::high_resolution_clock::now();
+        ASSERT_TRUE(loadOk);
+
+        // Measure OnInit (6 system registrations + scheduler build)
+        auto initStart = std::chrono::high_resolution_clock::now();
+        bool initOk = plugin.OnInit();
+        auto initEnd = std::chrono::high_resolution_clock::now();
+        ASSERT_TRUE(initOk);
+
+        double loadMs =
+            std::chrono::duration<double, std::milli>(loadEnd - loadStart)
+                .count();
+        double initMs =
+            std::chrono::duration<double, std::milli>(initEnd - initStart)
+                .count();
+
+        loadLatencies.push_back(loadMs);
+        initLatencies.push_back(initMs);
+        totalLatencies.push_back(loadMs + initMs);
+
+        plugin.OnShutdown();
+        plugin.OnUnload();
+    }
+
+    std::sort(totalLatencies.begin(), totalLatencies.end());
+    std::sort(loadLatencies.begin(), loadLatencies.end());
+    std::sort(initLatencies.begin(), initLatencies.end());
+
+    double totalMedian = totalLatencies[totalLatencies.size() / 2];
+    double totalP99 =
+        totalLatencies[static_cast<std::size_t>(
+            static_cast<double>(totalLatencies.size()) * 0.99)];
+    double totalAvg =
+        std::accumulate(totalLatencies.begin(), totalLatencies.end(), 0.0) /
+        static_cast<double>(totalLatencies.size());
+
+    double loadMedian = loadLatencies[loadLatencies.size() / 2];
+    double initMedian = initLatencies[initLatencies.size() / 2];
+    double loadP99 =
+        loadLatencies[static_cast<std::size_t>(
+            static_cast<double>(loadLatencies.size()) * 0.99)];
+    double initP99 =
+        initLatencies[static_cast<std::size_t>(
+            static_cast<double>(initLatencies.size()) * 0.99)];
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Plugin Load Benchmark (SRS-NFR-006)             |\n"
+              << "|  MMORPGPlugin Full Startup                       |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Iterations:    " << std::setw(10) << kIterations
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  OnLoad Median: " << std::setw(10) << std::fixed
+              << std::setprecision(4) << loadMedian << " ms               |\n"
+              << "|  OnLoad p99:    " << std::setw(10) << loadP99
+              << " ms               |\n"
+              << "|  OnInit Median: " << std::setw(10) << initMedian
+              << " ms               |\n"
+              << "|  OnInit p99:    " << std::setw(10) << initP99
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Total Avg:     " << std::setw(10) << totalAvg
+              << " ms               |\n"
+              << "|  Total Median:  " << std::setw(10) << totalMedian
+              << " ms               |\n"
+              << "|  Total p99:     " << std::setw(10) << totalP99
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Requirement:   " << std::setw(10) << std::setprecision(1)
+              << kMaxLoadTimeMs << " ms (SRS-NFR-006)  |\n"
+              << "|  Status:        " << std::setw(10)
+              << (totalP99 <= kMaxLoadTimeMs ? "PASS" : "FAIL")
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_LE(totalP99, kMaxLoadTimeMs)
+        << "p99 plugin load time " << totalP99
+        << " ms exceeds the " << kMaxLoadTimeMs
+        << " ms requirement (SRS-NFR-006)";
+}
+
+// ===========================================================================
+// Plugin Construction Overhead
+// ===========================================================================
+
+TEST_F(PluginLoadBenchmark, ConstructionOverhead) {
+    // Measure just the constructor (class template initialization)
+    constexpr int kConstructIterations = 1000;
+
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kConstructIterations));
+
+    for (int iter = 0; iter < kConstructIterations; ++iter) {
+        auto start = std::chrono::high_resolution_clock::now();
+        MMORPGPlugin plugin;
+        auto end = std::chrono::high_resolution_clock::now();
+
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+
+        // Prevent optimizer from eliding the construction
+        EXPECT_EQ(plugin.PlayerCount(), 0u);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double medianMs = latencies[latencies.size() / 2];
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Plugin Construction Benchmark                   |\n"
+              << "|  (Constructor + Class Template Init)             |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Iterations:    " << std::setw(10) << kConstructIterations
+              << "                    |\n"
+              << "|  Median:        " << std::setw(10) << std::fixed
+              << std::setprecision(4) << medianMs << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+}
+
+// ===========================================================================
+// Repeated Load/Unload Cycle (Hot Reload Scenario)
+// ===========================================================================
+
+TEST_F(PluginLoadBenchmark, LoadUnloadCycleStability) {
+    constexpr int kCycles = 100;
+
+    std::vector<double> latencies;
+    latencies.reserve(static_cast<std::size_t>(kCycles));
+
+    for (int cycle = 0; cycle < kCycles; ++cycle) {
+        MMORPGPlugin plugin;
+        PluginContext ctx;
+
+        auto start = std::chrono::high_resolution_clock::now();
+
+        (void)plugin.OnLoad(ctx);
+        (void)plugin.OnInit();
+
+        // Simulate brief usage
+        auto map = plugin.CreateMapInstance(1, cgs::game::MapType::OpenWorld);
+        (void)plugin.CreateCharacter("TestPlayer", CharacterClass::Warrior,
+                                     {0.0f, 0.0f, 0.0f}, map);
+        plugin.OnUpdate(0.016f);
+
+        plugin.OnShutdown();
+        plugin.OnUnload();
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms =
+            std::chrono::duration<double, std::milli>(end - start).count();
+        latencies.push_back(ms);
+    }
+
+    std::sort(latencies.begin(), latencies.end());
+
+    double medianMs = latencies[latencies.size() / 2];
+    double p99Ms =
+        latencies[static_cast<std::size_t>(
+            static_cast<double>(latencies.size()) * 0.99)];
+    double maxMs = latencies.back();
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Load/Unload Cycle Stability                     |\n"
+              << "|  (Full Lifecycle with Brief Usage)               |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Cycles:        " << std::setw(10) << kCycles
+              << "                    |\n"
+              << "|  Median:        " << std::setw(10) << std::fixed
+              << std::setprecision(4) << medianMs << " ms               |\n"
+              << "|  p99:           " << std::setw(10) << p99Ms
+              << " ms               |\n"
+              << "|  Max:           " << std::setw(10) << maxMs
+              << " ms               |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_LE(p99Ms, kMaxLoadTimeMs)
+        << "p99 load/unload cycle " << p99Ms
+        << " ms exceeds the " << kMaxLoadTimeMs << " ms requirement";
+}


### PR DESCRIPTION
## Summary

Closes #75. Part of #30.

Implements performance benchmarks validating three SRS non-functional requirements:

- **SRS-NFR-002** (World Tick ≤50ms): Full 6-system world tick with 10K entities — p99 = 0.15ms
- **SRS-NFR-003** (10K Entity Update ≤5ms): Sparse-set component iteration — p99 = 0.014ms
- **SRS-NFR-006** (Plugin Load ≤100ms): MMORPG plugin OnLoad+OnInit — p99 = 0.005ms

### Benchmark Results (Apple Silicon, Release build)

| SRS Requirement | Target | Measured (p99) | Status |
|-----------------|--------|----------------|--------|
| NFR-002 World Tick | ≤50ms | 0.154ms | PASS |
| NFR-003 10K Entity | ≤5ms | 0.014ms | PASS |
| NFR-006 Plugin Load | ≤100ms | 0.005ms | PASS |

### New Files

- `tests/benchmark/ecs/component_storage_benchmark_test.cpp` — Add/Get/Remove/Iterate throughput (5 tests)
- `tests/benchmark/ecs/system_scheduler_benchmark_test.cpp` — World tick, scheduler build, sustained stability (3 tests)
- `tests/benchmark/plugin/plugin_load_benchmark_test.cpp` — Startup time, construction, load/unload cycles (3 tests)
- `tests/CMakeLists.txt` — 3 new benchmark targets with "benchmark" label

### Architecture

All benchmarks follow the established project pattern: GTest fixture + `std::chrono::high_resolution_clock` timing + formatted results table + `EXPECT` assertions for SRS compliance.

## Test Plan

- [x] All 11 new benchmark tests pass
- [x] All 1,077 existing tests pass (12 `NOT_BUILT` are pre-existing service tests)
- [x] Release build with `-O3` used for accurate performance measurement
- [x] Warmup phases included to stabilize CPU caches before measurement