### PR TITLE
feat(service): add entry points, Dockerfiles, and Docker Compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Build artifacts
+build/
+out/
+
+# Version control
+.git/
+.gitignore
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Documentation and design
+.ad-sdlc/
+docs/
+
+# Tests and benchmarks (not needed in production images)
+tests/
+benchmarks/
+
+# CI/CD
+.github/
+
+# Claude Code
+.claude/
+
+# Object files and libraries
+*.o
+*.a
+*.so
+*.dylib
+
+# Python cache
+__pycache__/
+*.pyc
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(CGS_BUILD_TESTS "Build unit and integration tests" ON)
 option(CGS_BUILD_BENCHMARKS "Build performance benchmarks" OFF)
 option(CGS_ENABLE_SANITIZERS "Enable address and undefined behavior sanitizers" OFF)
 option(CGS_HOT_RELOAD "Enable plugin hot reload (development only)" OFF)
+option(CGS_BUILD_SERVICES "Build service executables" OFF)
 
 # Compiler warning flags
 add_library(cgs_warnings INTERFACE)

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,10 +12,12 @@ class CommonGameServerConan(ConanFile):
     options = {
         "build_tests": [True, False],
         "build_benchmarks": [True, False],
+        "build_services": [True, False],
     }
     default_options = {
         "build_tests": True,
         "build_benchmarks": False,
+        "build_services": False,
     }
 
     def requirements(self):
@@ -36,6 +38,7 @@ class CommonGameServerConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["CGS_BUILD_TESTS"] = bool(self.options.build_tests)
         tc.variables["CGS_BUILD_BENCHMARKS"] = bool(self.options.build_benchmarks)
+        tc.variables["CGS_BUILD_SERVICES"] = bool(self.options.build_services)
         tc.generate()
 
     def build(self):

--- a/deploy/config/auth.yaml
+++ b/deploy/config/auth.yaml
@@ -1,0 +1,8 @@
+# Auth Service Configuration
+auth:
+  signing_key: "change-me-in-production"
+  access_token_expiry_seconds: 900       # 15 minutes
+  refresh_token_expiry_seconds: 604800   # 7 days
+  min_password_length: 8
+  rate_limit_max_attempts: 5
+  rate_limit_window_seconds: 60

--- a/deploy/config/dbproxy.yaml
+++ b/deploy/config/dbproxy.yaml
@@ -1,0 +1,14 @@
+# DBProxy Service Configuration
+dbproxy:
+  primary:
+    connection_string: "host=localhost port=5432 dbname=cgs user=cgs password=cgs_dev"
+    min_connections: 2
+    max_connections: 10
+    connection_timeout_seconds: 30
+
+  cache:
+    enabled: true
+    max_entries: 10000
+    default_ttl_seconds: 300
+
+  health_check_interval_seconds: 30

--- a/deploy/config/game.yaml
+++ b/deploy/config/game.yaml
@@ -1,0 +1,6 @@
+# Game Service Configuration
+game:
+  tick_rate: 20                 # 20 Hz (50ms per tick)
+  max_instances: 1000
+  spatial_cell_size: 32.0       # World spatial partitioning cell size
+  ai_tick_interval: 0.1         # AI update interval in seconds

--- a/deploy/config/gateway.yaml
+++ b/deploy/config/gateway.yaml
@@ -1,0 +1,14 @@
+# Gateway Service Configuration
+auth:
+  signing_key: "change-me-in-production"
+  access_token_expiry_seconds: 900
+  refresh_token_expiry_seconds: 604800
+
+gateway:
+  tcp_port: 8080
+  websocket_port: 8081
+  auth_timeout_seconds: 10
+  rate_limit_capacity: 100
+  rate_limit_refill_rate: 50
+  max_connections: 10000
+  idle_timeout_seconds: 300

--- a/deploy/config/lobby.yaml
+++ b/deploy/config/lobby.yaml
@@ -1,0 +1,11 @@
+# Lobby Service Configuration
+lobby:
+  max_party_size: 5
+  queue:
+    min_players_per_match: 2
+    max_players_per_match: 2
+    initial_rating_tolerance: 100
+    max_rating_tolerance: 500
+    expansion_step: 50
+    expansion_interval_seconds: 10
+    max_queue_size: 10000

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,80 @@
+# Docker Compose for local full-stack development.
+#
+# Usage:
+#   cd deploy
+#   docker compose up --build
+#
+# All service images are built from the project root context.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: cgs
+      POSTGRES_USER: cgs
+      POSTGRES_PASSWORD: cgs_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cgs"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  auth:
+    build:
+      context: ../
+      dockerfile: deploy/docker/Dockerfile.auth
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "9001:9001"
+    environment:
+      CGS_CONFIG_PATH: /etc/cgs/config.yaml
+
+  gateway:
+    build:
+      context: ../
+      dockerfile: deploy/docker/Dockerfile.gateway
+    depends_on:
+      - auth
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    environment:
+      CGS_CONFIG_PATH: /etc/cgs/config.yaml
+
+  game:
+    build:
+      context: ../
+      dockerfile: deploy/docker/Dockerfile.game
+    depends_on:
+      - gateway
+    environment:
+      CGS_CONFIG_PATH: /etc/cgs/config.yaml
+
+  lobby:
+    build:
+      context: ../
+      dockerfile: deploy/docker/Dockerfile.lobby
+    depends_on:
+      - gateway
+    environment:
+      CGS_CONFIG_PATH: /etc/cgs/config.yaml
+
+  dbproxy:
+    build:
+      context: ../
+      dockerfile: deploy/docker/Dockerfile.dbproxy
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      CGS_CONFIG_PATH: /etc/cgs/config.yaml
+      CGS_DBPROXY_PRIMARY_CONNECTION: "host=postgres port=5432 dbname=cgs user=cgs password=cgs_dev"
+
+volumes:
+  pgdata:

