### PR TITLE
feat(dbproxy): add PreparedStatement support for SQL injection prevention

### DIFF
--- a/include/cgs/service/connection_pool_manager.hpp
+++ b/include/cgs/service/connection_pool_manager.hpp
@@ -62,6 +62,19 @@ public:
     [[nodiscard]] cgs::foundation::GameResult<uint64_t>
     execute(std::string_view sql);
 
+    /// Execute a parameterized SELECT query, routing to a replica if available.
+    ///
+    /// Uses PreparedStatement for SQL injection prevention (SRS-NFR-016).
+    /// The statement is resolved to safe SQL before execution.
+    [[nodiscard]] cgs::foundation::GameResult<cgs::foundation::QueryResult>
+    query(const cgs::foundation::PreparedStatement& stmt);
+
+    /// Execute a parameterized write command on the primary.
+    ///
+    /// Uses PreparedStatement for SQL injection prevention (SRS-NFR-016).
+    [[nodiscard]] cgs::foundation::GameResult<uint64_t>
+    execute(const cgs::foundation::PreparedStatement& stmt);
+
     /// Get the number of available replicas.
     [[nodiscard]] std::size_t replicaCount() const;
 

--- a/include/cgs/service/dbproxy_server.hpp
+++ b/include/cgs/service/dbproxy_server.hpp
@@ -87,6 +87,27 @@ public:
         cgs::foundation::GameResult<cgs::foundation::QueryResult>>
     queryAsync(std::string_view sql);
 
+    // ── Parameterized query execution (SRS-NFR-016) ──────────────────────
+
+    /// Execute a parameterized SELECT query using PreparedStatement.
+    ///
+    /// Prevents SQL injection by resolving bound parameters with proper
+    /// escaping. Cache lookup uses the resolved SQL string.
+    [[nodiscard]] cgs::foundation::GameResult<cgs::foundation::QueryResult>
+    query(const cgs::foundation::PreparedStatement& stmt);
+
+    /// Execute a parameterized write command using PreparedStatement.
+    ///
+    /// Prevents SQL injection by resolving bound parameters with proper
+    /// escaping. Cache invalidation uses the resolved SQL.
+    [[nodiscard]] cgs::foundation::GameResult<uint64_t>
+    execute(const cgs::foundation::PreparedStatement& stmt);
+
+    /// Execute a parameterized SELECT query asynchronously.
+    [[nodiscard]] std::future<
+        cgs::foundation::GameResult<cgs::foundation::QueryResult>>
+    queryAsync(const cgs::foundation::PreparedStatement& stmt);
+
     // ── Cache management ────────────────────────────────────────────────
 
     /// Manually invalidate all cache entries for a specific table.

--- a/src/services/dbproxy/connection_pool_manager.cpp
+++ b/src/services/dbproxy/connection_pool_manager.cpp
@@ -18,6 +18,7 @@ using cgs::foundation::ErrorCode;
 using cgs::foundation::GameDatabase;
 using cgs::foundation::GameError;
 using cgs::foundation::GameResult;
+using cgs::foundation::PreparedStatement;
 using cgs::foundation::QueryResult;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -174,6 +175,23 @@ GameResult<uint64_t> ConnectionPoolManager::execute(std::string_view sql) {
     }
 
     return impl_->primaryDb.execute(sql);
+}
+
+// ── query(PreparedStatement) ────────────────────────────────────────────────
+
+GameResult<QueryResult> ConnectionPoolManager::query(
+    const PreparedStatement& stmt) {
+    // Resolve to safe SQL with escaped parameters.
+    auto resolved = stmt.resolve();
+    return query(resolved);
+}
+
+// ── execute(PreparedStatement) ──────────────────────────────────────────────
+
+GameResult<uint64_t> ConnectionPoolManager::execute(
+    const PreparedStatement& stmt) {
+    auto resolved = stmt.resolve();
+    return execute(resolved);
 }
 
 // ── replicaCount() ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `query(PreparedStatement)` and `execute(PreparedStatement)` overloads to **DBProxyServer** and **ConnectionPoolManager**, exposing the existing foundation-layer `PreparedStatement` through the service layer
- Add `queryAsync(PreparedStatement)` for async parameterized queries
- Add 9 SQL injection prevention tests covering classic attack vectors (`' OR '1'='1`, `'; DROP TABLE`, `UNION SELECT`, nested quotes, empty strings, backslash)
- Add 5 DBProxyServer/ConnectionPoolManager PreparedStatement integration tests

## Security Context

The existing `PreparedStatement` class in `cgs::foundation` properly escapes single quotes (`'` → `''`) and uses typed bindings (int, double, bool, null) that are not injectable. However, `DBProxyServer` and `ConnectionPoolManager` only accepted raw `string_view sql`, forcing callers to concatenate SQL strings manually. This PR closes that gap by providing safe parameterized query methods at the service layer.

## Test Plan

- [x] All 39 dbproxy unit tests pass (25 existing + 14 new)
- [x] SQL injection vectors verified: quote escaping, DROP TABLE, UNION SELECT, nested quotes
- [x] PreparedStatement methods correctly return `DBProxyNotStarted` when proxy is not running
- [x] Full test suite passes (excluding pre-existing NOT_BUILT service stubs)

Closes #104