### PR TITLE
feat(network): add TLS 1.3 support to GameNetworkManager

### DIFF
--- a/include/cgs/foundation/error_code.hpp
+++ b/include/cgs/foundation/error_code.hpp
@@ -30,6 +30,9 @@ enum class ErrorCode : uint32_t {
     ListenFailed = 0x0105,
     SessionNotFound = 0x0106,
     InvalidMessage = 0x0107,
+    TlsHandshakeFailed = 0x0108,
+    TlsCertificateInvalid = 0x0109,
+    TlsNotSupported = 0x010A,
 
     // Database (0x0200 - 0x02FF)
     DatabaseError = 0x0200,


### PR DESCRIPTION
## Summary

- Add `TlsConfig` struct to `game_network_manager.hpp` with cert/key paths, CA path, and peer verification settings
- Add `listen(port, protocol, TlsConfig)` overload that enforces TLS 1.3 minimum via network_system's TCP facade
- Add 3 new network error codes: `TlsHandshakeFailed`, `TlsCertificateInvalid`, `TlsNotSupported`
- Reject TLS requests for UDP/WebSocket with `TlsNotSupported` (upstream facade limitation)
- Add 11 unit tests for config validation, protocol rejection, and error subsystem classification

Closes #103
Part of #33

## Changes

| File | Change |
|------|--------|
| `include/cgs/foundation/error_code.hpp` | Add 3 TLS error codes (0x0108-0x010A) |
| `include/cgs/foundation/game_network_manager.hpp` | Add `TlsConfig` struct + `listen()` TLS overload |
| `src/foundation/network/game_network_manager.cpp` | Pass TLS config to TCP facade, validate config |
| `tests/unit/foundation/network_adapter_test.cpp` | Add 11 TLS-related unit tests |

## Test Plan

- [x] All 44 network adapter tests pass (33 existing + 11 new)
- [x] TlsConfig validation: empty, missing cert, missing key all rejected
- [x] Protocol rejection: UDP and WebSocket return TlsNotSupported
- [x] Error subsystem: TLS codes correctly classified as Network
- [x] Existing tests unchanged and passing
- [x] CI: macOS Release, Ubuntu Release, Ubuntu Debug all green