--- a/deploy/docker/Dockerfile.auth
+++ b/deploy/docker/Dockerfile.auth
@@ -1,0 +1,66 @@
+# Dockerfile.auth — Multi-stage build for the Auth service executable.
+#
+# Build:  docker build -f deploy/docker/Dockerfile.auth -t cgs-auth .
+# Run:    docker run --rm cgs-auth
+
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        python3-pip \
+        python3-venv \
+        libpq-dev \
+        pkg-config \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Conan 2.x in a virtual environment.
+RUN python3 -m venv /opt/conan && \
+    /opt/conan/bin/pip install --no-cache-dir conan && \
+    ln -s /opt/conan/bin/conan /usr/local/bin/conan && \
+    conan profile detect --force
+
+WORKDIR /src
+
+# Copy dependency descriptors first for layer caching.
+COPY conanfile.py CMakeLists.txt ./
+COPY cmake/ cmake/
+
+RUN conan install . \
+        --output-folder=build \
+        --build=missing \
+        -s build_type=Release \
+        -o build_tests=False \
+        -o build_benchmarks=False \
+        -o build_services=True
+
+# Copy full source tree.
+COPY . .
+
+RUN cmake -S . -B build \
+        -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCGS_BUILD_SERVICES=ON \
+        -DCGS_BUILD_TESTS=OFF \
+        -DCGS_BUILD_BENCHMARKS=OFF \
+    && cmake --build build --target cgs_auth_server -j"$(nproc)"
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r cgs && useradd -r -g cgs -d /opt/cgs cgs
+
+COPY --from=builder /src/build/src/services/auth/cgs_auth_server /usr/local/bin/
+COPY deploy/config/auth.yaml /etc/cgs/config.yaml
+
+USER cgs
+ENTRYPOINT ["cgs_auth_server", "--config", "/etc/cgs/config.yaml"]

--- a/deploy/docker/Dockerfile.dbproxy
+++ b/deploy/docker/Dockerfile.dbproxy
@@ -1,0 +1,63 @@
+# Dockerfile.dbproxy — Multi-stage build for the DBProxy service executable.
+#
+# Build:  docker build -f deploy/docker/Dockerfile.dbproxy -t cgs-dbproxy .
+# Run:    docker run --rm cgs-dbproxy
+
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        python3-pip \
+        python3-venv \
+        libpq-dev \
+        pkg-config \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/conan && \
+    /opt/conan/bin/pip install --no-cache-dir conan && \
+    ln -s /opt/conan/bin/conan /usr/local/bin/conan && \
+    conan profile detect --force
+
+WORKDIR /src
+
+COPY conanfile.py CMakeLists.txt ./
+COPY cmake/ cmake/
+
+RUN conan install . \
+        --output-folder=build \
+        --build=missing \
+        -s build_type=Release \
+        -o build_tests=False \
+        -o build_benchmarks=False \
+        -o build_services=True
+
+COPY . .
+
+RUN cmake -S . -B build \
+        -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCGS_BUILD_SERVICES=ON \
+        -DCGS_BUILD_TESTS=OFF \
+        -DCGS_BUILD_BENCHMARKS=OFF \
+    && cmake --build build --target cgs_dbproxy_server -j"$(nproc)"
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r cgs && useradd -r -g cgs -d /opt/cgs cgs
+
+COPY --from=builder /src/build/src/services/dbproxy/cgs_dbproxy_server /usr/local/bin/
+COPY deploy/config/dbproxy.yaml /etc/cgs/config.yaml
+
+USER cgs
+ENTRYPOINT ["cgs_dbproxy_server", "--config", "/etc/cgs/config.yaml"]

--- a/deploy/docker/Dockerfile.game
+++ b/deploy/docker/Dockerfile.game
@@ -1,0 +1,63 @@
+# Dockerfile.game — Multi-stage build for the Game service executable.
+#
+# Build:  docker build -f deploy/docker/Dockerfile.game -t cgs-game .
+# Run:    docker run --rm cgs-game
+
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        python3-pip \
+        python3-venv \
+        libpq-dev \
+        pkg-config \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/conan && \
+    /opt/conan/bin/pip install --no-cache-dir conan && \
+    ln -s /opt/conan/bin/conan /usr/local/bin/conan && \
+    conan profile detect --force
+
+WORKDIR /src
+
+COPY conanfile.py CMakeLists.txt ./
+COPY cmake/ cmake/
+
+RUN conan install . \
+        --output-folder=build \
+        --build=missing \
+        -s build_type=Release \
+        -o build_tests=False \
+        -o build_benchmarks=False \
+        -o build_services=True
+
+COPY . .
+
+RUN cmake -S . -B build \
+        -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCGS_BUILD_SERVICES=ON \
+        -DCGS_BUILD_TESTS=OFF \
+        -DCGS_BUILD_BENCHMARKS=OFF \
+    && cmake --build build --target cgs_game_server -j"$(nproc)"
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r cgs && useradd -r -g cgs -d /opt/cgs cgs
+
+COPY --from=builder /src/build/src/services/game/cgs_game_server /usr/local/bin/
+COPY deploy/config/game.yaml /etc/cgs/config.yaml
+
+USER cgs
+ENTRYPOINT ["cgs_game_server", "--config", "/etc/cgs/config.yaml"]

