### PR TITLE
feat(k8s): add Kubernetes base manifests and service discovery

### DIFF
--- a/deploy/k8s/base/auth.yaml
+++ b/deploy/k8s/base/auth.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: auth
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: auth
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: auth
+        app.kubernetes.io/component: service
+        app.kubernetes.io/part-of: common-game-server
+    spec:
+      serviceAccountName: cgs-service-account
+      containers:
+        - name: auth
+          image: cgs-auth:latest
+          ports:
+            - name: auth-api
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: CGS_CONFIG_PATH
+              value: /etc/cgs/config.yaml
+            - name: CGS_AUTH_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cgs-secrets
+                  key: jwt-signing-key
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cgs
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: config
+          configMap:
+            name: cgs-config
+            items:
+              - key: auth.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: auth
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: auth
+  ports:
+    - name: auth-api
+      port: 9001
+      targetPort: auth-api
+      protocol: TCP

--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cgs-config
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/part-of: common-game-server
+data:
+  # Each key is mounted as /etc/cgs/config.yaml in the corresponding deployment.
+  # Service discovery uses K8s DNS: <service>.cgs-system.svc.cluster.local
+
+  auth.yaml: |
+    auth:
+      signing_key: "injected-from-secret"
+      access_token_expiry_seconds: 900
+      refresh_token_expiry_seconds: 604800
+      min_password_length: 8
+      rate_limit_max_attempts: 5
+      rate_limit_window_seconds: 60
+
+  gateway.yaml: |
+    auth:
+      signing_key: "injected-from-secret"
+      access_token_expiry_seconds: 900
+      refresh_token_expiry_seconds: 604800
+    gateway:
+      tcp_port: 8080
+      websocket_port: 8081
+      auth_timeout_seconds: 10
+      rate_limit_capacity: 100
+      rate_limit_refill_rate: 50
+      max_connections: 10000
+      idle_timeout_seconds: 300
+
+  game.yaml: |
+    game:
+      tick_rate: 20
+      max_instances: 1000
+      spatial_cell_size: 32.0
+      ai_tick_interval: 0.1
+
+  lobby.yaml: |
+    lobby:
+      max_party_size: 5
+      queue:
+        min_players_per_match: 2
+        max_players_per_match: 2
+        initial_rating_tolerance: 100
+        max_rating_tolerance: 500
+        expansion_step: 50
+        expansion_interval_seconds: 10
+        max_queue_size: 10000
+
+  dbproxy.yaml: |
+    dbproxy:
+      primary:
+        connection_string: "host=postgres.cgs-system.svc.cluster.local port=5432 dbname=cgs user=cgs password=injected-from-secret"
+        min_connections: 2
+        max_connections: 10
+        connection_timeout_seconds: 30
+      cache:
+        enabled: true
+        max_entries: 10000
+        default_ttl_seconds: 300
+      health_check_interval_seconds: 30

--- a/deploy/k8s/base/dbproxy.yaml
+++ b/deploy/k8s/base/dbproxy.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dbproxy
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: dbproxy
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dbproxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dbproxy
+        app.kubernetes.io/component: service
+        app.kubernetes.io/part-of: common-game-server
+    spec:
+      serviceAccountName: cgs-service-account
+      containers:
+        - name: dbproxy
+          image: cgs-dbproxy:latest
+          ports:
+            - name: dbproxy-api
+              containerPort: 9003
+              protocol: TCP
+          env:
+            - name: CGS_CONFIG_PATH
+              value: /etc/cgs/config.yaml
+            - name: CGS_DB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: cgs-secrets
+                  key: db-connection-string
+            - name: CGS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cgs-secrets
+                  key: db-password
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cgs
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: config
+          configMap:
+            name: cgs-config
+            items:
+              - key: dbproxy.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dbproxy
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: dbproxy
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dbproxy
+  ports:
+    - name: dbproxy-api
+      port: 9003
+      targetPort: dbproxy-api
+      protocol: TCP

--- a/deploy/k8s/base/gateway.yaml
+++ b/deploy/k8s/base/gateway.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gateway
+        app.kubernetes.io/component: service
+        app.kubernetes.io/part-of: common-game-server
+    spec:
+      serviceAccountName: cgs-service-account
+      containers:
+        - name: gateway
+          image: cgs-gateway:latest
+          ports:
+            - name: tcp
+              containerPort: 8080
+              protocol: TCP
+            - name: websocket
+              containerPort: 8081
+              protocol: TCP
+          env:
+            - name: CGS_CONFIG_PATH
+              value: /etc/cgs/config.yaml
+            - name: CGS_AUTH_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cgs-secrets
+                  key: jwt-signing-key
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cgs
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          livenessProbe:
+            tcpSocket:
+              port: tcp
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: tcp
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: config
+          configMap:
+            name: cgs-config
+            items:
+              - key: gateway.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: gateway
+  ports:
+    - name: tcp
+      port: 8080
+      targetPort: tcp
+      protocol: TCP
+    - name: websocket
+      port: 8081
+      targetPort: websocket
+      protocol: TCP

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -1,0 +1,30 @@
+# Kustomize base configuration for CGS Kubernetes deployment.
+#
+# Usage:
+#   kubectl apply -k deploy/k8s/base/
+#
+# To customize images for a specific registry:
+#   cd deploy/k8s/base
+#   kustomize edit set image cgs-auth=ghcr.io/kcenon/cgs-auth:v0.1.0
+#   kustomize edit set image cgs-gateway=ghcr.io/kcenon/cgs-gateway:v0.1.0
+#   ...
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: cgs-system
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - secrets.yaml
+  - auth.yaml
+  - gateway.yaml
+  - lobby.yaml
+  - dbproxy.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: common-game-server
+      app.kubernetes.io/managed-by: kustomize
+    includeSelectors: false

