### PR TITLE
feat(k8s): add HPA, StatefulSet, PDB, and rolling update strategy (#83)

### DIFF
--- a/deploy/k8s/base/auth.yaml
+++ b/deploy/k8s/base/auth.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/part-of: common-game-server
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: auth
@@ -20,6 +25,7 @@ spec:
         app.kubernetes.io/part-of: common-game-server
     spec:
       serviceAccountName: cgs-service-account
+      terminationGracePeriodSeconds: 30
       containers:
         - name: auth
           image: cgs-auth:latest
@@ -60,6 +66,10 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       volumes:
         - name: config
           configMap:

--- a/deploy/k8s/base/dbproxy.yaml
+++ b/deploy/k8s/base/dbproxy.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/part-of: common-game-server
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: dbproxy
@@ -20,6 +25,7 @@ spec:
         app.kubernetes.io/part-of: common-game-server
     spec:
       serviceAccountName: cgs-service-account
+      terminationGracePeriodSeconds: 30
       containers:
         - name: dbproxy
           image: cgs-dbproxy:latest
@@ -65,6 +71,10 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       volumes:
         - name: config
           configMap:

--- a/deploy/k8s/base/game.yaml
+++ b/deploy/k8s/base/game.yaml
@@ -1,0 +1,113 @@
+# GameServer StatefulSet — provides stable network identity and ordered
+# deployment for stateful game instances.  Each pod owns a persistent
+# identity (game-0, game-1, ...) so that the Gateway can route players to
+# the same instance across reconnects (sticky sessions).
+#
+# Headless Service (clusterIP: None) gives each pod a DNS record:
+#   game-<ordinal>.game.cgs-system.svc.cluster.local
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: game
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: game
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  serviceName: game
+  replicas: 2
+  podManagementPolicy: OrderedReady
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: game
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Update one pod at a time to preserve running game instances.
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: game
+        app.kubernetes.io/component: service
+        app.kubernetes.io/part-of: common-game-server
+    spec:
+      serviceAccountName: cgs-service-account
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: game
+          image: cgs-game:latest
+          ports:
+            - name: game-api
+              containerPort: 9010
+              protocol: TCP
+          env:
+            - name: CGS_CONFIG_PATH
+              value: /etc/cgs/config.yaml
+            # Inject the pod ordinal as an environment variable so the
+            # game server can register a unique instance identity.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cgs
+              readOnly: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "kill -0 1"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                # Allow in-flight game ticks to complete and player sessions
+                # to drain before SIGTERM reaches the process.
+                command: ["sh", "-c", "sleep 10"]
+      volumes:
+        - name: config
+          configMap:
+            name: cgs-config
+            items:
+              - key: game.yaml
+                path: config.yaml
+---
+# Headless Service for StatefulSet DNS resolution.
+# Each pod gets: game-<N>.game.cgs-system.svc.cluster.local
+apiVersion: v1
+kind: Service
+metadata:
+  name: game
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: game
+    app.kubernetes.io/component: service
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: game
+  ports:
+    - name: game-api
+      port: 9010
+      targetPort: game-api
+      protocol: TCP

--- a/deploy/k8s/base/gateway.yaml
+++ b/deploy/k8s/base/gateway.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/part-of: common-game-server
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: gateway
@@ -20,6 +25,7 @@ spec:
         app.kubernetes.io/part-of: common-game-server
     spec:
       serviceAccountName: cgs-service-account
+      terminationGracePeriodSeconds: 30
       containers:
         - name: gateway
           image: cgs-gateway:latest
@@ -63,6 +69,10 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       volumes:
         - name: config
           configMap:

--- a/deploy/k8s/base/hpa.yaml
+++ b/deploy/k8s/base/hpa.yaml
@@ -1,0 +1,139 @@
+# Horizontal Pod Autoscalers for stateless CGS services.
+#
+# Only stateless Deployments get HPAs.  GameServer (StatefulSet) needs
+# manual scaling because game instances carry live player state.
+# DBProxy is excluded because scaling it beyond the connection-pool
+# limit wastes database connections.
+#
+# Scaling thresholds:
+#   CPU  70% — leaves headroom for burst traffic
+#   Memory 80% — catches memory pressure before OOM
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gateway-hpa
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/component: autoscaling
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gateway
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: auth-hpa
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: auth
+    app.kubernetes.io/component: autoscaling
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: auth
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: lobby-hpa
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: lobby
+    app.kubernetes.io/component: autoscaling
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: lobby
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -20,8 +20,11 @@ resources:
   - secrets.yaml
   - auth.yaml
   - gateway.yaml
+  - game.yaml
   - lobby.yaml
   - dbproxy.yaml
+  - hpa.yaml
+  - pdb.yaml
 
 labels:
   - pairs:

--- a/deploy/k8s/base/lobby.yaml
+++ b/deploy/k8s/base/lobby.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/part-of: common-game-server
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: lobby
@@ -20,6 +25,7 @@ spec:
         app.kubernetes.io/part-of: common-game-server
     spec:
       serviceAccountName: cgs-service-account
+      terminationGracePeriodSeconds: 30
       containers:
         - name: lobby
           image: cgs-lobby:latest
@@ -55,6 +61,10 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       volumes:
         - name: config
           configMap:

--- a/deploy/k8s/base/pdb.yaml
+++ b/deploy/k8s/base/pdb.yaml
@@ -1,0 +1,81 @@
+# PodDisruptionBudgets — guarantee minimum availability during voluntary
+# disruptions (node drain, cluster upgrade, etc.).
+#
+# Each PDB ensures at least 1 pod remains running per service.
+# For services with replicas=2 this means at most 1 pod is disrupted
+# at a time (maxUnavailable: 1).
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway-pdb
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/component: availability
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gateway
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: auth-pdb
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: auth
+    app.kubernetes.io/component: availability
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: auth
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: game-pdb
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: game
+    app.kubernetes.io/component: availability
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: game
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: lobby-pdb
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: lobby
+    app.kubernetes.io/component: availability
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: lobby
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dbproxy-pdb
+  namespace: cgs-system
+  labels:
+    app.kubernetes.io/name: dbproxy
+    app.kubernetes.io/component: availability
+    app.kubernetes.io/part-of: common-game-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dbproxy


### PR DESCRIPTION
Closes #83

## Summary
- Add GameServer StatefulSet with headless Service for sticky sessions and stable pod identity (game-0, game-1, ...)
- Add HorizontalPodAutoscaler for gateway (2-10), auth (2-8), and lobby (2-6) with CPU 70% / memory 80% targets
- Add PodDisruptionBudget for all 5 services (minAvailable: 1)
- Configure rolling update strategy on all Deployments (maxUnavailable: 0, maxSurge: 1) for zero-downtime deployments
- Add terminationGracePeriodSeconds and preStop lifecycle hooks for graceful connection draining

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| StatefulSet for GameServer | Provides stable network identity for sticky player sessions |
| Headless Service (clusterIP: None) | Enables individual pod DNS: game-N.game.cgs-system.svc |
| HPA only on stateless services | GameServer has live state; DBProxy has connection-pool limits |
| preStop sleep 5s (Deployments) | Allows kube-proxy to update iptables before SIGTERM |
| preStop sleep 10s (GameServer) | Extra time for game tick completion and session drain |
| ScaleDown stabilization 300s | Prevents flapping during traffic oscillation |

## Test Plan
- [x] kubectl kustomize build validates all 25 resources
- [x] No warnings from kustomize
- [x] Existing C++ build unaffected (K8s manifests only)