### PR TITLE
perf(benchmark): add memory profiling and message throughput benchmarks

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -471,3 +471,28 @@ target_link_libraries(cgs_plugin_load_benchmark_tests PRIVATE
 gtest_discover_tests(cgs_plugin_load_benchmark_tests
     PROPERTIES LABELS "benchmark"
 )
+
+# Benchmark tests - ECS memory profiling (SRS-NFR-005)
+add_executable(cgs_ecs_memory_profiling_benchmark_tests
+    benchmark/ecs/memory_profiling_benchmark_test.cpp
+)
+target_link_libraries(cgs_ecs_memory_profiling_benchmark_tests PRIVATE
+    cgs::plugin_mmorpg
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_ecs_memory_profiling_benchmark_tests
+    PROPERTIES LABELS "benchmark"
+)
+
+# Benchmark tests - message serialization throughput (SRS-NFR-001)
+add_executable(cgs_message_serialization_benchmark_tests
+    benchmark/foundation/message_serialization_benchmark_test.cpp
+)
+target_link_libraries(cgs_message_serialization_benchmark_tests PRIVATE
+    cgs::foundation_network
+    cgs::foundation_container
+    GTest::gtest_main
+)
+gtest_discover_tests(cgs_message_serialization_benchmark_tests
+    PROPERTIES LABELS "benchmark"
+)

--- a/tests/benchmark/ecs/memory_profiling_benchmark_test.cpp
+++ b/tests/benchmark/ecs/memory_profiling_benchmark_test.cpp
@@ -1,0 +1,395 @@
+/// @file memory_profiling_benchmark_test.cpp
+/// @brief Memory profiling benchmark for concurrent player entities.
+///
+/// Measures memory usage per 1K concurrent player entities with all MMORPG
+/// components attached.  Reports per-component breakdown and total memory.
+///
+/// SRS-NFR-005: Memory per 1K concurrent players ≤100MB.
+///
+/// Memory measurement approach:
+///   - Theoretical: sizeof(T) × entity count for each component type
+///   - Practical: Platform-specific RSS measurement (macOS mach_task_info)
+///   - Both methods are reported for comprehensive analysis.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#endif
+
+#include "cgs/plugin/mmorpg_plugin.hpp"
+
+using namespace cgs::plugin;
+using namespace cgs::game;
+
+namespace {
+
+// Benchmark parameters
+constexpr int kPlayerCount = 1000;
+constexpr double kMaxMemoryMB = 100.0; // SRS-NFR-005
+
+/// Get current process resident set size (RSS) in bytes.
+/// Returns 0 if not available on the platform.
+std::size_t getCurrentRSS() {
+#ifdef __APPLE__
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    kern_return_t kr = task_info(
+        mach_task_self(), MACH_TASK_BASIC_INFO,
+        reinterpret_cast<task_info_t>(&info), &count);
+    if (kr == KERN_SUCCESS) {
+        return info.resident_size;
+    }
+#endif
+    return 0;
+}
+
+/// Helper to format bytes as human-readable string.
+std::string formatBytes(std::size_t bytes) {
+    if (bytes >= 1024ULL * 1024ULL) {
+        double mb = static_cast<double>(bytes) / (1024.0 * 1024.0);
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(2) << mb << " MB";
+        return oss.str();
+    }
+    if (bytes >= 1024ULL) {
+        double kb = static_cast<double>(bytes) / 1024.0;
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(2) << kb << " KB";
+        return oss.str();
+    }
+    return std::to_string(bytes) + " B";
+}
+
+} // anonymous namespace
+
+// ===========================================================================
+// Memory Profiling Fixture
+// ===========================================================================
+
+class MemoryProfilingBenchmark : public ::testing::Test {};
+
+// ===========================================================================
+// Per-Component Memory Breakdown
+// ===========================================================================
+
+TEST_F(MemoryProfilingBenchmark, ComponentMemoryBreakdown) {
+    // Calculate theoretical memory per component type
+    struct ComponentInfo {
+        const char* name;
+        std::size_t sizePerEntity;
+        int count;
+        std::size_t total() const {
+            return sizePerEntity * static_cast<std::size_t>(count);
+        }
+    };
+
+    // Player entities have these components:
+    // Identity, Transform, Stats, Movement, SpellCast, AuraHolder,
+    // ThreatList, MapMembership, VisibilityRange, QuestLog,
+    // Inventory, Equipment
+    std::vector<ComponentInfo> playerComponents = {
+        {"Transform",       sizeof(Transform),       kPlayerCount},
+        {"Identity",        sizeof(Identity),        kPlayerCount},
+        {"Stats",           sizeof(Stats),           kPlayerCount},
+        {"Movement",        sizeof(Movement),        kPlayerCount},
+        {"SpellCast",       sizeof(SpellCast),       kPlayerCount},
+        {"AuraHolder",      sizeof(AuraHolder),      kPlayerCount},
+        {"ThreatList",      sizeof(ThreatList),      kPlayerCount},
+        {"MapMembership",   sizeof(MapMembership),   kPlayerCount},
+        {"VisibilityRange", sizeof(VisibilityRange), kPlayerCount},
+        {"QuestLog",        sizeof(QuestLog),        kPlayerCount},
+        {"Inventory",       sizeof(Inventory),       kPlayerCount},
+        {"Equipment",       sizeof(Equipment),       kPlayerCount},
+    };
+
+    // Sparse-set overhead: sparse array (uint32_t per potential entity slot)
+    // + entities array (uint32_t per stored entity)
+    // + versions array (uint32_t per stored entity)
+    std::size_t sparseOverheadPerStorage =
+        static_cast<std::size_t>(kPlayerCount) * sizeof(uint32_t) * 3;
+    std::size_t totalSparseOverhead =
+        sparseOverheadPerStorage * playerComponents.size();
+
+    std::size_t totalComponentMemory = 0;
+    for (const auto& c : playerComponents) {
+        totalComponentMemory += c.total();
+    }
+
+    // CharacterData per player (stored in unordered_map)
+    std::size_t characterDataSize = sizeof(CharacterData);
+    std::size_t totalCharacterData =
+        characterDataSize * static_cast<std::size_t>(kPlayerCount);
+
+    // Entity manager overhead (versions_, alive_, freeList_)
+    std::size_t entityManagerOverhead =
+        static_cast<std::size_t>(kPlayerCount) *
+        (sizeof(uint8_t) + sizeof(bool));
+
+    std::size_t totalTheoretical =
+        totalComponentMemory + totalSparseOverhead +
+        totalCharacterData + entityManagerOverhead;
+    double totalMB =
+        static_cast<double>(totalTheoretical) / (1024.0 * 1024.0);
+
+    // Report per-component breakdown
+    std::cout << "\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Memory Profiling: Per-Component Breakdown         |\n"
+              << "|  (SRS-NFR-005: ≤100MB per 1K players)             |\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Players:        " << std::setw(10) << kPlayerCount
+              << "                      |\n"
+              << "+---------------------------------------------------+\n";
+
+    for (const auto& c : playerComponents) {
+        std::cout << "|  " << std::left << std::setw(16) << c.name
+                  << std::right
+                  << "  sizeof=" << std::setw(5) << c.sizePerEntity
+                  << "  total=" << std::setw(10)
+                  << formatBytes(c.total()) << "  |\n";
+    }
+
+    std::cout << "+---------------------------------------------------+\n"
+              << "|  Component Data:  " << std::setw(10)
+              << formatBytes(totalComponentMemory)
+              << "                      |\n"
+              << "|  Sparse Overhead: " << std::setw(10)
+              << formatBytes(totalSparseOverhead)
+              << "                      |\n"
+              << "|  CharacterData:   " << std::setw(10)
+              << formatBytes(totalCharacterData)
+              << "                      |\n"
+              << "|  EntityManager:   " << std::setw(10)
+              << formatBytes(entityManagerOverhead)
+              << "                      |\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Total (theory):  " << std::setw(10)
+              << formatBytes(totalTheoretical)
+              << "                      |\n"
+              << "|  Requirement:     " << std::setw(10) << std::fixed
+              << std::setprecision(1) << kMaxMemoryMB
+              << " MB" << "                    |\n"
+              << "|  Status:          " << std::setw(10)
+              << (totalMB <= kMaxMemoryMB ? "PASS" : "FAIL")
+              << "                      |\n"
+              << "+---------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_LE(totalMB, kMaxMemoryMB)
+        << "Theoretical memory " << totalMB
+        << " MB exceeds " << kMaxMemoryMB
+        << " MB requirement (SRS-NFR-005)";
+}
+
+// ===========================================================================
+// Practical RSS Measurement with 1K Players
+// ===========================================================================
+
+TEST_F(MemoryProfilingBenchmark, PracticalRSSMeasurement) {
+    // Measure RSS before and after creating 1K player entities
+    std::size_t rssBefore = getCurrentRSS();
+
+    MMORPGPlugin plugin;
+    PluginContext ctx;
+    ASSERT_TRUE(plugin.OnLoad(ctx));
+    ASSERT_TRUE(plugin.OnInit());
+
+    auto map = plugin.CreateMapInstance(1, MapType::OpenWorld);
+
+    for (int i = 0; i < kPlayerCount; ++i) {
+        Vector3 pos{static_cast<float>(i % 100),
+                    0.0f,
+                    static_cast<float>(i / 100)};
+        auto cls = static_cast<CharacterClass>(
+            static_cast<std::size_t>(i) % kCharacterClassCount);
+        (void)plugin.CreateCharacter(
+            "Player" + std::to_string(i), cls, pos, map);
+    }
+
+    EXPECT_EQ(plugin.PlayerCount(), static_cast<std::size_t>(kPlayerCount));
+
+    std::size_t rssAfter = getCurrentRSS();
+
+    // RSS delta (approximate — other allocations may occur)
+    std::size_t rssDelta = 0;
+    if (rssAfter > rssBefore) {
+        rssDelta = rssAfter - rssBefore;
+    }
+    double rssDeltaMB =
+        static_cast<double>(rssDelta) / (1024.0 * 1024.0);
+
+    std::cout << "\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Memory Profiling: RSS Measurement                 |\n"
+              << "|  (SRS-NFR-005: ≤100MB per 1K players)             |\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Players:        " << std::setw(10) << kPlayerCount
+              << "                      |\n"
+              << "|  RSS Before:     " << std::setw(10)
+              << formatBytes(rssBefore) << "                      |\n"
+              << "|  RSS After:      " << std::setw(10)
+              << formatBytes(rssAfter) << "                      |\n"
+              << "|  RSS Delta:      " << std::setw(10)
+              << formatBytes(rssDelta) << "                      |\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Requirement:    " << std::setw(10) << std::fixed
+              << std::setprecision(1) << kMaxMemoryMB
+              << " MB" << "                    |\n"
+              << "|  Status:         " << std::setw(10)
+              << (rssDeltaMB <= kMaxMemoryMB ? "PASS" : "FAIL")
+              << "                      |\n"
+              << "+---------------------------------------------------+\n"
+              << std::endl;
+
+    // RSS delta should be well within the 100MB budget
+    if (rssDelta > 0) {
+        EXPECT_LE(rssDeltaMB, kMaxMemoryMB)
+            << "RSS delta " << rssDeltaMB
+            << " MB exceeds " << kMaxMemoryMB
+            << " MB requirement (SRS-NFR-005)";
+    }
+
+    plugin.OnShutdown();
+    plugin.OnUnload();
+}
+
+// ===========================================================================
+// Memory Scaling Test (100, 500, 1000 players)
+// ===========================================================================
+
+TEST_F(MemoryProfilingBenchmark, MemoryScalingLinear) {
+    struct ScalePoint {
+        int playerCount;
+        std::size_t rssBefore;
+        std::size_t rssAfter;
+        std::size_t delta;
+    };
+
+    std::vector<int> scaleLevels = {100, 500, 1000};
+    std::vector<ScalePoint> points;
+
+    for (int count : scaleLevels) {
+        std::size_t before = getCurrentRSS();
+
+        {
+            MMORPGPlugin plugin;
+            PluginContext ctx;
+            ASSERT_TRUE(plugin.OnLoad(ctx));
+            ASSERT_TRUE(plugin.OnInit());
+
+            auto map = plugin.CreateMapInstance(1, MapType::OpenWorld);
+            for (int i = 0; i < count; ++i) {
+                Vector3 pos{static_cast<float>(i % 100), 0.0f,
+                            static_cast<float>(i / 100)};
+                auto cls = static_cast<CharacterClass>(
+                    static_cast<std::size_t>(i) % kCharacterClassCount);
+                (void)plugin.CreateCharacter(
+                    "P" + std::to_string(i), cls, pos, map);
+            }
+
+            std::size_t after = getCurrentRSS();
+            std::size_t delta = (after > before) ? (after - before) : 0;
+            points.push_back({count, before, after, delta});
+
+            plugin.OnShutdown();
+            plugin.OnUnload();
+        }
+    }
+
+    std::cout << "\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Memory Scaling Analysis                           |\n"
+              << "+---------------------------------------------------+\n";
+
+    for (const auto& p : points) {
+        double perPlayerKB =
+            (p.delta > 0 && p.playerCount > 0)
+            ? static_cast<double>(p.delta) /
+              (static_cast<double>(p.playerCount) * 1024.0)
+            : 0.0;
+        std::cout << "|  " << std::setw(5) << p.playerCount
+                  << " players: delta=" << std::setw(10)
+                  << formatBytes(p.delta)
+                  << "  per-player=" << std::setw(8) << std::fixed
+                  << std::setprecision(2) << perPlayerKB << " KB |\n";
+    }
+
+    // Extrapolate 1K player memory from measured data
+    if (!points.empty() && points.back().delta > 0) {
+        double extrapolatedMB =
+            static_cast<double>(points.back().delta) / (1024.0 * 1024.0);
+        std::cout << "+---------------------------------------------------+\n"
+                  << "|  1K Extrapolated: " << std::setw(10) << std::fixed
+                  << std::setprecision(2) << extrapolatedMB
+                  << " MB" << "                    |\n";
+    }
+
+    std::cout << "|  Requirement:     " << std::setw(10) << std::fixed
+              << std::setprecision(1) << kMaxMemoryMB
+              << " MB" << "                    |\n"
+              << "+---------------------------------------------------+\n"
+              << std::endl;
+}
+
+// ===========================================================================
+// Entity Destruction Memory Reclamation
+// ===========================================================================
+
+TEST_F(MemoryProfilingBenchmark, DestructionMemoryReclamation) {
+    MMORPGPlugin plugin;
+    PluginContext ctx;
+    ASSERT_TRUE(plugin.OnLoad(ctx));
+    ASSERT_TRUE(plugin.OnInit());
+
+    auto map = plugin.CreateMapInstance(1, MapType::OpenWorld);
+
+    // Create 1K players
+    std::vector<cgs::ecs::Entity> entities;
+    entities.reserve(static_cast<std::size_t>(kPlayerCount));
+
+    for (int i = 0; i < kPlayerCount; ++i) {
+        Vector3 pos{static_cast<float>(i), 0.0f, 0.0f};
+        auto cls = static_cast<CharacterClass>(
+            static_cast<std::size_t>(i) % kCharacterClassCount);
+        entities.push_back(plugin.CreateCharacter(
+            "P" + std::to_string(i), cls, pos, map));
+    }
+
+    EXPECT_EQ(plugin.PlayerCount(), static_cast<std::size_t>(kPlayerCount));
+    std::size_t rssWithPlayers = getCurrentRSS();
+
+    // Destroy all players
+    for (auto e : entities) {
+        plugin.RemoveCharacter(e);
+    }
+
+    EXPECT_EQ(plugin.PlayerCount(), 0u);
+    std::size_t rssAfterDestroy = getCurrentRSS();
+
+    // Verify entity manager reclaimed the slots
+    EXPECT_EQ(plugin.GetEntityManager().Count(), 1u); // Only map entity left
+
+    std::cout << "\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Memory Reclamation After Entity Destruction       |\n"
+              << "+---------------------------------------------------+\n"
+              << "|  RSS With Players:   " << std::setw(12)
+              << formatBytes(rssWithPlayers) << "                |\n"
+              << "|  RSS After Destroy:  " << std::setw(12)
+              << formatBytes(rssAfterDestroy) << "                |\n"
+              << "+---------------------------------------------------+\n"
+              << std::endl;
+
+    plugin.OnShutdown();
+    plugin.OnUnload();
+}

--- a/tests/benchmark/foundation/message_serialization_benchmark_test.cpp
+++ b/tests/benchmark/foundation/message_serialization_benchmark_test.cpp
@@ -1,0 +1,321 @@
+/// @file message_serialization_benchmark_test.cpp
+/// @brief Message serialization throughput benchmark (SRS-NFR-001).
+///
+/// Measures NetworkMessage serialize/deserialize throughput with realistic
+/// game payloads of various sizes.  This complements the existing
+/// network_throughput_test.cpp which measures TCP dispatch throughput.
+///
+/// SRS-NFR-001: Message throughput ≥300,000 msg/sec.
+///
+/// Focus areas:
+///   - Serialization-only throughput (encoding)
+///   - Deserialization-only throughput (decoding + validation)
+///   - Round-trip throughput (serialize → deserialize)
+///   - Payload size impact on throughput
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "cgs/foundation/game_network_manager.hpp"
+#include "cgs/foundation/game_serializer.hpp"
+
+using namespace cgs::foundation;
+
+namespace {
+
+// Benchmark parameters
+constexpr int kMessageCount = 100000;
+constexpr int kIterations = 10;
+constexpr double kMinThroughput = 300000.0; // SRS-NFR-001: ≥300K msg/sec
+
+/// Create a realistic game message with the given payload size.
+NetworkMessage makeGameMessage(uint16_t opcode, std::size_t payloadSize) {
+    NetworkMessage msg;
+    msg.opcode = opcode;
+    msg.payload.resize(payloadSize);
+
+    // Fill with pseudo-realistic game data pattern
+    for (std::size_t i = 0; i < payloadSize; ++i) {
+        msg.payload[i] = static_cast<uint8_t>(
+            (i * 37 + opcode) & 0xFF);
+    }
+    return msg;
+}
+
+/// Payload sizes representing typical game messages
+struct PayloadProfile {
+    const char* name;
+    uint16_t opcode;
+    std::size_t size;
+};
+
+const PayloadProfile kProfiles[] = {
+    {"Heartbeat",       0x01,   4},   // 4 bytes: timestamp
+    {"Movement",        0x10,  32},   // position(12) + rotation(16) + flags(4)
+    {"Chat",            0x20, 128},   // channel(4) + sender(32) + message(92)
+    {"SpellCast",       0x30,  24},   // spell_id(4) + target(4) + position(12) + flags(4)
+    {"InventoryUpdate", 0x40, 256},   // slot updates, item data
+    {"WorldState",      0x50, 512},   // snapshot of nearby entities
+};
+constexpr int kProfileCount =
+    static_cast<int>(sizeof(kProfiles) / sizeof(kProfiles[0]));
+
+} // anonymous namespace
+
+// ===========================================================================
+// Benchmark Fixture
+// ===========================================================================
+
+class MessageSerializationBenchmark : public ::testing::Test {};
+
+// ===========================================================================
+// Serialization Throughput (64-byte messages)
+// ===========================================================================
+
+TEST_F(MessageSerializationBenchmark, SerializeThroughput) {
+    auto msg = makeGameMessage(0x10, 58); // 6 header + 58 payload = 64 bytes
+
+    // Warmup
+    for (int i = 0; i < 1000; ++i) {
+        auto wire = msg.serialize();
+        (void)wire.size();
+    }
+
+    std::vector<double> throughputs;
+    throughputs.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        auto start = std::chrono::high_resolution_clock::now();
+
+        for (int i = 0; i < kMessageCount; ++i) {
+            auto wire = msg.serialize();
+            (void)wire.size(); // prevent dead-code elimination
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double seconds =
+            std::chrono::duration<double>(end - start).count();
+        double tp = static_cast<double>(kMessageCount) / seconds;
+        throughputs.push_back(tp);
+    }
+
+    std::sort(throughputs.begin(), throughputs.end());
+    double medianTp = throughputs[throughputs.size() / 2];
+    double minTp = throughputs.front();
+    double maxTp = throughputs.back();
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Serialization Throughput (64-byte msg)          |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Messages:      " << std::setw(10) << kMessageCount
+              << "                    |\n"
+              << "|  Iterations:    " << std::setw(10) << kIterations
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Min:           " << std::setw(10) << std::fixed
+              << std::setprecision(0) << minTp << " msg/sec          |\n"
+              << "|  Median:        " << std::setw(10) << medianTp
+              << " msg/sec          |\n"
+              << "|  Max:           " << std::setw(10) << maxTp
+              << " msg/sec          |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Requirement:   " << std::setw(10) << kMinThroughput
+              << " msg/sec          |\n"
+              << "|  Status:        " << std::setw(10)
+              << (medianTp >= kMinThroughput ? "PASS" : "FAIL")
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_GE(medianTp, kMinThroughput)
+        << "Serialization throughput " << medianTp
+        << " msg/sec below " << kMinThroughput << " msg/sec (SRS-NFR-001)";
+}
+
+// ===========================================================================
+// Deserialization Throughput
+// ===========================================================================
+
+TEST_F(MessageSerializationBenchmark, DeserializeThroughput) {
+    auto msg = makeGameMessage(0x10, 58);
+    auto wireData = msg.serialize();
+
+    // Warmup
+    for (int i = 0; i < 1000; ++i) {
+        auto result = NetworkMessage::deserialize(wireData);
+        ASSERT_TRUE(result.has_value());
+    }
+
+    std::vector<double> throughputs;
+    throughputs.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        auto start = std::chrono::high_resolution_clock::now();
+
+        for (int i = 0; i < kMessageCount; ++i) {
+            auto result = NetworkMessage::deserialize(wireData);
+            (void)result; // prevent dead-code elimination
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double seconds =
+            std::chrono::duration<double>(end - start).count();
+        double tp = static_cast<double>(kMessageCount) / seconds;
+        throughputs.push_back(tp);
+    }
+
+    std::sort(throughputs.begin(), throughputs.end());
+    double medianTp = throughputs[throughputs.size() / 2];
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Deserialization Throughput (64-byte msg)        |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Median:        " << std::setw(10) << std::fixed
+              << std::setprecision(0) << medianTp << " msg/sec          |\n"
+              << "|  Requirement:   " << std::setw(10) << kMinThroughput
+              << " msg/sec          |\n"
+              << "|  Status:        " << std::setw(10)
+              << (medianTp >= kMinThroughput ? "PASS" : "FAIL")
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_GE(medianTp, kMinThroughput)
+        << "Deserialization throughput " << medianTp
+        << " msg/sec below " << kMinThroughput << " msg/sec (SRS-NFR-001)";
+}
+
+// ===========================================================================
+// Round-Trip Throughput (Serialize + Deserialize)
+// ===========================================================================
+
+TEST_F(MessageSerializationBenchmark, RoundTripThroughput) {
+    auto msg = makeGameMessage(0x10, 58);
+
+    std::vector<double> throughputs;
+    throughputs.reserve(static_cast<std::size_t>(kIterations));
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        auto start = std::chrono::high_resolution_clock::now();
+
+        for (int i = 0; i < kMessageCount; ++i) {
+            auto wire = msg.serialize();
+            auto result = NetworkMessage::deserialize(wire);
+            (void)result;
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double seconds =
+            std::chrono::duration<double>(end - start).count();
+        double tp = static_cast<double>(kMessageCount) / seconds;
+        throughputs.push_back(tp);
+    }
+
+    std::sort(throughputs.begin(), throughputs.end());
+    double medianTp = throughputs[throughputs.size() / 2];
+
+    std::cout << "\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Round-Trip Throughput (64-byte msg)             |\n"
+              << "+-------------------------------------------------+\n"
+              << "|  Median:        " << std::setw(10) << std::fixed
+              << std::setprecision(0) << medianTp << " msg/sec          |\n"
+              << "|  Requirement:   " << std::setw(10) << kMinThroughput
+              << " msg/sec          |\n"
+              << "|  Status:        " << std::setw(10)
+              << (medianTp >= kMinThroughput ? "PASS" : "FAIL")
+              << "                    |\n"
+              << "+-------------------------------------------------+\n"
+              << std::endl;
+
+    EXPECT_GE(medianTp, kMinThroughput)
+        << "Round-trip throughput " << medianTp
+        << " msg/sec below " << kMinThroughput << " msg/sec (SRS-NFR-001)";
+}
+
+// ===========================================================================
+// Payload Size Impact on Throughput
+// ===========================================================================
+
+TEST_F(MessageSerializationBenchmark, PayloadSizeImpact) {
+    std::cout << "\n"
+              << "+---------------------------------------------------+\n"
+              << "|  Payload Size Impact on Throughput                  |\n"
+              << "|  (SRS-NFR-001: ≥300K msg/sec)                      |\n"
+              << "+---------------------------------------------------+\n";
+
+    bool allPass = true;
+
+    for (int p = 0; p < kProfileCount; ++p) {
+        const auto& profile = kProfiles[p];
+        auto msg = makeGameMessage(profile.opcode, profile.size);
+
+        // Measure round-trip throughput
+        auto start = std::chrono::high_resolution_clock::now();
+
+        for (int i = 0; i < kMessageCount; ++i) {
+            auto wire = msg.serialize();
+            auto result = NetworkMessage::deserialize(wire);
+            (void)result;
+        }
+
+        auto end = std::chrono::high_resolution_clock::now();
+        double seconds =
+            std::chrono::duration<double>(end - start).count();
+        double tp = static_cast<double>(kMessageCount) / seconds;
+        double wireSize =
+            static_cast<double>(profile.size) + 6.0; // 4-len + 2-opcode
+
+        bool pass = (tp >= kMinThroughput);
+        if (!pass) { allPass = false; }
+
+        std::cout << "|  " << std::left << std::setw(16) << profile.name
+                  << std::right
+                  << "  wire=" << std::setw(4) << static_cast<int>(wireSize)
+                  << "B  tp=" << std::setw(10) << std::fixed
+                  << std::setprecision(0) << tp
+                  << "  " << (pass ? "PASS" : "FAIL") << " |\n";
+    }
+
+    std::cout << "+---------------------------------------------------+\n"
+              << "|  Requirement:     " << std::setw(10) << std::fixed
+              << std::setprecision(0) << kMinThroughput
+              << " msg/sec              |\n"
+              << "|  All Profiles:    " << std::setw(10)
+              << (allPass ? "PASS" : "FAIL")
+              << "                      |\n"
+              << "+---------------------------------------------------+\n"
+              << std::endl;
+
+    // Small messages (heartbeat, movement, spellcast) must exceed threshold
+    for (int p = 0; p < kProfileCount; ++p) {
+        if (kProfiles[p].size <= 64) {
+            auto msg = makeGameMessage(kProfiles[p].opcode, kProfiles[p].size);
+            auto tpStart = std::chrono::high_resolution_clock::now();
+            for (int i = 0; i < kMessageCount; ++i) {
+                auto wire = msg.serialize();
+                auto result = NetworkMessage::deserialize(wire);
+                (void)result;
+            }
+            auto tpEnd = std::chrono::high_resolution_clock::now();
+            double seconds =
+                std::chrono::duration<double>(tpEnd - tpStart).count();
+            double tp = static_cast<double>(kMessageCount) / seconds;
+
+            EXPECT_GE(tp, kMinThroughput)
+                << kProfiles[p].name << " (" << kProfiles[p].size
+                << " bytes) throughput " << tp
+                << " below " << kMinThroughput << " msg/sec";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #76. Part of #30.

Implements performance benchmarks for the two remaining SRS non-functional requirements:

- **SRS-NFR-001** (Message Throughput ≥300K msg/sec): Serialization, deserialization, and round-trip throughput with 6 realistic game payload profiles
- **SRS-NFR-005** (Memory ≤100MB per 1K players): Per-component breakdown, platform RSS measurement, scaling analysis, and destruction reclamation

### Benchmark Results (Apple Silicon, Release build)

| SRS Requirement | Target | Measured | Status |
|-----------------|--------|----------|--------|
| NFR-001 Serialize | ≥300K msg/sec | 52M msg/sec | PASS |
| NFR-001 Deserialize | ≥300K msg/sec | 63M msg/sec | PASS |
| NFR-001 Round-trip | ≥300K msg/sec | 31M msg/sec | PASS |
| NFR-005 Memory (theory) | ≤100MB | 1.19MB | PASS |
| NFR-005 Memory (RSS) | ≤100MB | 4.11MB | PASS |

### Payload Profile Throughput

| Profile | Wire Size | Throughput |
|---------|-----------|------------|
| Heartbeat | 10B | 27.6M msg/sec |
| Movement | 38B | 27.1M msg/sec |
| SpellCast | 30B | 29.5M msg/sec |
| Chat | 134B | 30.5M msg/sec |
| InventoryUpdate | 262B | 22.2M msg/sec |
| WorldState | 518B | 16.1M msg/sec |

### Memory Per-Component Breakdown (1K Players)

| Component | sizeof | Total |
|-----------|--------|-------|
| Equipment | 680B | 664KB |
| Stats | 80B | 78KB |
| QuestLog | 72B | 70KB |
| Transform | 40B | 39KB |
| Identity | 40B | 39KB |
| Inventory | 40B | 39KB |
| **Total** | | **1.19MB** |

### New Files

- `tests/benchmark/ecs/memory_profiling_benchmark_test.cpp` — 4 tests (component breakdown, RSS, scaling, reclamation)
- `tests/benchmark/foundation/message_serialization_benchmark_test.cpp` — 4 tests (serialize, deserialize, roundtrip, payload profiles)
- `tests/CMakeLists.txt` — 2 new benchmark targets

### Completing Issue #30

With this PR and PR #77 (ECS/World Tick/Plugin Load benchmarks), all 6 SRS NFR requirements now have comprehensive performance benchmarks:

| SRS | Requirement | PR | Result |
|-----|-------------|------|--------|
| NFR-001 | Message ≥300K/s | This PR | 31M msg/sec |
| NFR-002 | World Tick ≤50ms | #77 | 0.15ms |
| NFR-003 | 10K Entity ≤5ms | #77 | 0.014ms |
| NFR-004 | DB Query p99 ≤50ms | Pre-existing | 0.006ms |
| NFR-005 | Memory ≤100MB/1K | This PR | 4.11MB |
| NFR-006 | Plugin Load ≤100ms | #77 | 0.005ms |

## Test Plan

- [x] All 8 new benchmark tests pass
- [x] All 19 benchmark tests pass (including Part 1)
- [x] Release build with `-O3` for accurate measurement
- [x] macOS mach_task_info used for RSS measurement