--- a/deploy/k8s/base/lobby.yaml
+++ b/deploy/k8s/base/lobby.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lobby
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: lobby
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: lobby
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: lobby
+        app.kubernetes.io/component: service
+        app.kubernetes.io/part-of: common-game-server
+    spec:
+      serviceAccountName: cgs-service-account
+      containers:
+        - name: lobby
+          image: cgs-lobby:latest
+          ports:
+            - name: lobby-api
+              containerPort: 9002
+              protocol: TCP
+          env:
+            - name: CGS_CONFIG_PATH
+              value: /etc/cgs/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cgs
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: config
+          configMap:
+            name: cgs-config
+            items:
+              - key: lobby.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lobby
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: lobby
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: lobby
+  ports:
+    - name: lobby-api
+      port: 9002
+      targetPort: lobby-api
+      protocol: TCP

--- a/deploy/k8s/base/namespace.yaml
+++ b/deploy/k8s/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cgs-system
+  labels:
+    app.kubernetes.io/part-of: common-game-server
+    app.kubernetes.io/managed-by: kustomize

--- a/deploy/k8s/base/rbac.yaml
+++ b/deploy/k8s/base/rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cgs-service-account
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/part-of: common-game-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cgs-role
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/part-of: common-game-server
+rules:
+  # Allow reading ConfigMaps and Secrets for configuration.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+  # Allow listing pods for service discovery and health checks.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cgs-role-binding
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/part-of: common-game-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cgs-role
+subjects:
+  - kind: ServiceAccount
+    name: cgs-service-account
+    namespace: cgs-system

--- a/deploy/k8s/base/secrets.yaml
+++ b/deploy/k8s/base/secrets.yaml
@@ -1,0 +1,20 @@
+# Secret template for CGS production credentials.
+#
+# WARNING: Replace placeholder values before deploying to production.
+# Consider using sealed-secrets or external-secrets-operator for
+# GitOps-safe secret management.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cgs-secrets
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/part-of: common-game-server
+type: Opaque
+stringData:
+  # JWT signing key (min 32 bytes recommended for HMAC-SHA256).
+  jwt-signing-key: "change-me-in-production"
+
+  # PostgreSQL credentials.
+  db-password: "cgs_dev"
+  db-connection-string: "host=postgres.cgs-system.svc.cluster.local port=5432 dbname=cgs user=cgs password=cgs_dev"


### PR DESCRIPTION
Closes #82

## Summary

Add kustomize-based Kubernetes deployment manifests for the CGS microservice stack. All 4 stateless services (auth, gateway, lobby, dbproxy) get Deployment + ClusterIP Service pairs with DNS-based service discovery.

GameServer StatefulSet is deferred to #83 (requires sticky sessions and persistent state).

### Resources Created (14 total)

| Kind | Name | Purpose |
|------|------|---------|
| Namespace | `cgs-system` | Isolated namespace for all CGS resources |
| ServiceAccount | `cgs-service-account` | Pod identity for RBAC |
| Role | `cgs-role` | Read access to ConfigMaps, Secrets, Pods |
| RoleBinding | `cgs-role-binding` | Binds role to service account |
| ConfigMap | `cgs-config` | Per-service YAML configs with K8s DNS names |
| Secret | `cgs-secrets` | JWT signing key + DB credentials (template) |
| Deployment x4 | auth, gateway, lobby, dbproxy | Stateless service workloads |
| Service x4 | auth, gateway, lobby, dbproxy | ClusterIP for DNS discovery |

### Design Decisions

- **Service Discovery**: All inter-service references use K8s DNS (`<svc>.cgs-system.svc.cluster.local`) — zero hardcoded endpoints
- **Probes**: Gateway uses `tcpSocket` on port 8080; other services use `exec: kill -0 1` (PID 1 liveness check)
- **Secrets**: `stringData` format for readability; production should use sealed-secrets or external-secrets-operator
- **ConfigMap**: One ConfigMap with multiple data keys; each Deployment mounts only its own config as `/etc/cgs/config.yaml`
- **Resource limits**: Conservative defaults (100-200m CPU, 128-256Mi memory requests)

## Test Plan

- [x] `kubectl kustomize deploy/k8s/base/` generates 14 resources without warnings
- [x] All resource kinds correct: 1 Namespace, 1 SA, 1 Role, 1 RoleBinding, 1 ConfigMap, 1 Secret, 4 Deployments, 4 Services
- [x] C++ build unaffected (no source changes)
- [ ] `kubectl apply -k deploy/k8s/base/` on a K8s cluster (requires cluster access)