### PR TITLE
feat(monitoring): wire GameMetrics into services and persistence layer

### DIFF
--- a/src/services/game/CMakeLists.txt
+++ b/src/services/game/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(cgs_service_game
 )
 target_link_libraries(cgs_service_game
     PUBLIC cgs_core
+    PUBLIC cgs_foundation_monitoring
     PUBLIC cgs_ecs_component_storage
     PUBLIC cgs_ecs_entity_manager
     PUBLIC cgs_ecs_system_scheduler

--- a/src/services/runner/health_server.cpp
+++ b/src/services/runner/health_server.cpp
@@ -267,6 +267,7 @@ void HealthServer::stop() {
 
 void HealthServer::setReady(bool ready) {
     impl_->ready.store(ready, std::memory_order_relaxed);
+    impl_->metrics.setGauge("cgs_health_ready", ready ? 1.0 : 0.0);
 }
 
 bool HealthServer::isRunning() const {


### PR DESCRIPTION
## Summary

Closes #97 (Part of #32 — Reliability & Fault Tolerance)

Completes the monitoring pipeline by wiring `GameMetrics` calls into service code and the persistence layer. The monitoring infrastructure (ServiceMonitor, alerting rules, Grafana dashboard) was delivered in PR #96, but custom metrics were not recorded — this PR fills that gap.

### Changes

**HealthServer** (`health_server.cpp`):
- `setReady()` now updates `cgs_health_ready` gauge (1.0 = ready, 0.0 = not ready)

**PersistenceManager** (`persistence_manager.cpp`):
- `recordChange()` updates `cgs_wal_pending_entries` gauge after each WAL append
- `doSnapshot()` updates `cgs_last_snapshot_timestamp` and `cgs_wal_pending_entries` after snapshot

**GameServer** (`game_server.cpp`):
- `addPlayer()` / `removePlayer()` update `cgs_ccu` gauge
- `start()` registers `cgs_tick_ms` histogram and sets `MetricsCallback` to record tick latency and `cgs_tick_budget_utilization` per tick

**Service Entry Points** (all 5 `main.cpp` files):
- Instantiate `HealthServer` + `GameMetrics::instance()` with correct port per service
- Call `health.setReady(true)` after service starts, `health.setReady(false)` before shutdown
- Ports: auth=9101, gateway=9100, game=9110, lobby=9102, dbproxy=9103

**Build** (`CMakeLists.txt`):
- Added `cgs_foundation_monitoring` to `cgs_service_game` link dependencies (required for `GameMetrics` symbols in test targets)

### Metrics Now Recorded

| Metric | Type | Source |
|--------|------|--------|
| `cgs_health_ready` | gauge | HealthServer |
| `cgs_wal_pending_entries` | gauge | PersistenceManager |
| `cgs_last_snapshot_timestamp` | gauge | PersistenceManager |
| `cgs_tick_ms` | histogram | GameServer (via MetricsCallback) |
| `cgs_tick_budget_utilization` | gauge | GameServer (via MetricsCallback) |
| `cgs_ccu` | gauge | GameServer |

### Impact on PR #96 Monitoring Config

After this PR, the monitoring infrastructure is nearly fully operational:
- **Alerting rules**: 9/9 rules will evaluate against real data (was 4/9)
- **Grafana panels**: 10/11 panels will render data (was 6/11)
- **Chaos tests**: `data_loss_test.sh` WAL verification will return actual values

### Known limitation: `cgs_requests_total`

The **Request Rate** dashboard panel (`cgs_requests_total`) will still show "No Data". This counter requires per-request instrumentation inside gRPC/REST request handlers, which do not exist yet. This metric should be added when transport-layer handlers are implemented in a future issue.

| Component | Metric | Status |
|-----------|--------|--------|
| Dashboard: Request Rate panel | `cgs_requests_total` | Not recorded — no request handlers yet |

## Test Plan

### Verified (code review + local tests)

- [x] **`cgs_health_ready`** gauge: `setGauge("cgs_health_ready", ...)` confirmed in `health_server.cpp:270`
- [x] **`cgs_wal_pending_entries`** gauge: confirmed in `persistence_manager.cpp` at both `recordChange()` (L207-211) and `doSnapshot()` (L105-107)
- [x] **`cgs_last_snapshot_timestamp`** gauge: confirmed in `persistence_manager.cpp:104`
- [x] **`cgs_tick_ms`** histogram: `registerHistogram()` + `recordHistogram()` confirmed in `game_server.cpp:197-205`
- [x] **`cgs_tick_budget_utilization`** gauge: confirmed in `game_server.cpp:206-207`
- [x] **`cgs_ccu`** gauge: confirmed in both `addPlayer()` (L383) and `removePlayer()` (L410) in `game_server.cpp`
- [x] **Service entry points**: All 5 services instantiate HealthServer with correct ports (auth=9101, gw=9100, game=9110, lobby=9102, db=9103)
- [x] **HealthServer lifecycle**: All 5 services call `start()`, `setReady(true)`, `setReady(false)`, `stop()` in correct order
- [x] **`cgs_service_game_tests`** — 47 tests passed (GameServer with new metrics calls)
- [x] **`cgs_service_persistence_tests`** — 23 tests passed (PersistenceManager with gauge updates)
- [x] **Linker verification** — `cgs_foundation_monitoring` added to `cgs_service_game` CMakeLists; test targets link successfully

### Alerting rules coverage (9/9)

| Alert | Metric | Available? |
|-------|--------|------------|
| CGSServiceDown | `up` (Prometheus built-in) | Yes |
| CGSServiceMTTRBreached | `up` (Prometheus built-in) | Yes |
| CGSUptimeBurnRateHigh | `up` (Prometheus built-in) | Yes |
| CGSServiceNotReady | `cgs_health_ready` | Yes (this PR) |
| CGSPodRestartHigh | `kube_pod_container_status_restarts_total` (kube-state-metrics) | Yes |
| CGSGameTickSlow | `cgs_tick_ms_bucket` | Yes (this PR) |
| CGSGameTickOverBudget | `cgs_tick_budget_utilization` | Yes (this PR) |
| CGSWalEntriesHigh | `cgs_wal_pending_entries` | Yes (this PR) |
| CGSSnapshotStale | `cgs_last_snapshot_timestamp` | Yes (this PR) |

### Dashboard panel coverage (10/11)

| Panel | Metric Source | Renders? |
|-------|--------------|----------|
| Service Uptime SLO | `up` (Prometheus) | Yes |
| Error Budget Remaining | `up` (Prometheus) | Yes |
| Active Services | `up` (Prometheus) | Yes |
| CCU | `cgs_ccu` (this PR) | Yes |
| Service Health Status | `up` (Prometheus) | Yes |
| Pod Restarts | `kube_pod_container_status_restarts_total` (kube-state-metrics) | Yes |
| Service Up/Down Timeline | `up` (Prometheus) | Yes |
| Game Tick Latency | `cgs_tick_ms_bucket` (this PR) | Yes |
| **Request Rate** | **`cgs_requests_total`** | **No — not recorded** |
| WAL Pending Entries | `cgs_wal_pending_entries` (this PR) | Yes |
| Last Snapshot Age | `cgs_last_snapshot_timestamp` (this PR) | Yes |

### Requires K8s cluster deployment

- [ ] Deploy services and verify `/metrics` returns Prometheus text with `cgs_tick_ms`, `cgs_ccu`, `cgs_health_ready`
- [ ] Verify Grafana dashboard panels populate with real data (10/11 expected)
- [ ] Verify `CGSServiceNotReady` alert fires when a service sets readiness to false