--- a/deploy/docker/Dockerfile.gateway
+++ b/deploy/docker/Dockerfile.gateway
@@ -1,0 +1,64 @@
+# Dockerfile.gateway — Multi-stage build for the Gateway service executable.
+#
+# Build:  docker build -f deploy/docker/Dockerfile.gateway -t cgs-gateway .
+# Run:    docker run --rm -p 8080:8080 -p 8081:8081 cgs-gateway
+
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        python3-pip \
+        python3-venv \
+        libpq-dev \
+        pkg-config \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/conan && \
+    /opt/conan/bin/pip install --no-cache-dir conan && \
+    ln -s /opt/conan/bin/conan /usr/local/bin/conan && \
+    conan profile detect --force
+
+WORKDIR /src
+
+COPY conanfile.py CMakeLists.txt ./
+COPY cmake/ cmake/
+
+RUN conan install . \
+        --output-folder=build \
+        --build=missing \
+        -s build_type=Release \
+        -o build_tests=False \
+        -o build_benchmarks=False \
+        -o build_services=True
+
+COPY . .
+
+RUN cmake -S . -B build \
+        -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCGS_BUILD_SERVICES=ON \
+        -DCGS_BUILD_TESTS=OFF \
+        -DCGS_BUILD_BENCHMARKS=OFF \
+    && cmake --build build --target cgs_gateway_server -j"$(nproc)"
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r cgs && useradd -r -g cgs -d /opt/cgs cgs
+
+COPY --from=builder /src/build/src/services/gateway/cgs_gateway_server /usr/local/bin/
+COPY deploy/config/gateway.yaml /etc/cgs/config.yaml
+
+USER cgs
+EXPOSE 8080 8081
+ENTRYPOINT ["cgs_gateway_server", "--config", "/etc/cgs/config.yaml"]

--- a/deploy/docker/Dockerfile.lobby
+++ b/deploy/docker/Dockerfile.lobby
@@ -1,0 +1,63 @@
+# Dockerfile.lobby — Multi-stage build for the Lobby service executable.
+#
+# Build:  docker build -f deploy/docker/Dockerfile.lobby -t cgs-lobby .
+# Run:    docker run --rm cgs-lobby
+
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        python3-pip \
+        python3-venv \
+        libpq-dev \
+        pkg-config \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/conan && \
+    /opt/conan/bin/pip install --no-cache-dir conan && \
+    ln -s /opt/conan/bin/conan /usr/local/bin/conan && \
+    conan profile detect --force
+
+WORKDIR /src
+
+COPY conanfile.py CMakeLists.txt ./
+COPY cmake/ cmake/
+
+RUN conan install . \
+        --output-folder=build \
+        --build=missing \
+        -s build_type=Release \
+        -o build_tests=False \
+        -o build_benchmarks=False \
+        -o build_services=True
+
+COPY . .
+
+RUN cmake -S . -B build \
+        -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCGS_BUILD_SERVICES=ON \
+        -DCGS_BUILD_TESTS=OFF \
+        -DCGS_BUILD_BENCHMARKS=OFF \
+    && cmake --build build --target cgs_lobby_server -j"$(nproc)"
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r cgs && useradd -r -g cgs -d /opt/cgs cgs
+
+COPY --from=builder /src/build/src/services/lobby/cgs_lobby_server /usr/local/bin/
+COPY deploy/config/lobby.yaml /etc/cgs/config.yaml
+
+USER cgs
+ENTRYPOINT ["cgs_lobby_server", "--config", "/etc/cgs/config.yaml"]

--- a/include/cgs/service/service_runner.hpp
+++ b/include/cgs/service/service_runner.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+/// @file service_runner.hpp
+/// @brief Shared utilities for service entry points.
+///
+/// Provides signal handling, configuration loading, and CLI argument
+/// parsing for all CGS service executables.
+
+#include <atomic>
+#include <filesystem>
+#include <string_view>
+
+#include "cgs/foundation/config_manager.hpp"
+#include "cgs/foundation/game_result.hpp"
+
+namespace cgs::service {
+
+/// Installs SIGINT and SIGTERM handlers and exposes a shutdown flag.
+///
+/// Only one SignalHandler instance should exist per process.
+/// The handler writes to a static atomic flag in an async-signal-safe
+/// manner (relaxed store on a lock-free atomic).
+///
+/// After shutdown is requested, the original default handlers are
+/// restored so that a second signal terminates the process immediately.
+class SignalHandler {
+public:
+    SignalHandler();
+    ~SignalHandler();
+
+    SignalHandler(const SignalHandler&) = delete;
+    SignalHandler& operator=(const SignalHandler&) = delete;
+
+    /// Returns true after SIGINT or SIGTERM is received.
+    [[nodiscard]] bool shutdownRequested() const noexcept;
+
+    /// Block the calling thread until a shutdown signal arrives.
+    void waitForShutdown() const;
+
+private:
+    static std::atomic<bool> shutdownFlag_;
+    static void handler(int signal);
+};
+
+/// Load a YAML configuration file into the provided ConfigManager.
+///
+/// The config file path is resolved in order:
+///   1. CGS_CONFIG_PATH environment variable (if set)
+///   2. @p defaultPath parameter
+///
+/// @param config      ConfigManager to populate.
+/// @param defaultPath Fallback config file path.
+/// @return Success or ConfigLoadFailed error.
+[[nodiscard]] cgs::foundation::GameResult<void>
+loadConfig(cgs::foundation::ConfigManager& config,
+           const std::filesystem::path& defaultPath);
+
+/// Parse --config <path> from command-line arguments.
+///
+/// @return Config file path, or empty path if not specified.
+[[nodiscard]] std::filesystem::path
+parseConfigArg(int argc, char* argv[]);
+
+} // namespace cgs::service

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -4,3 +4,8 @@ add_subdirectory(gateway)
 add_subdirectory(game)
 add_subdirectory(lobby)
 add_subdirectory(dbproxy)
