### PR TITLE
docs(readme): update README to reflect fully-implemented project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Common Game Server
 
+[![CI](https://github.com/kcenon/common_game_server/actions/workflows/ci.yml/badge.svg)](https://github.com/kcenon/common_game_server/actions/workflows/ci.yml)
+[![Code Coverage](https://github.com/kcenon/common_game_server/actions/workflows/coverage.yml/badge.svg)](https://github.com/kcenon/common_game_server/actions/workflows/coverage.yml)
+[![API Docs](https://github.com/kcenon/common_game_server/actions/workflows/docs.yml/badge.svg)](https://github.com/kcenon/common_game_server/actions/workflows/docs.yml)
+
 A unified, production-ready game server framework built with C++20, combining proven patterns from multiple game server implementations.
 
 ## Overview
@@ -13,11 +17,16 @@ Common Game Server unifies the best aspects of four existing projects into a coh
 
 ## Key Features
 
-- **Entity-Component System (ECS)**: Data-oriented design for optimal CPU cache utilization
-- **Plugin Architecture**: Support multiple game genres without modifying core code
-- **Microservices**: Horizontally scalable service-based deployment
-- **7 Foundation Systems**: Logging, networking, database, threading, monitoring, serialization, and common utilities
-- **Cloud-Native**: Kubernetes-ready with Prometheus/Grafana integration
+- **Entity-Component System (ECS)**: Data-oriented design with parallel execution and component queries
+- **Plugin Architecture**: Hot-reloadable plugins with dependency resolution and event communication
+- **Microservices**: 5 horizontally scalable services (Auth, Gateway, Game, Lobby, DBProxy)
+- **7 Foundation Adapters**: Logging, networking, database, threading, monitoring, serialization, and common utilities
+- **Game Logic Systems**: Object, Combat, World, AI (BehaviorTree), Quest, and Inventory systems
+- **Security**: JWT RS256 signing, TLS 1.3, input validation, SQL parameterization
+- **Reliability**: WAL + snapshots, circuit breaker, graceful shutdown, chaos testing
+- **Cloud-Native**: Kubernetes-ready with HPA, StatefulSet, PDB, Prometheus/Grafana integration
+- **Structured Logging**: JSON log output with correlation IDs
+- **Doxygen API Documentation**: Auto-generated from source comments
 
 ## Architecture
 
@@ -26,17 +35,23 @@ Common Game Server unifies the best aspects of four existing projects into a coh
 |                      COMMON GAME SERVER                            |
 +-------------------------------------------------------------------+
 |  Layer 6: PLUGIN LAYER (MMORPG, Battle Royale, RTS, Custom)       |
+|           Hot reload, dependency resolution, event communication   |
 +-------------------------------------------------------------------+
-|  Layer 5: GAME LOGIC LAYER (Object, Combat, World, AI Systems)    |
+|  Layer 5: GAME LOGIC LAYER                                         |
+|           Object, Combat, World, AI, Quest, Inventory              |
 +-------------------------------------------------------------------+
-|  Layer 4: CORE ECS LAYER (Entity, Component, System, World)       |
+|  Layer 4: CORE ECS LAYER                                           |
+|           Entity, Component, System Scheduler, Query, Parallel Exec|
 +-------------------------------------------------------------------+
-|  Layer 3: SERVICE LAYER (Auth, Gateway, Game, Lobby, DBProxy)     |
+|  Layer 3: SERVICE LAYER                                            |
+|           Auth, Gateway, Game, Lobby, DBProxy                      |
 +-------------------------------------------------------------------+
 |  Layer 2: FOUNDATION ADAPTER LAYER                                 |
+|           Result<T,E> pattern, no exceptions                       |
 +-------------------------------------------------------------------+
-|  Layer 1: 7 FOUNDATION SYSTEMS                                     |
-|  (common, thread, logger, network, database, container, monitoring)|
+|  Layer 1: 7 FOUNDATION SYSTEMS (from CGSS)                         |
+|           common, thread, logger, network, database, container,    |
+|           monitoring                                               |
 +-------------------------------------------------------------------+
 ```
 
@@ -56,19 +71,21 @@ Common Game Server unifies the best aspects of four existing projects into a coh
 | Component | Technology |
 |-----------|------------|
 | Language | C++20 |
-| Build System | CMake 3.20+ |
-| Package Manager | Conan |
+| Build System | CMake 3.20+ with presets |
+| Package Manager | Conan 2 |
 | Database | PostgreSQL 14+ |
-| Container | Docker |
-| Orchestration | Kubernetes |
+| Container | Docker + Docker Compose |
+| Orchestration | Kubernetes (HPA, StatefulSet, PDB) |
 | Monitoring | Prometheus + Grafana |
+| Code Style | clang-format 21 (Google-based) |
+| Documentation | Doxygen |
 
 ## Prerequisites
 
 - C++20 compatible compiler (GCC 11+, Clang 14+, MSVC 2022+)
 - CMake 3.20 or higher
-- Conan package manager
-- PostgreSQL 14+
+- Conan 2 package manager
+- PostgreSQL 14+ (for database features)
 - Docker (optional, for containerized deployment)
 
 ## Getting Started
@@ -77,21 +94,29 @@ Common Game Server unifies the best aspects of four existing projects into a coh
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-org/common_game_server.git
+git clone https://github.com/kcenon/common_game_server.git
 cd common_game_server
 
 # Install dependencies via Conan
-conan install . --build=missing
+conan install . --output-folder=build --build=missing -s build_type=Release
 
-# Configure and build
-cmake -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build
+# Configure and build using CMake presets
+cmake --preset conan-release
+cmake --build --preset conan-release -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
 # Run tests
-ctest --test-dir build
+ctest --preset conan-release --output-on-failure
 ```
 
-### Running the Server
+### Debug Build (Linux)
+
+```bash
+conan install . --output-folder=build --build=missing -s build_type=Debug
+cmake --preset conan-debug
+cmake --build --preset conan-debug -j$(nproc)
+```
+
+### Running Services
 
 ```bash
 # Start the auth service
@@ -107,21 +132,99 @@ ctest --test-dir build
 ### Docker Deployment
 
 ```bash
-# Build Docker images
-docker compose build
-
-# Start all services
-docker compose up -d
+cd deploy
+docker compose up --build
 ```
+
+### Kubernetes Deployment
+
+```bash
+kubectl apply -f deploy/k8s/base/
+```
+
+## CI/CD Pipeline
+
+The project runs 6 automated workflows on every push and pull request:
+
+| Workflow | Description | Trigger |
+|----------|-------------|---------|
+| **CI** | Lint (clang-format) → Build & Test (3 configs) | push, PR |
+| **Code Coverage** | lcov coverage report | push, PR |
+| **API Docs** | Doxygen documentation generation | push, PR |
+| **Benchmarks** | Performance benchmark suite | manual |
+| **Load Test** | CCU validation scripts | manual |
+| **Chaos Tests** | Fault injection & resilience testing | manual |
+
+```
+lint (clang-format 21.1.8)
+  └─> build & test (ubuntu-24.04 Debug)
+  └─> build & test (ubuntu-24.04 Release)
+  └─> build & test (macos-14 Release)
+coverage (lcov)
+docs (doxygen)
+```
+
+## Project Structure
+
+```
+common_game_server/
+├── include/cgs/              # Public headers
+│   ├── core/                 # Core types and utilities
+│   ├── ecs/                  # ECS (entity, component, scheduler, query)
+│   ├── foundation/           # Foundation adapter interfaces
+│   ├── game/                 # Game logic (combat, world, AI, quest, inventory)
+│   ├── plugin/               # Plugin interfaces and hot reload
+│   └── service/              # Service types (auth, gateway, lobby, etc.)
+├── src/                      # Implementation
+│   ├── ecs/                  # ECS implementation
+│   ├── foundation/           # 8 foundation adapters
+│   ├── game/                 # 6 game logic systems
+│   ├── plugins/              # Plugin manager, hot reload, MMORPG plugin
+│   └── services/             # 5 microservices + shared runner
+├── tests/                    # Test suites
+│   ├── unit/                 # Unit tests
+│   ├── integration/          # Integration tests
+│   ├── benchmark/            # Performance benchmarks
+│   ├── load/                 # Load testing scripts
+│   └── chaos/                # Chaos/fault injection tests
+├── deploy/                   # Deployment configuration
+│   ├── docker/               # Dockerfiles for each service
+│   ├── k8s/                  # Kubernetes manifests (HPA, PDB, StatefulSet)
+│   ├── monitoring/           # Prometheus + Grafana dashboards
+│   ├── config/               # Service configuration files
+│   └── docker-compose.yml    # Local full-stack development
+├── docs/                     # Documentation
+│   ├── reference/            # Reference documentation
+│   ├── PRD.md                # Product Requirements Document
+│   ├── SRS.md                # Software Requirements Specification
+│   ├── SDS.md                # Software Design Specification
+│   ├── ARCHITECTURE.md       # Technical architecture design
+│   └── PERFORMANCE_REPORT.md # Benchmark results
+├── .clang-format             # Code style (Google-based, 4-space indent)
+├── .clang-tidy               # Static analysis checks
+├── Doxyfile                  # API documentation configuration
+└── conanfile.py              # Conan dependency definition
+```
+
+## Microservices
+
+| Service | Description | Default Port |
+|---------|-------------|--------------|
+| AuthServer | JWT RS256 authentication, session management, rate limiting | 8000 |
+| GatewayServer | Client routing, load balancing, token bucket rate limiting | 8080/8081 |
+| GameServer | World simulation, game loop, map instance management | 9000 |
+| LobbyServer | Matchmaking (ELO), party management, region-based queues | 9100 |
+| DBProxy | Connection pooling, prepared statements, SQL injection prevention | 5432 |
 
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
 | [PRD](docs/PRD.md) | Product Requirements Document |
-| [SRS](docs/SRS.md) | Software Requirements Specification |
-| [SDS](docs/SDS.md) | Software Design Specification |
+| [SRS](docs/SRS.md) | Software Requirements Specification (126 requirements) |
+| [SDS](docs/SDS.md) | Software Design Specification (29 modules) |
 | [Architecture](docs/ARCHITECTURE.md) | Technical architecture design |
+| [Performance Report](docs/PERFORMANCE_REPORT.md) | Benchmark results and analysis |
 | [Integration Strategy](docs/INTEGRATION_STRATEGY.md) | Integration approach |
 | [Roadmap](docs/ROADMAP.md) | Implementation timeline |
 
@@ -130,7 +233,7 @@ docker compose up -d
 | Document | Description |
 |----------|-------------|
 | [ECS Design](docs/reference/ECS_DESIGN.md) | Entity-Component System details |
-| [Plugin System](docs/reference/PLUGIN_SYSTEM.md) | Plugin architecture |
+| [Plugin System](docs/reference/PLUGIN_SYSTEM.md) | Plugin architecture and hot reload |
 | [Foundation Adapters](docs/reference/FOUNDATION_ADAPTERS.md) | Adapter patterns |
 | [Protocol Design](docs/reference/PROTOCOL_DESIGN.md) | Network protocol specification |
 | [Database Schema](docs/reference/DATABASE_SCHEMA.md) | Database design |
@@ -139,53 +242,41 @@ docker compose up -d
 | [Deployment Guide](docs/reference/DEPLOYMENT_GUIDE.md) | Production deployment |
 | [Configuration Guide](docs/reference/CONFIGURATION_GUIDE.md) | Configuration options |
 
-## Project Structure
+## Milestones
 
-```
-common_game_server/
-+-- docs/                    # Documentation
-|   +-- reference/           # Reference documentation
-+-- src/                     # Source code
-|   +-- foundation/          # Foundation adapters
-|   +-- ecs/                 # Entity-Component System
-|   +-- services/            # Microservices
-|   +-- game/                # Game logic systems
-|   +-- plugins/             # Game plugins
-+-- include/                 # Public headers
-+-- tests/                   # Test suites
-+-- config/                  # Configuration files
-+-- deploy/                  # Deployment manifests
-+-- scripts/                 # Build and utility scripts
-```
-
-## Microservices
-
-| Service | Description | Default Port |
-|---------|-------------|--------------|
-| AuthServer | Authentication and session management | 8000 |
-| GatewayServer | Client routing and load balancing | 8080/8081 |
-| GameServer | World simulation and game logic | 9000 |
-| LobbyServer | Matchmaking and party management | 9100 |
-| DBProxy | Database connection pooling | 5432 |
+| Milestone | Description | Status |
+|-----------|-------------|--------|
+| M1: Foundation | Project bootstrap + 7 foundation adapters | Done |
+| M2: Core ECS | Component storage, entity management, scheduling, queries, parallel execution | Done |
+| M3: Game Logic | Object, Combat, World, AI, Quest, Inventory systems | Done |
+| M4: Services | Auth, Gateway, Game, Lobby, DBProxy microservices | Done |
+| M5: Plugin | Event communication, hot reload, MMORPG plugin | Done |
+| M6: Production | Performance, scalability (K8s), reliability, security, code quality | Done |
 
 ## Contributing
 
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes following [Conventional Commits](https://www.conventionalcommits.org/)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+2. Create a feature branch (`git checkout -b feat/issue-N-description`)
+3. Format your code (`clang-format -i <files>` using version 21+)
+4. Commit your changes following [Conventional Commits](https://www.conventionalcommits.org/)
+5. Push to the branch (`git push origin feat/issue-N-description`)
+6. Open a Pull Request
 
-## Milestones
+### Code Style
 
-| Milestone | Duration | Status |
-|-----------|----------|--------|
-| M1: Foundation | 4 weeks | Planned |
-| M2: Core ECS | 4 weeks | Planned |
-| M3: Game Logic | 6 weeks | Planned |
-| M4: Services | 4 weeks | Planned |
-| M5: MMORPG Plugin | 4 weeks | Planned |
-| M6: Production | 4 weeks | Planned |
+This project uses clang-format (Google-based style, 4-space indent, 100-column limit). CI enforces formatting on every pull request. To check locally:
+
+```bash
+find include/cgs src -name '*.hpp' -o -name '*.cpp' | xargs clang-format --dry-run --Werror
+```
+
+### Git Blame
+
+To skip the mass formatting commit in `git blame`:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
 
 ## License
 


### PR DESCRIPTION
## Summary
- Update README.md to accurately reflect the current project state after completing all 6 milestones
- All 34+ GitHub issues are closed, all PRs merged, full 6-layer architecture implemented

### Changes
- Add CI, Coverage, and API Docs status badges
- Update all milestones from "Planned" to "Done"
- Expand key features list (security, reliability, structured logging, Doxygen docs)
- Update architecture diagram with per-layer detail
- Replace build instructions with actual Conan preset commands (`cmake --preset conan-release`)
- Add CI/CD pipeline section documenting all 6 workflows and their dependency chain
- Update project structure tree to match actual directory layout (deploy/, tests/ subdirs)
- Expand microservices table with feature descriptions (JWT RS256, ELO matching, etc.)
- Add code style enforcement and git blame instructions for contributors
- Add Performance Report to documentation links

## Test Plan
- [x] README renders correctly in markdown
- [x] All documentation links are valid (22/22 files verified)
- [x] CI badge URLs point to correct workflows
- [x] All CI checks pass (Lint, Build x3, Docs, Coverage, GitGuardian)