+
+# Shared entry-point utilities (always built when services are requested)
+if(CGS_BUILD_SERVICES)
+    add_subdirectory(runner)
+endif()

--- a/src/services/auth/CMakeLists.txt
+++ b/src/services/auth/CMakeLists.txt
@@ -14,3 +14,10 @@ target_link_libraries(cgs_service_auth
     PUBLIC cgs_core
 )
 add_library(cgs::service_auth ALIAS cgs_service_auth)
+
+if(CGS_BUILD_SERVICES)
+    add_executable(cgs_auth_server main.cpp)
+    target_link_libraries(cgs_auth_server
+        PRIVATE cgs_service_auth cgs_service_runner
+    )
+endif()

--- a/src/services/auth/main.cpp
+++ b/src/services/auth/main.cpp
@@ -1,0 +1,92 @@
+/// @file main.cpp
+/// @brief Auth service entry point.
+///
+/// Standalone executable for the authentication service.
+/// Creates an AuthServer with in-memory storage backends
+/// suitable for development and testing.
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+#include "cgs/foundation/config_manager.hpp"
+#include "cgs/service/auth_server.hpp"
+#include "cgs/service/auth_types.hpp"
+#include "cgs/service/service_runner.hpp"
+#include "cgs/service/token_store.hpp"
+#include "cgs/service/user_repository.hpp"
+
+namespace {
+
+cgs::service::AuthConfig buildAuthConfig(
+    const cgs::foundation::ConfigManager& config) {
+    cgs::service::AuthConfig cfg;
+
+    auto signingKey = config.get<std::string>("auth.signing_key");
+    if (signingKey) {
+        cfg.signingKey = std::move(signingKey).value();
+    }
+
+    auto accessExpiry = config.get<int>("auth.access_token_expiry_seconds");
+    if (accessExpiry) {
+        cfg.accessTokenExpiry = std::chrono::seconds(accessExpiry.value());
+    }
+
+    auto refreshExpiry = config.get<int>("auth.refresh_token_expiry_seconds");
+    if (refreshExpiry) {
+        cfg.refreshTokenExpiry = std::chrono::seconds(refreshExpiry.value());
+    }
+
+    auto minPwLen = config.get<unsigned int>("auth.min_password_length");
+    if (minPwLen) {
+        cfg.minPasswordLength = minPwLen.value();
+    }
+
+    auto rateMax = config.get<unsigned int>("auth.rate_limit_max_attempts");
+    if (rateMax) {
+        cfg.rateLimitMaxAttempts = rateMax.value();
+    }
+
+    auto rateWindow = config.get<int>("auth.rate_limit_window_seconds");
+    if (rateWindow) {
+        cfg.rateLimitWindow = std::chrono::seconds(rateWindow.value());
+    }
+
+    return cfg;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    cgs::service::SignalHandler signals;
+
+    // Resolve config path: --config flag > CGS_CONFIG_PATH env > default.
+    auto configPath = cgs::service::parseConfigArg(argc, argv);
+    if (configPath.empty()) {
+        configPath = "/etc/cgs/config.yaml";
+    }
+
+    cgs::foundation::ConfigManager config;
+    auto loadResult = cgs::service::loadConfig(config, configPath);
+    if (!loadResult) {
+        std::cerr << "Failed to load config: "
+                  << loadResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    auto authConfig = buildAuthConfig(config);
+
+    // In-memory backends for standalone development mode.
+    auto userRepo = std::make_shared<cgs::service::InMemoryUserRepository>();
+    auto tokenStore = std::make_shared<cgs::service::InMemoryTokenStore>();
+
+    cgs::service::AuthServer server(authConfig, userRepo, tokenStore);
+
+    std::cout << "Auth service started (config: " << configPath.string()
+              << ")\n";
+
+    signals.waitForShutdown();
+
+    std::cout << "Auth service stopped\n";
+    return EXIT_SUCCESS;
+}

--- a/src/services/dbproxy/CMakeLists.txt
+++ b/src/services/dbproxy/CMakeLists.txt
@@ -9,3 +9,10 @@ target_link_libraries(cgs_service_dbproxy
     PRIVATE cgs::foundation_database
 )
 add_library(cgs::service_dbproxy ALIAS cgs_service_dbproxy)
+
+if(CGS_BUILD_SERVICES)
+    add_executable(cgs_dbproxy_server main.cpp)
+    target_link_libraries(cgs_dbproxy_server
+        PRIVATE cgs_service_dbproxy cgs_service_runner
+    )
+endif()

--- a/src/services/dbproxy/main.cpp
+++ b/src/services/dbproxy/main.cpp
@@ -1,0 +1,125 @@
+/// @file main.cpp
+/// @brief DBProxy service entry point.
+///
+/// Standalone executable for the database proxy server.
+/// Provides connection pooling, query caching, and read replica routing.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "cgs/foundation/config_manager.hpp"
+#include "cgs/service/dbproxy_server.hpp"
+#include "cgs/service/dbproxy_types.hpp"
+#include "cgs/service/service_runner.hpp"
+
+namespace {
+
+cgs::service::DBEndpointConfig buildEndpointConfig(
+    const cgs::foundation::ConfigManager& config,
+    const std::string& prefix) {
+    cgs::service::DBEndpointConfig ep;
+
+    auto connStr = config.get<std::string>(prefix + ".connection_string");
+    if (connStr) {
+        ep.connectionString = std::move(connStr).value();
+    }
+
+    auto minConn = config.get<unsigned int>(prefix + ".min_connections");
+    if (minConn) {
+        ep.minConnections = minConn.value();
+    }
+
+    auto maxConn = config.get<unsigned int>(prefix + ".max_connections");
+    if (maxConn) {
+        ep.maxConnections = maxConn.value();
+    }
+
+    auto timeout = config.get<int>(prefix + ".connection_timeout_seconds");
+    if (timeout) {
+        ep.connectionTimeout = std::chrono::seconds(timeout.value());
+    }
+
+    return ep;
+}
+
+cgs::service::DBProxyConfig buildDBProxyConfig(
+    const cgs::foundation::ConfigManager& config) {
+    cgs::service::DBProxyConfig cfg;
+
+    cfg.primary = buildEndpointConfig(config, "dbproxy.primary");
+
+    // Check for numbered replicas: dbproxy.replicas.0, dbproxy.replicas.1, ...
+    for (unsigned int i = 0; i < 8; ++i) {
+        auto prefix = "dbproxy.replicas." + std::to_string(i);
+        auto connStr = config.get<std::string>(prefix + ".connection_string");
+        if (connStr) {
+            cfg.replicas.push_back(buildEndpointConfig(config, prefix));
+        } else {
+            break;
+        }
+    }
+
+    auto cacheEnabled = config.get<bool>("dbproxy.cache.enabled");
+    if (cacheEnabled) {
+        cfg.cache.enabled = cacheEnabled.value();
+    }
+
+    auto maxEntries = config.get<unsigned int>("dbproxy.cache.max_entries");
+    if (maxEntries) {
+        cfg.cache.maxEntries = static_cast<std::size_t>(maxEntries.value());
+    }
+
+    auto ttl = config.get<int>("dbproxy.cache.default_ttl_seconds");
+    if (ttl) {
+        cfg.cache.defaultTtl = std::chrono::seconds(ttl.value());
+    }
+
+    auto healthCheck = config.get<int>("dbproxy.health_check_interval_seconds");
+    if (healthCheck) {
+        cfg.healthCheckInterval = std::chrono::seconds(healthCheck.value());
+    }
+
+    return cfg;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    cgs::service::SignalHandler signals;
+
+    auto configPath = cgs::service::parseConfigArg(argc, argv);
+    if (configPath.empty()) {
+        configPath = "/etc/cgs/config.yaml";
+    }
+
+    cgs::foundation::ConfigManager config;
+    auto loadResult = cgs::service::loadConfig(config, configPath);
+    if (!loadResult) {
+        std::cerr << "Failed to load config: "
+                  << loadResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    auto dbCfg = buildDBProxyConfig(config);
+    cgs::service::DBProxyServer server(dbCfg);
+
+    auto startResult = server.start();
+    if (!startResult) {
+        std::cerr << "Failed to start dbproxy server: "
+                  << startResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "DBProxy server started (primary: "
+              << dbCfg.primary.connectionString
+              << ", replicas: " << dbCfg.replicas.size() << ")\n";
+
+    signals.waitForShutdown();
+
+    std::cout << "Shutting down dbproxy server...\n";
+    server.stop();
+    std::cout << "DBProxy server stopped\n";
+    return EXIT_SUCCESS;
+}

--- a/src/services/game/CMakeLists.txt
+++ b/src/services/game/CMakeLists.txt
@@ -17,3 +17,10 @@ target_link_libraries(cgs_service_game
     PUBLIC cgs_game_inventory_system
 )
 add_library(cgs::service_game ALIAS cgs_service_game)
+
+if(CGS_BUILD_SERVICES)
+    add_executable(cgs_game_server main.cpp)
+    target_link_libraries(cgs_game_server
+        PRIVATE cgs_service_game cgs_service_runner
+    )
+endif()

--- a/src/services/game/main.cpp
+++ b/src/services/game/main.cpp
@@ -1,0 +1,80 @@
+/// @file main.cpp
+/// @brief Game service entry point.
+///
+/// Standalone executable for the game server.
+/// Runs the ECS-based world simulation with a fixed-rate game loop.
+
+#include <cstdlib>
+#include <iostream>
+
+#include "cgs/foundation/config_manager.hpp"
+#include "cgs/service/game_server.hpp"
+#include "cgs/service/service_runner.hpp"
+
+namespace {
+
+cgs::service::GameServerConfig buildGameConfig(
+    const cgs::foundation::ConfigManager& config) {
+    cgs::service::GameServerConfig cfg;
+
+    auto tickRate = config.get<unsigned int>("game.tick_rate");
+    if (tickRate) {
+        cfg.tickRate = tickRate.value();
+    }
+
+    auto maxInstances = config.get<unsigned int>("game.max_instances");
+    if (maxInstances) {
+        cfg.maxInstances = maxInstances.value();
+    }
+
+    auto cellSize = config.get<float>("game.spatial_cell_size");
+    if (cellSize) {
+        cfg.spatialCellSize = cellSize.value();
+    }
+
+    auto aiTick = config.get<float>("game.ai_tick_interval");
+    if (aiTick) {
+        cfg.aiTickInterval = aiTick.value();
+    }
+
+    return cfg;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    cgs::service::SignalHandler signals;
+
+    auto configPath = cgs::service::parseConfigArg(argc, argv);
+    if (configPath.empty()) {
+        configPath = "/etc/cgs/config.yaml";
+    }
+
+    cgs::foundation::ConfigManager config;
+    auto loadResult = cgs::service::loadConfig(config, configPath);
+    if (!loadResult) {
+        std::cerr << "Failed to load config: "
+                  << loadResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    auto gameCfg = buildGameConfig(config);
+    cgs::service::GameServer server(gameCfg);
+
+    auto startResult = server.start();
+    if (!startResult) {
+        std::cerr << "Failed to start game server: "
+                  << startResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Game server started (tick_rate: " << gameCfg.tickRate
+              << " Hz, max_instances: " << gameCfg.maxInstances << ")\n";
+
+    signals.waitForShutdown();
+
+    std::cout << "Shutting down game server...\n";
+    server.stop();
+    std::cout << "Game server stopped\n";
+    return EXIT_SUCCESS;
+}

--- a/src/services/gateway/CMakeLists.txt
+++ b/src/services/gateway/CMakeLists.txt
@@ -10,3 +10,10 @@ target_link_libraries(cgs_service_gateway
     PUBLIC cgs_service_auth
 )
 add_library(cgs::service_gateway ALIAS cgs_service_gateway)
+
+if(CGS_BUILD_SERVICES)
+    add_executable(cgs_gateway_server main.cpp)
+    target_link_libraries(cgs_gateway_server
+        PRIVATE cgs_service_gateway cgs_service_runner
+    )
+endif()

--- a/src/services/gateway/main.cpp
+++ b/src/services/gateway/main.cpp
@@ -1,0 +1,131 @@
+/// @file main.cpp
+/// @brief Gateway service entry point.
+///
+/// Standalone executable for the gateway server.
+/// Creates an embedded AuthServer (in-memory backends) and starts
+/// the GatewayServer for client connection management.
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+#include "cgs/foundation/config_manager.hpp"
+#include "cgs/service/auth_server.hpp"
+#include "cgs/service/auth_types.hpp"
+#include "cgs/service/gateway_server.hpp"
+#include "cgs/service/gateway_types.hpp"
+#include "cgs/service/service_runner.hpp"
+#include "cgs/service/token_store.hpp"
+#include "cgs/service/user_repository.hpp"
+
+namespace {
+
+cgs::service::AuthConfig buildAuthConfig(
+    const cgs::foundation::ConfigManager& config) {
+    cgs::service::AuthConfig cfg;
+
+    auto signingKey = config.get<std::string>("auth.signing_key");
+    if (signingKey) {
+        cfg.signingKey = std::move(signingKey).value();
+    }
+
+    auto accessExpiry = config.get<int>("auth.access_token_expiry_seconds");
+    if (accessExpiry) {
+        cfg.accessTokenExpiry = std::chrono::seconds(accessExpiry.value());
+    }
+
+    auto refreshExpiry = config.get<int>("auth.refresh_token_expiry_seconds");
+    if (refreshExpiry) {
+        cfg.refreshTokenExpiry = std::chrono::seconds(refreshExpiry.value());
+    }
+
+    return cfg;
+}
+
+cgs::service::GatewayConfig buildGatewayConfig(
+    const cgs::foundation::ConfigManager& config) {
+    cgs::service::GatewayConfig cfg;
+
+    auto tcpPort = config.get<int>("gateway.tcp_port");
+    if (tcpPort) {
+        cfg.tcpPort = static_cast<uint16_t>(tcpPort.value());
+    }
+
+    auto wsPort = config.get<int>("gateway.websocket_port");
+    if (wsPort) {
+        cfg.webSocketPort = static_cast<uint16_t>(wsPort.value());
+    }
+
+    auto authTimeout = config.get<int>("gateway.auth_timeout_seconds");
+    if (authTimeout) {
+        cfg.authTimeout = std::chrono::seconds(authTimeout.value());
+    }
+
+    auto rlCapacity = config.get<unsigned int>("gateway.rate_limit_capacity");
+    if (rlCapacity) {
+        cfg.rateLimitCapacity = rlCapacity.value();
+    }
+
+    auto rlRefill = config.get<unsigned int>("gateway.rate_limit_refill_rate");
+    if (rlRefill) {
+        cfg.rateLimitRefillRate = rlRefill.value();
+    }
+
+    auto maxConn = config.get<unsigned int>("gateway.max_connections");
+    if (maxConn) {
+        cfg.maxConnections = maxConn.value();
+    }
+
+    auto idleTimeout = config.get<int>("gateway.idle_timeout_seconds");
+    if (idleTimeout) {
+        cfg.idleTimeout = std::chrono::seconds(idleTimeout.value());
+    }
+
+    return cfg;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    cgs::service::SignalHandler signals;
+
+    auto configPath = cgs::service::parseConfigArg(argc, argv);
+    if (configPath.empty()) {
+        configPath = "/etc/cgs/config.yaml";
+    }
+
+    cgs::foundation::ConfigManager config;
+    auto loadResult = cgs::service::loadConfig(config, configPath);
+    if (!loadResult) {
+        std::cerr << "Failed to load config: "
+                  << loadResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    // Embedded auth server with in-memory storage.
+    auto authConfig = buildAuthConfig(config);
+    auto userRepo = std::make_shared<cgs::service::InMemoryUserRepository>();
+    auto tokenStore = std::make_shared<cgs::service::InMemoryTokenStore>();
+    auto authServer = std::make_shared<cgs::service::AuthServer>(
+        authConfig, userRepo, tokenStore);
+
+    auto gwConfig = buildGatewayConfig(config);
+    cgs::service::GatewayServer gateway(gwConfig, authServer);
+
+    auto startResult = gateway.start();
+    if (!startResult) {
+        std::cerr << "Failed to start gateway: "
+                  << startResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Gateway server started (tcp:" << gwConfig.tcpPort
+              << " ws:" << gwConfig.webSocketPort << ")\n";
+
+    signals.waitForShutdown();
+
+    std::cout << "Shutting down gateway...\n";
+    gateway.stop();
+    std::cout << "Gateway server stopped\n";
+    return EXIT_SUCCESS;
+}

--- a/src/services/lobby/CMakeLists.txt
+++ b/src/services/lobby/CMakeLists.txt
@@ -9,3 +9,10 @@ target_link_libraries(cgs_service_lobby
     PUBLIC cgs_core
 )
 add_library(cgs::service_lobby ALIAS cgs_service_lobby)
+
+if(CGS_BUILD_SERVICES)
+    add_executable(cgs_lobby_server main.cpp)
+    target_link_libraries(cgs_lobby_server
+        PRIVATE cgs_service_lobby cgs_service_runner
+    )
+endif()

--- a/src/services/lobby/main.cpp
+++ b/src/services/lobby/main.cpp
@@ -1,0 +1,104 @@
+/// @file main.cpp
+/// @brief Lobby service entry point.
+///
+/// Standalone executable for the lobby server.
+/// Manages matchmaking queues, party groups, and ELO rating.
+
+#include <cstdlib>
+#include <iostream>
+
+#include "cgs/foundation/config_manager.hpp"
+#include "cgs/service/lobby_server.hpp"
+#include "cgs/service/lobby_types.hpp"
+#include "cgs/service/service_runner.hpp"
+
+namespace {
+
+cgs::service::LobbyConfig buildLobbyConfig(
+    const cgs::foundation::ConfigManager& config) {
+    cgs::service::LobbyConfig cfg;
+
+    auto minPlayers =
+        config.get<unsigned int>("lobby.queue.min_players_per_match");
+    if (minPlayers) {
+        cfg.queueConfig.minPlayersPerMatch = minPlayers.value();
+    }
+
+    auto maxPlayers =
+        config.get<unsigned int>("lobby.queue.max_players_per_match");
+    if (maxPlayers) {
+        cfg.queueConfig.maxPlayersPerMatch = maxPlayers.value();
+    }
+
+    auto initTol = config.get<int>("lobby.queue.initial_rating_tolerance");
+    if (initTol) {
+        cfg.queueConfig.initialRatingTolerance = initTol.value();
+    }
+
+    auto maxTol = config.get<int>("lobby.queue.max_rating_tolerance");
+    if (maxTol) {
+        cfg.queueConfig.maxRatingTolerance = maxTol.value();
+    }
+
+    auto expStep = config.get<int>("lobby.queue.expansion_step");
+    if (expStep) {
+        cfg.queueConfig.expansionStep = expStep.value();
+    }
+
+    auto expInterval = config.get<int>("lobby.queue.expansion_interval_seconds");
+    if (expInterval) {
+        cfg.queueConfig.expansionInterval =
+            std::chrono::seconds(expInterval.value());
+    }
+
+    auto maxQueue = config.get<unsigned int>("lobby.queue.max_queue_size");
+    if (maxQueue) {
+        cfg.queueConfig.maxQueueSize = maxQueue.value();
+    }
+
+    auto maxParty = config.get<unsigned int>("lobby.max_party_size");
+    if (maxParty) {
+        cfg.maxPartySize = maxParty.value();
+    }
+
+    return cfg;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    cgs::service::SignalHandler signals;
+
+    auto configPath = cgs::service::parseConfigArg(argc, argv);
+    if (configPath.empty()) {
+        configPath = "/etc/cgs/config.yaml";
+    }
+
+    cgs::foundation::ConfigManager config;
+    auto loadResult = cgs::service::loadConfig(config, configPath);
+    if (!loadResult) {
+        std::cerr << "Failed to load config: "
+                  << loadResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    auto lobbyCfg = buildLobbyConfig(config);
+    cgs::service::LobbyServer server(lobbyCfg);
+
+    auto startResult = server.start();
+    if (!startResult) {
+        std::cerr << "Failed to start lobby server: "
+                  << startResult.error().message() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Lobby server started (max_party: " << lobbyCfg.maxPartySize
+              << ", max_queue: " << lobbyCfg.queueConfig.maxQueueSize << ")\n";
+
+    signals.waitForShutdown();
+
+    std::cout << "Shutting down lobby server...\n";
+    server.stop();
+    std::cout << "Lobby server stopped\n";
+    return EXIT_SUCCESS;
+}

--- a/src/services/runner/CMakeLists.txt
+++ b/src/services/runner/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Service Runner - shared entry-point utilities (signal handling, config loading)
+add_library(cgs_service_runner STATIC
+    service_runner.cpp
+)
+target_link_libraries(cgs_service_runner
+    PUBLIC cgs_core
+    PUBLIC cgs_foundation_common
+)
+add_library(cgs::service_runner ALIAS cgs_service_runner)

--- a/src/services/runner/service_runner.cpp
+++ b/src/services/runner/service_runner.cpp
@@ -1,0 +1,80 @@
+/// @file service_runner.cpp
+/// @brief Implementation of shared service entry-point utilities.
+
+#include "cgs/service/service_runner.hpp"
+
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <string_view>
+#include <thread>
+
+namespace cgs::service {
+
+// -- SignalHandler -----------------------------------------------------------
+
+std::atomic<bool> SignalHandler::shutdownFlag_{false};
+
+void SignalHandler::handler(int /*signal*/) {
+    // async-signal-safe: relaxed store on a lock-free atomic.
+    shutdownFlag_.store(true, std::memory_order_relaxed);
+}
+
+SignalHandler::SignalHandler() {
+    shutdownFlag_.store(false, std::memory_order_relaxed);
+    std::signal(SIGINT, &SignalHandler::handler);
+    std::signal(SIGTERM, &SignalHandler::handler);
+}
+
+SignalHandler::~SignalHandler() {
+    // Restore default handlers so that a second signal terminates immediately.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+    std::signal(SIGINT, SIG_DFL);
+    std::signal(SIGTERM, SIG_DFL);
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+}
+
+bool SignalHandler::shutdownRequested() const noexcept {
+    return shutdownFlag_.load(std::memory_order_relaxed);
+}
+
+void SignalHandler::waitForShutdown() const {
+    using namespace std::chrono_literals;
+    while (!shutdownFlag_.load(std::memory_order_relaxed)) {
+        std::this_thread::sleep_for(100ms);
+    }
+}
+
+// -- Config loading ----------------------------------------------------------
+
+cgs::foundation::GameResult<void>
+loadConfig(cgs::foundation::ConfigManager& config,
+           const std::filesystem::path& defaultPath) {
+    std::filesystem::path configPath = defaultPath;
+
+    // Environment variable override for 12-factor compliance.
+    const char* envPath = std::getenv("CGS_CONFIG_PATH");
+    if (envPath != nullptr) {
+        configPath = envPath;
+    }
+
+    return config.load(configPath);
+}
+
+// -- CLI argument parsing ----------------------------------------------------
+
+std::filesystem::path parseConfigArg(int argc, char* argv[]) {
+    for (int i = 1; i < argc - 1; ++i) {
+        if (std::string_view(argv[i]) == "--config") {  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            return argv[i + 1];  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        }
+    }
+    return {};
+}
+
+} // namespace cgs::service


### PR DESCRIPTION
## Summary

Resolves #81 — Service Entry Points, Dockerfiles & Docker Compose.

This PR adds executable entry points for all 5 existing service libraries, Docker images for each, and a Docker Compose orchestration file for local full-stack development.

### New Components

- **Service Runner Library** (`cgs_service_runner`): Shared utilities for signal handling (`SignalHandler`), YAML config loading with `CGS_CONFIG_PATH` env override, and `--config` CLI parsing
- **5 Service Executables**: `cgs_auth_server`, `cgs_gateway_server`, `cgs_game_server`, `cgs_lobby_server`, `cgs_dbproxy_server`
- **YAML Configs**: Sensible defaults for each service under `deploy/config/`
- **Multi-stage Dockerfiles**: Ubuntu 24.04 base, Conan + CMake build, minimal runtime images
- **Docker Compose**: PostgreSQL + 5 services with health checks and dependency ordering

### Build Integration

- New `CGS_BUILD_SERVICES` CMake option (default `OFF`) — guards all executable targets so library-only builds (tests, benchmarks) remain unaffected
- Conan `build_services` option propagated to CMake

### Design Decisions

- Auth entry point uses in-memory `IUserRepository`/`ITokenStore` (standalone dev mode)
- Gateway embeds its own AuthServer instance
- `SignalHandler` uses `std::atomic<bool>` with relaxed ordering for async-signal-safe writes
- Destructor restores `SIG_DFL` so second signal terminates immediately

## Test Plan

- [x] CMake configure with `CGS_BUILD_SERVICES=ON` succeeds
- [x] All 5 executables compile with `-Werror` (zero warnings)
- [x] Auth server: starts, responds to SIGTERM, shuts down cleanly
- [x] Gateway server: starts (tcp:8080 ws:8081), SIGTERM shutdown works
- [x] Game server: starts with config (20 Hz), SIGTERM shutdown works
- [x] Lobby server: starts with config, SIGTERM shutdown works
- [x] DBProxy server: starts with config, SIGTERM shutdown works
- [x] Default build (`CGS_BUILD_SERVICES=OFF`) configures without errors
- [x] Full build (`cmake --build`) completes with zero warnings
- [x] All existing 1,341 tests pass (0 failures, 4 skipped DB-integration)
- [ ] Docker build test — Docker daemon not available in dev environment
- [ ] Docker Compose integration — requires Docker daemon